### PR TITLE
Add the module name to the transaction action while using decorators

### DIFF
--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -48,7 +48,7 @@ defmodule Appsignal.Instrumentation.Decorators do
         Appsignal.Transaction.generate_id,
         unquote(namespace)
       )
-      |> Appsignal.Transaction.set_action(unquote("#{context.name}"))
+      |> Appsignal.Transaction.set_action(unquote("#{context.module}##{context.name}"))
 
       unquote(body)
 

--- a/test/appsignal/instrumentation/decorator_test.exs
+++ b/test/appsignal/instrumentation/decorator_test.exs
@@ -40,6 +40,7 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
   test_with_mock "instrument transaction", Appsignal.Transaction, [:passthrough], [] do
     Example.transaction
     assert called Transaction.start(:_, :http_request)
+    assert called Appsignal.Transaction.set_action(:_, "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example#transaction")
     assert called Appsignal.Transaction.finish(:_)
     assert called Appsignal.Transaction.complete(:_)
   end
@@ -47,6 +48,7 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
   test_with_mock "instrument background transaction", Appsignal.Transaction, [:passthrough], [] do
     Example.background_transaction
     assert called Transaction.start(:_, :background_job)
+    assert called Appsignal.Transaction.set_action(:_, "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example#background_transaction")
     assert called Appsignal.Transaction.finish(:_)
     assert called Appsignal.Transaction.complete(:_)
   end


### PR DESCRIPTION
Sometimes, specially using background jobs libraries, the function names are always the same (like `perform`), while the module name differentiate the actions (`EmailDeliverWorker`, `CacheUpdateWorker`, ...).

This fix adds the module name to the action name, so it resembles more the action names of controllers.