### PR TITLE
README: `use Appsignal.Phoenix` in pipeline block

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ applications and sends it to [AppSignal](https://appsignal.com).
 
   3. If you use the
      [Phoenix framework](http://www.phoenixframework.org/), *use* the
-     `Appsignal.Phoenix` module in your `endpoint.ex` file, just
-     *before* the line where your router module gets called
-     (which should read something like `plug MyApp.Router`):
+     `Appsignal.Phoenix` module in your `endpoint.ex` file, inside the :browser `pipeline` block:
 
-     ```elixir
-     use Appsignal.Phoenix
-     ```
+     ``` elixir
+     pipeline :browser do
+       use Appsignal.Phoenix
+       plug :accepts, ["html"]
+       plug :fetch_session
+       # ...
+     end
 
 When the AppSignal OTP application starts, it looks for a valid
 configuration (e.g. an AppSignal push key), and start the AppSignal agent.


### PR DESCRIPTION
Since 0.0.6(?), the instructions about putting the `use Appsignal.Phoenix`
block before including the router don't work anymore
(https://github.com/jeffkreeftmeijer/appsignal-phoenix-example/commit/0c93b9e66c54af5232f9fa7b5a2cbd1969ea6a1f):

    $ mix phoenix.server
    Compiling 6 files (.ex)

    == Compilation error on file web/router.ex ==
    ** (CompileError) web/router.ex:2: undefined function plug/1
        expanding macro: Appsignal.Phoenix.__using__/1
        web/router.ex:2: AppsignalPhoenixExample.Router (module)
        (elixir) expanding macro: Kernel.use/1
        web/router.ex:2: AppsignalPhoenixExample.Router (module)
        (elixir) lib/kernel/parallel_compiler.ex:116: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1

Putting it right after the router, it complains about not being able to
use `plug` outside a `pipeline` block
(https://github.com/jeffkreeftmeijer/appsignal-phoenix-example/commit/e8b16fadd385a6d458d1466afef265d5fe8bc43b):

    $ mix phoenix.server
    Compiling 6 files (.ex)

    == Compilation error on file web/router.ex ==
    ** (RuntimeError) cannot define plug at the router level, plug must be defined inside a pipeline
        web/router.ex:3: (module)
        (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
        (elixir) lib/kernel/parallel_compiler.ex:116: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1

Instead, putting it in the :browser `pipeline` block properly starts the
Phoenix server again
(https://github.com/jeffkreeftmeijer/appsignal-phoenix-example/commit/8573e60358ce187accfc038378d1e8b2550bddf5):

    $ mix phoenix.server
    Compiling 6 files (.ex)
    [warn] Warning: No valid Appsignal configuration found, continuing with Appsignal metrics disabled.
    [info] Running AppsignalPhoenixExample.Endpoint with Cowboy using http://localhost:4000
    27 Jul 10:09:15 - info: compiled 6 files into 2 files, copied 3 in 1.2 sec

This commit updates the README to reflect this change. Setting it up like this allows me to get data into AppSignal from https://github.com/jeffkreeftmeijer/appsignal-phoenix-example.

I'm not a 100% sure this is the way to go, as I'm getting a missing function clause (`Appsignal.Transaction.set_error/4`) when doing a GET on the index (https://gist.github.com/jeffkreeftmeijer/4b01fa893906a45d25dc90e6df76cf5a). I'll open up a new issue for that if putting `use Appsignal.Phoenix` inside the `pipeline` block like this is correct.