### PR TITLE
Add Alpine linux

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -102,6 +102,7 @@ defmodule Mix.Appsignal.Helper do
 
   defp map_arch('x86_64-redhat-linux-gnu' ++ _), do: "x86_64-linux"
   defp map_arch('x86_64-pc-linux-gnu' ++ _), do: "x86_64-linux"
+  defp map_arch('x86_64-alpine-linux' ++ _), do: "x86_64-linux"
   defp map_arch('x86_64-unknown-linux' ++ _), do: "x86_64-linux"
   defp map_arch('x86_64-apple-darwin' ++ _), do: "x86_64-darwin"
 


### PR DESCRIPTION
`Mix.Appsignal.map_arch/1` was missing for Alpine, this should add it.