### PR TITLE
Appsignal.Transaction.set_error/4 handles unformatted stacktraces

### DIFF
--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -61,7 +61,7 @@ defmodule Appsignal.Phoenix do
 
   @doc false
   def submit_http_error(reason, message, stack, transaction, conn) do
-    Transaction.set_error(transaction, reason, message, ErrorHandler.format_stack(stack))
+    Transaction.set_error(transaction, reason, message, stack)
     Transaction.try_set_action(transaction, conn)
     if Transaction.finish(transaction) == :sample do
       Transaction.set_request_metadata(transaction, conn)

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -171,6 +171,14 @@ defmodule Appsignal.Transaction do
   """
   @spec set_error(Transaction.t | nil, String.t, String.t, any) :: Transaction.t
   def set_error(nil, _name, _message, _backtrace), do: nil
+  def set_error(%Transaction{} = transaction, name, message, [h|_] = backtrace) when is_tuple(h) do
+    set_error(
+      transaction,
+      name,
+      message,
+      Appsignal.ErrorHandler.format_stack(backtrace)
+    )
+  end
   def set_error(%Transaction{} = transaction, name, message, backtrace) do
     name = name |> String.split_at(@max_name_size) |> elem(0)
     backtrace_data = Appsignal.Utils.DataEncoder.encode(backtrace)

--- a/test/transaction/transaction_test.exs
+++ b/test/transaction/transaction_test.exs
@@ -93,4 +93,11 @@ defmodule AppsignalTransactionTest do
     assert ^transaction = Transaction.start_event(transaction)
     assert ^transaction = Transaction.finish_event(transaction, "phoenix_controller_render", "phoenix_controller_render", %{format: "html", template: "index.html"}, 0)
   end
+
+  test "handles unformatted stacktraces" do
+    transaction = Transaction.start("test1", :http_request)
+    assert ^transaction = Transaction.set_error(transaction, "Error", "error message", System.stacktrace)
+    assert ^transaction = Transaction.start_event(transaction)
+    assert ^transaction = Transaction.finish_event(transaction, "phoenix_controller_render", "phoenix_controller_render", %{format: "html", template: "index.html"}, 0)
+  end
 end


### PR DESCRIPTION
We assume that a list with a tuple as its first element is an unformatted stack trace. In that case we'll call `Appsignal.ErrorHandler.format_stack/1` on it in `Appsignal.Transaction.set_error/4`, so modules that call it don't need coupling with `Appsignal.ErrorHandler`.