### PR TITLE
Prevent module not loaded errors in phoenix

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -18,6 +18,8 @@
       [applications: [:appsignal]]
     end
     ```
+    
+    **Note:** If you're using Phoenix, make sure to load `appsignal` after `phoenix` but before your application.
 
   3. If you use the
      [Phoenix framework](http://www.phoenixframework.org/), *use* the


### PR DESCRIPTION
Prevents "module Appsignal.Phoenix is not loaded and could not be found" errors when Appsignal is compiled before Phoenix and breaks the `Code.ensure_loaded?(Phoenix)` check.