### PR TITLE
Add appsignal.demo mix task

### DIFF
--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -1,0 +1,60 @@
+defmodule Appsignal.Demo do
+  alias Appsignal.ErrorHandler
+  import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
+
+  def transmit do
+    Appsignal.start(nil, nil)
+    create_transaction_performance_request()
+    create_transaction_error_request()
+    Appsignal.stop(nil)
+  end
+
+  @doc false
+  def create_transaction_error_request do
+    transaction = create_demo_transaction()
+    Appsignal.Transaction.set_error(
+      transaction,
+      "TestError",
+      "Hello world! This is an error used for demonstration purposes.",
+      ErrorHandler.format_stack(System.stacktrace)
+    )
+
+    finish_demo_transaction(transaction)
+  end
+
+  @doc false
+  def create_transaction_performance_request do
+    transaction = create_demo_transaction()
+
+    instrument(transaction, "template.render", "Rendering something slow", fn() ->
+      :timer.sleep(1000)
+      instrument(transaction, "ecto.query", "Slow query", fn() ->
+        :timer.sleep(300)
+      end)
+      instrument(transaction, "ecto.query", "Slow query", fn() ->
+        :timer.sleep(500)
+      end)
+      instrument(transaction, "template.render", "Rendering something slow", fn() ->
+        :timer.sleep(100)
+      end)
+    end)
+
+    finish_demo_transaction(transaction)
+  end
+
+  defp create_demo_transaction do
+    Appsignal.Transaction.start(
+      Appsignal.Transaction.generate_id,
+      :http_request
+    )
+    |> Appsignal.Transaction.set_action("DemoController#hello")
+    |> Appsignal.Transaction.set_meta_data("demo_sample", "true")
+    |> Appsignal.Transaction.set_meta_data("path", "/hello")
+    |> Appsignal.Transaction.set_meta_data("method", "GET")
+  end
+
+  defp finish_demo_transaction(transaction) do
+    Appsignal.Transaction.finish(transaction)
+    :ok = Appsignal.Transaction.complete(transaction)
+  end
+end

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -2,13 +2,6 @@ defmodule Appsignal.Demo do
   alias Appsignal.ErrorHandler
   import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
 
-  def transmit do
-    {:ok, _} = Application.ensure_all_started(:appsignal)
-    create_transaction_performance_request()
-    create_transaction_error_request()
-    Appsignal.stop(nil)
-  end
-
   @doc false
   def create_transaction_error_request do
     transaction = create_demo_transaction()

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -1,5 +1,4 @@
 defmodule Appsignal.Demo do
-  alias Appsignal.ErrorHandler
   import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
 
   @doc false
@@ -9,7 +8,7 @@ defmodule Appsignal.Demo do
       transaction,
       "TestError",
       "Hello world! This is an error used for demonstration purposes.",
-      ErrorHandler.format_stack(System.stacktrace)
+      System.stacktrace
     )
 
     finish_demo_transaction(transaction)

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -3,15 +3,13 @@ defmodule Appsignal.Demo do
 
   @doc false
   def create_transaction_error_request do
-    transaction = create_demo_transaction()
-    Appsignal.Transaction.set_error(
-      transaction,
+    create_demo_transaction
+    |> Appsignal.Transaction.set_error(
       "TestError",
       "Hello world! This is an error used for demonstration purposes.",
       System.stacktrace
     )
-
-    finish_demo_transaction(transaction)
+    |> finish_demo_transaction
   end
 
   @doc false

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -39,8 +39,9 @@ defmodule Appsignal.Demo do
     )
     |> Appsignal.Transaction.set_action("DemoController#hello")
     |> Appsignal.Transaction.set_meta_data("demo_sample", "true")
-    |> Appsignal.Transaction.set_meta_data("path", "/hello")
-    |> Appsignal.Transaction.set_meta_data("method", "GET")
+    |> Appsignal.Transaction.set_sample_data(
+      "environment", %{request_path: "/hello", method: "GET"}
+    )
   end
 
   defp finish_demo_transaction(transaction) do

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -3,7 +3,7 @@ defmodule Appsignal.Demo do
   import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
 
   def transmit do
-    Appsignal.start(nil, nil)
+    {:ok, _} = Application.ensure_all_started(:appsignal)
     create_transaction_performance_request()
     create_transaction_error_request()
     Appsignal.stop(nil)

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -3,13 +3,13 @@ defmodule Appsignal.Demo do
 
   @doc false
   def create_transaction_error_request do
-    create_demo_transaction
+    create_demo_transaction()
     |> Appsignal.Transaction.set_error(
       "TestError",
       "Hello world! This is an error used for demonstration purposes.",
       System.stacktrace
     )
-    |> finish_demo_transaction
+    |> finish_demo_transaction()
   end
 
   @doc false

--- a/lib/appsignal/instrumentation/helpers.ex
+++ b/lib/appsignal/instrumentation/helpers.ex
@@ -34,10 +34,10 @@ defmodule Appsignal.Instrumentation.Helpers do
   import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
 
   def index(conn, _params) do
-  result = instrument(conn, "net.http", "Some slow backend call", fn() ->
-  Backend.get_result()
-  end
-  json conn, result
+    result = instrument conn, "net.http", "Some slow backend call", fn() ->
+      Backend.get_result()
+    end
+    json conn, result
   end
   ```
 

--- a/lib/mix/tasks/appsignal.demo.ex
+++ b/lib/mix/tasks/appsignal.demo.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Appsignal.Demo do
+  require Logger
   use Mix.Task
 
   @shortdoc "Perform and send a demonstration error and performance issue to AppSignal."
@@ -8,5 +9,7 @@ defmodule Mix.Tasks.Appsignal.Demo do
     Appsignal.Demo.create_transaction_performance_request
     Appsignal.Demo.create_transaction_error_request
     Appsignal.stop(nil)
+    Logger.info("Demonstration sample data sent!")
+    Logger.info("It may take about a minute for the data to appear on AppSignal.com/accounts")
   end
 end

--- a/lib/mix/tasks/appsignal.demo.ex
+++ b/lib/mix/tasks/appsignal.demo.ex
@@ -1,0 +1,9 @@
+defmodule Mix.Tasks.Appsignal.Demo do
+  use Mix.Task
+
+  @shortdoc "Perform and send a demonstration error and performance issue to AppSignal."
+
+  def run(_args) do
+    Appsignal.Demo.transmit
+  end
+end

--- a/lib/mix/tasks/appsignal.demo.ex
+++ b/lib/mix/tasks/appsignal.demo.ex
@@ -4,6 +4,9 @@ defmodule Mix.Tasks.Appsignal.Demo do
   @shortdoc "Perform and send a demonstration error and performance issue to AppSignal."
 
   def run(_args) do
-    Appsignal.Demo.transmit
+    {:ok, _} = Application.ensure_all_started(:appsignal)
+    Appsignal.Demo.create_transaction_performance_request
+    Appsignal.Demo.create_transaction_error_request
+    Appsignal.stop(nil)
   end
 end

--- a/lib/mix/tasks/appsignal.demo.ex
+++ b/lib/mix/tasks/appsignal.demo.ex
@@ -10,6 +10,6 @@ defmodule Mix.Tasks.Appsignal.Demo do
     Appsignal.Demo.create_transaction_error_request
     Appsignal.stop(nil)
     Logger.info("Demonstration sample data sent!")
-    Logger.info("It may take about a minute for the data to appear on AppSignal.com/accounts")
+    Logger.info("It may take about a minute for the data to appear on https://appsignal.com/accounts")
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,6 @@ defmodule Mix.Tasks.Compile.Appsignal do
   end
 end
 
-
 defmodule Appsignal.Mixfile do
   use Mix.Project
 
@@ -57,7 +56,6 @@ defmodule Appsignal.Mixfile do
       {:poison, "~> 2.1"},
       {:decorator, "~> 1.0"},
       {:phoenix, "~> 1.2.0", optional: true, only: :test_phoenix},
-
       {:mock, "~> 0.1.1", only: [:test, :test_phoenix]},
       {:ex_doc, "~> 0.12", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
-  "mock": {:hex, :mock, "0.1.3", "657937b03f88fce89b3f7d6becc9f1ec1ac19c71081aeb32117db9bc4d9b3980", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]},
+  "mock": {:hex, :mock, "0.2.0", "5991877be6bb514b647dbd6f4869bc12bd7f2829df16e86c98d6108f966d34d7", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]},
   "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], []},
   "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},

--- a/test/demo_test.exs
+++ b/test/demo_test.exs
@@ -1,0 +1,48 @@
+defmodule AppsignalDemoTest do
+  use ExUnit.Case
+  import Mock
+  alias Appsignal.{Transaction, TransactionRegistry}
+
+  test "starts and stops the AppSignal agent" do
+    with_mocks([
+      {Appsignal,
+       [],
+       [start: fn(_, _) -> nil end,
+        stop: fn(_) -> nil end,
+        started?: fn() -> true end]},
+      {Appsignal.Demo,
+       [:passthrough],
+       []}
+    ]) do
+      Appsignal.Demo.transmit
+
+      assert called Appsignal.start(nil, nil)
+      assert called Appsignal.Demo.create_transaction_performance_request
+      assert called Appsignal.Demo.create_transaction_error_request
+      assert called Appsignal.stop(nil)
+    end
+  end
+
+  test_with_mock "sends a demonstration error", Appsignal.Transaction, [:passthrough], [] do
+    Appsignal.Demo.create_transaction_error_request
+
+    t = %Transaction{} = TransactionRegistry.lookup(self())
+    assert called Appsignal.Transaction.set_action(t, "DemoController#hello")
+    assert called Appsignal.Transaction.set_error(t, "TestError", "Hello world! This is an error used for demonstration purposes.", [])
+    assert called Appsignal.Transaction.set_meta_data(t, "demo_sample", "true")
+    assert called Appsignal.Transaction.finish(t)
+    assert called Appsignal.Transaction.complete(t)
+  end
+
+  test_with_mock "sends a performance issue", Appsignal.Transaction, [:passthrough], [] do
+    Appsignal.Demo.create_transaction_performance_request
+
+    t = %Transaction{} = TransactionRegistry.lookup(self())
+    assert called Appsignal.Transaction.set_action(t, "DemoController#hello")
+    assert called Appsignal.Transaction.set_meta_data(t, "demo_sample", "true")
+    assert called Appsignal.Transaction.start_event(t)
+    assert called Appsignal.Transaction.finish_event(t, "template.render", "Rendering something slow", "", 0)
+    assert called Appsignal.Transaction.finish(t)
+    assert called Appsignal.Transaction.complete(t)
+  end
+end

--- a/test/demo_test.exs
+++ b/test/demo_test.exs
@@ -3,26 +3,6 @@ defmodule AppsignalDemoTest do
   import Mock
   alias Appsignal.{Transaction, TransactionRegistry}
 
-  test "starts and stops the AppSignal agent" do
-    with_mocks([
-      {Appsignal,
-       [],
-       [start: fn(_, _) -> nil end,
-        stop: fn(_) -> nil end,
-        started?: fn() -> true end]},
-      {Appsignal.Demo,
-       [:passthrough],
-       []}
-    ]) do
-      Appsignal.Demo.transmit
-
-      assert called Appsignal.start(nil, nil)
-      assert called Appsignal.Demo.create_transaction_performance_request
-      assert called Appsignal.Demo.create_transaction_error_request
-      assert called Appsignal.stop(nil)
-    end
-  end
-
   test_with_mock "sends a demonstration error", Appsignal.Transaction, [:passthrough], [] do
     Appsignal.Demo.create_transaction_error_request
 


### PR DESCRIPTION
As currently present in our Ruby gem as well:
appsignal/appsignal-ruby#199

The "appsignal.demo" command is useful for debugging AppSignal and
testing AppSignal. It's also being used for the Ruby gem installer at and installation UI on AppSignal.com the moment.

It sends a demonstration sample for an error and a performance issue.
They will show up on AppSignal.com as demonstration samples with a small
special UI attached to them describing their purpose.

Debugging manual referencing the "demo" command:
http://docs.appsignal.com/support/debugging.html

Based on #68 
Closes #46 