### PR TITLE
Set APPSIGNAL_IGNORE_ACTIONS from config

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -139,6 +139,7 @@ defmodule Appsignal.Config do
       System.put_env("APPSIGNAL_HTTP_PROXY", config[:http_proxy])
     end
     System.put_env("APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
+    System.put_env("APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))
     System.put_env("APPSIGNAL_RUNNING_IN_CONTAINER", Atom.to_string(config[:running_in_container]))
     unless empty?(config[:working_dir_path]) do
       System.put_env("APPSIGNAL_WORKING_DIR_PATH", config[:working_dir_path])

--- a/test/config/appsignal_config_test.exs
+++ b/test/config/appsignal_config_test.exs
@@ -37,12 +37,39 @@ defmodule AppsignalConfigTest do
     assert "b5f2b9" = init_config()[:revision]
   end
 
-  test "app revision from application env gets put in system env" do
+  test "app config from application env gets put in system env" do
+    System.delete_env("APPSIGNAL_ACTIVE")
+    System.delete_env("APPSIGNAL_ENVIRONMENT")
+    System.delete_env("APPSIGNAL_PUSH_API_KEY")
+    System.delete_env("APPSIGNAL_APP_NAME")
+    System.delete_env("APPSIGNAL_ENABLE_HOST_METRICS")
     System.delete_env("APP_REVISION")
+
     Application.put_env(:appsignal, :config,
-      push_api_key: "-test",
+      active: true,
+      env: :prod,
+      debug: true,
+      log_path: "log/appsignal.log",
+      push_api_endpoint: "https://push.appsignal.com",
+      push_api_key: "00000000-0000-0000-0000-000000000000",
+      name: :ExampleApplication,
+      http_proxy: "http://10.10.10.10:8888",
+      ignore_actions: ["ExampleApplication.PageController#ignored"],
+      working_dir_path: "/tmp/appsignal",
+      enable_host_metrics: true,
       revision: "03bd9e")
     init_config()
+    assert "true" = System.get_env("APPSIGNAL_ACTIVE")
+    assert "prod" = System.get_env("APPSIGNAL_ENVIRONMENT")
+    assert "true" = System.get_env("APPSIGNAL_DEBUG_LOGGING")
+    assert "log/appsignal.log" = System.get_env("APPSIGNAL_LOG_FILE_PATH")
+    assert "https://push.appsignal.com" = System.get_env("APPSIGNAL_PUSH_API_ENDPOINT")
+    assert "00000000-0000-0000-0000-000000000000" = System.get_env("APPSIGNAL_PUSH_API_KEY")
+    assert "ExampleApplication" = System.get_env("APPSIGNAL_APP_NAME")
+    assert "http://10.10.10.10:8888" = System.get_env("APPSIGNAL_HTTP_PROXY")
+    assert "ExampleApplication.PageController#ignored" = System.get_env("APPSIGNAL_IGNORE_ACTIONS")
+    assert "/tmp/appsignal" = System.get_env("APPSIGNAL_WORKING_DIR_PATH")
+    assert "true" = System.get_env("APPSIGNAL_ENABLE_HOST_METRICS")
     assert "03bd9e" = System.get_env("APP_REVISION")
   end
 

--- a/test/config/appsignal_config_test.exs
+++ b/test/config/appsignal_config_test.exs
@@ -25,23 +25,25 @@ defmodule AppsignalConfigTest do
   end
 
   test "app revision" do
-    System.put_env("APP_REVISION", "123")
-    assert "123" = init_config()[:revision]
+    System.put_env("APP_REVISION", "0c497d")
+    assert "0c497d" = init_config()[:revision]
   end
 
   test "app revision from application env" do
+    System.delete_env("APP_REVISION")
     Application.put_env(:appsignal, :config,
       push_api_key: "-test",
-      revision: "123")
-    assert "123" = init_config()[:revision]
+      revision: "b5f2b9")
+    assert "b5f2b9" = init_config()[:revision]
   end
 
   test "app revision from application env gets put in system env" do
+    System.delete_env("APP_REVISION")
     Application.put_env(:appsignal, :config,
       push_api_key: "-test",
-      revision: "123")
+      revision: "03bd9e")
     init_config()
-    assert "123" = System.get_env("APP_REVISION")
+    assert "03bd9e" = System.get_env("APP_REVISION")
   end
 
   defp init_config do

--- a/test/config/appsignal_config_test.exs
+++ b/test/config/appsignal_config_test.exs
@@ -55,6 +55,7 @@ defmodule AppsignalConfigTest do
       name: :ExampleApplication,
       http_proxy: "http://10.10.10.10:8888",
       ignore_actions: ["ExampleApplication.PageController#ignored"],
+      ignore_errors: ["VerySpecificError"],
       working_dir_path: "/tmp/appsignal",
       enable_host_metrics: true,
       revision: "03bd9e")
@@ -68,6 +69,7 @@ defmodule AppsignalConfigTest do
     assert "ExampleApplication" = System.get_env("APPSIGNAL_APP_NAME")
     assert "http://10.10.10.10:8888" = System.get_env("APPSIGNAL_HTTP_PROXY")
     assert "ExampleApplication.PageController#ignored" = System.get_env("APPSIGNAL_IGNORE_ACTIONS")
+    assert "VerySpecificError" = System.get_env("APPSIGNAL_IGNORE_ERRORS")
     assert "/tmp/appsignal" = System.get_env("APPSIGNAL_WORKING_DIR_PATH")
     assert "true" = System.get_env("APPSIGNAL_ENABLE_HOST_METRICS")
     assert "03bd9e" = System.get_env("APP_REVISION")


### PR DESCRIPTION
Ignored errors will be implemented in the agent, this patch sets the configuration option in the system ENV.