### PR TITLE
Readded support for pids and refs inside payloads

### DIFF
--- a/lib/appsignal/utils/data_encoder.ex
+++ b/lib/appsignal/utils/data_encoder.ex
@@ -49,8 +49,11 @@ defmodule Appsignal.Utils.DataEncoder do
   def encode(resource, {key, nil}) do
     Nif.data_set_nil(resource, key)
   end
-  def encode(resource, {key, value}) do
+  def encode(resource, {key, value}) when is_atom(value) do
     encode(resource, {key, to_string(value)})
+  end
+  def encode(resource, {key, value}) do
+    encode(resource, {key, inspect(value)})
   end
   def encode(resource, value) when is_binary(value) do
     Nif.data_set_string(resource, value)


### PR DESCRIPTION
This support used to exist, but was dropped when `ParamsEncoder` was replaced by `DataEncoder`.

I added a clause to specifically handle atoms (to maintain the `:data` -> `"data"` behavior), and switched the `to_string` to a `inspect` call in the catch-all clause.