### PR TITLE
Remove impossible case

### DIFF
--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -31,7 +31,6 @@ defmodule Appsignal.Phoenix do
             import Appsignal.Phoenix
             case {Appsignal.TransactionRegistry.lookup(self), extract_error_metadata(e, conn, System.stacktrace)} do
               {nil, _} -> :skip
-              {_, nil} -> :skip
               {transaction, {reason, message, stack, conn}} ->
                 submit_http_error(reason, message, stack, transaction, conn)
             end


### PR DESCRIPTION
According to dialyzer, this case is impossible. I would guess it has to do with what `lookup/1` is capable of returning. It's not capable of returning anything that would trigger the case of `extract_error_metadata/3` that would return nil.

```
endpoint.ex:53: The pattern {_, 'nil'} can never match the type {_,{atom(),binary(),_,_}}
```

It could be a dialyzer bug, there are a few nasty ones in 19.