### PR TITLE
Fix remaining dialyzer error when used

### DIFF
--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -57,6 +57,13 @@ defmodule Appsignal.Phoenix do
     # Submit error
     {r.__struct__, Exception.message(r), stack, Map.get(r, :conn, conn)}
   end
+  def extract_error_metadata(r, conn, stack) when is_binary(r) do
+    extract_error_metadata(RuntimeError.exception(r), conn, stack)
+  end
+  def extract_error_metadata(r, conn, stack) when is_atom(r) do
+    extract_error_metadata(r.exception([]), conn, stack)
+  end
+
 
   @doc false
   def submit_http_error(reason, message, stack, transaction, conn) do


### PR DESCRIPTION
This is a weird one, but basically because `extract_error_metadata` did not actually match all of the things that could be [sent to `reraise`](https://github.com/elixir-lang/elixir/blob/76b355a9d90989987174a87957622ecc372add00/lib/elixir/lib/kernel.ex#L1463-L1473) it gave these dialyzer errors:

```
lib/the_link/endpoint.ex:69: Guard test is_atom(_@4::map()) can never succeed
lib/the_link/endpoint.ex:69: Guard test is_binary(_@3::map()) can never succeed
```

I just added cases that behave like `reraise` does any way.