### PR TITLE
Fix host metrics config key in GettingStarted

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -87,4 +87,4 @@ The full list of variables that can be configured is the following:
  - `APPSIGNAL_HTTP_PROXY` (Elixir config key: `:http_proxy`)
  - `APPSIGNAL_RUNNING_IN_CONTAINER` (Elixir config key: `:running_in_container`)
  - `APPSIGNAL_WORKING_DIR_PATH` (Elixir config key: `:working_dir_path`)
- - `APPSIGNAL_ENABLE_HOST_METRICS` (Elixir config key: `:enable_host_metric`)
+ - `APPSIGNAL_ENABLE_HOST_METRICS` (Elixir config key: `:enable_host_metrics`)


### PR DESCRIPTION
Very small typo in the GettingStarted guide but it seems, from [config.exs](https://github.com/appsignal/appsignal-elixir/blob/master/lib/appsignal/config.ex), that the key is `enable_host_metrics` and not `enable_host_metric`