### PR TITLE
Configure Travis builds for branches and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,10 @@ elixir:
 otp_release:
   - 19.0
   - 18.3
+
+branches:
+  only:
+    - "master"
+    - "develop"
+
 script: MIX_ENV=test mix compile --warnings-as-errors && MIX_ENV=test mix test


### PR DESCRIPTION
Only build master and develop branches when pushed. When a PR is made on GitHub travis will start a build as well.

This change  prevents two builds being started for one change, like you can see in PR #61 under "All checks have passed - 2 successful checks".

This PR only triggers one build as you can see below.

## Scenario

### Steps to reproduce issue

- I push a branch to make a PR (a build is triggered on TravisCI)
- I make a PR on the repo (a build is triggered on TravisCI)

### expected result

- one build triggered

### actual result

- two builds triggered

## New setup

- build branches "master" and "develop" on push
- build PRs when created.
- other branches are ignored on push

## Note

This is the same behavior we have on the Ruby gem repo: https://github.com/appsignal/appsignal-ruby/pull/131