### PR TITLE
Add fix for grabbing filter_parameters from Phoenix

### DIFF
--- a/lib/appsignal/utils/params_filter.ex
+++ b/lib/appsignal/utils/params_filter.ex
@@ -6,7 +6,7 @@ defmodule Appsignal.Utils.ParamsFilter do
 
   def get_filter_parameters do
     Application.get_env(:appsignal, :config)[:filter_parameters]
-    || Application.get_env(:phoenix, :config)[:filter_parameters]
+    || Application.get_env(:phoenix, :filter_parameters)
     || []
   end
 

--- a/test/transaction/filter_test.exs
+++ b/test/transaction/filter_test.exs
@@ -13,7 +13,7 @@ defmodule AppsignalTransactionFilterTest do
     end
 
     test "uses parameter filters from the phoenix config" do
-      with_app_config(:phoenix, :config, [filter_parameters: ["secret1"]], fn() ->
+      with_app_config(:phoenix, :filter_parameters, ["secret1"], fn() ->
         Config.initialize()
         assert ParamsFilter.get_filter_parameters() == ["secret1"]
       end)


### PR DESCRIPTION
Enjoying AppSignal with Elixir so far, but I noticed an issue where our users' passwords are showing up in the parameters section on the website, which is no bueno. It looks like this is due to how the filter parameters are being grabbed from Phoenix. The [default parameters for Phoenix](https://github.com/phoenixframework/phoenix/blob/d88a34ec5d316d6f9379f63d41d149df259c9813/mix.exs#L42) live in `Application.get_env(:phoenix, :filter_parameters)` instead of `:config`, so this isn't properly grabbing the defaults and secrets are being sent.

Also, I'll submit a PR for a fix with the docs. For setting it with AppSignal's filtering, it *does* check `:config`, but the docs don't mention that. 