### PR TITLE
Normalize reason string

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -37,7 +37,7 @@ defmodule Appsignal.ErrorHandler do
             false ->
               transaction = Transaction.lookup_or_create_transaction(origin)
               if transaction != nil do
-                submit_transaction(transaction, reason, message, stack, %{}, conn)
+                submit_transaction(transaction, normalize_reason(reason), message, stack, %{}, conn)
               end
             true ->
               # ignore this event; we have already handled it.
@@ -211,4 +211,9 @@ defmodule Appsignal.ErrorHandler do
   defp prefixed(nil, msg), do: msg
   defp prefixed("", msg), do: msg
   defp prefixed(pre, msg), do: pre <> ": " <> msg
+
+  @pid_or_ref_regex ~r/\<(\d+\.)+\d+\>/
+  def normalize_reason(reason) do
+    Regex.replace(@pid_or_ref_regex, reason, "<...>")
+  end
 end

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -362,11 +362,6 @@ defmodule Appsignal.Transaction do
     end
   end
 
-  defp ensure_headers_map(nil), do: %{}
-  defp ensure_headers_map(headers) when is_list(headers) do
-    headers |> Enum.into(%{})
-  end
-
   if Appsignal.phoenix? do
     @doc """
     Set the request metadata, given a Plug.Conn.t.

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -180,8 +180,23 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason(":function_clause")
   end
 
+  test "Task await" do
+    :proc_lib.spawn(fn() ->
+      Task.async(fn() ->
+        Process.sleep(2)
+      end)
+      |> Task.await(1)
+    end)
+    |> assert_crash_caught
+    |> reason_regex(~r/^{:exit, {:timeout/)
+  end
+
   defp reason(reason, expected) do
     assert expected == reason
+  end
+
+  defp reason_regex(reason, expected) do
+    assert reason =~ expected
   end
 
 end

--- a/test/appsignal/error_handler/normalize_reason_test.exs
+++ b/test/appsignal/error_handler/normalize_reason_test.exs
@@ -1,0 +1,15 @@
+defmodule Appsignal.ErrorHandler.NormalizeReasonTest do
+
+  use ExUnit.Case
+
+  alias Appsignal.ErrorHandler
+
+  @reason_raw  "{:exit, {:timeout, {Task, :await, [%Task{owner: #PID<0.178.0>, pid: #PID<0.179.0>, ref: #Reference<0.0.4.753>}, 1]}}}"
+  @reason_norm "{:exit, {:timeout, {Task, :await, [%Task{owner: #PID<...>, pid: #PID<...>, ref: #Reference<...>}, 1]}}}"
+  test "Remove pid / ref strings from reason" do
+
+    assert @reason_norm == ErrorHandler.normalize_reason(@reason_raw)
+
+  end
+
+end


### PR DESCRIPTION
Fix for #76

Note that backend strips all non-alphanumeric characters from the error reason string anyway.

Before and after:

![image](https://cloud.githubusercontent.com/assets/24722/21996397/5667a67a-dc2a-11e6-9b90-96a25fa34fd4.png)
