### PR TITLE
Don't crash when target platform is not supported

### DIFF
--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -29,9 +29,17 @@ defmodule Appsignal.Nif do
 
   @on_load :init
 
+  require Logger
+
   def init do
     path = :filename.join(:code.priv_dir(:appsignal), 'appsignal_extension')
-    :ok = :erlang.load_nif(path, 1)
+    case :erlang.load_nif(path, 1) do
+      :ok -> :ok
+      {:error, {:load_failed, reason}} ->
+        arch = :erlang.system_info(:system_architecture)
+        Logger.error "Error loading NIF, Appsignal integration disabled!\n\n#{reason}\n\nIs your operating system (#{arch}) supported?\nPlease check http://docs.appsignal.com/support/operating-systems.html"
+        :ok
+    end
   end
 
   def start do
@@ -163,130 +171,130 @@ defmodule Appsignal.Nif do
   end
 
   def _start do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _stop do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _start_transaction(_id, _namespace) do
-    exit(:nif_library_not_loaded)
+    {:ok, nil}
   end
 
   def _start_event(_transaction_resource) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _finish_event(_transaction_resource, _name, _title, _body, _body_format) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _finish_event_data(_transaction_resource, _name, _title, _body, _body_format) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _record_event(_transaction_resource, _name, _title, _body, _duration, _body_format) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _set_error(_transaction_resource, _error, _message, _backtrace) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _set_sample_data(_transaction_resource, _key, _payload) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _set_action(_transaction_resource, _action) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _set_queue_start(_transaction_resource, _start) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _set_meta_data(_transaction_resource, _key, _value) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _finish(_transaction_resource) do
-    exit(:nif_library_not_loaded)
+    :no_sample
   end
 
   def _complete(_transaction_resource) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _set_gauge(_key, _value) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _increment_counter(_key, _count) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _add_distribution_value(_key, _value) do
-    exit(:nif_library_not_loaded)
+    :ok
   end
 
   def _data_map_new do
-    exit(:nif_library_not_loaded)
+    {:ok, nil}
   end
 
-  def _data_set_string(_resource, _key, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_string(resource, _key, _value) do
+    resource
   end
 
-  def _data_set_string(_resource, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_string(resource, _value) do
+    resource
   end
 
-  def _data_set_integer(_resource, _key, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_integer(resource, _key, _value) do
+    resource
   end
 
-  def _data_set_integer(_resource, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_integer(resource, _value) do
+    resource
   end
 
-  def _data_set_float(_resource, _key, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_float(resource, _key, _value) do
+    resource
   end
 
-  def _data_set_float(_resource, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_float(resource, _value) do
+    resource
   end
 
-  def _data_set_boolean(_resource, _key, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_boolean(resource, _key, _value) do
+    resource
   end
 
-  def _data_set_boolean(_resource, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_boolean(resource, _value) do
+    resource
   end
 
-  def _data_set_nil(_resource, _key) do
-    exit(:nif_library_not_loaded)
+  def _data_set_nil(resource, _key) do
+    resource
   end
 
-  def _data_set_nil(_resource) do
-    exit(:nif_library_not_loaded)
+  def _data_set_nil(resource) do
+    resource
   end
 
-  def _data_set_data(_resource, _key, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_data(resource, _key, _value) do
+    resource
   end
 
-  def _data_set_data(_resource, _value) do
-    exit(:nif_library_not_loaded)
+  def _data_set_data(resource, _value) do
+    resource
   end
 
-  def _data_list_new do
-    exit(:nif_library_not_loaded)
+  def _data_list_new() do
+    {:ok, nil}
   end
 
-  def _data_to_json(_resource) do
-    exit(:nif_library_not_loaded)
+  def _data_to_json(resource) do
+    resource
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,14 @@ defmodule Mix.Tasks.Compile.Appsignal do
 
   def run(_args) do
     {_, _} = Code.eval_file("mix_helpers.exs")
-    :ok = Mix.Appsignal.Helper.ensure_downloaded
-    :ok = Mix.Appsignal.Helper.compile
+    case Mix.Appsignal.Helper.verify_system_architecture() do
+      {:ok, arch} ->
+        :ok = Mix.Appsignal.Helper.ensure_downloaded(arch)
+        :ok = Mix.Appsignal.Helper.compile
+      {:error, {:unsupported, arch}} ->
+        Mix.Shell.IO.error("Unsupported target platform #{arch}, AppSignal integration disabled!\nPlease check http://docs.appsignal.com/support/operating-systems.html")
+        :ok
+    end
   end
 end
 


### PR DESCRIPTION
This addresses both #89 and #90.

On compile time, a warning is printed when the CPU platform is not supported.

On runtime, while loading the NIF, an error is printed. All NIF
stub functions now return stub values and do not call exit() so that
the integration keeps working (without doing anything) when running on
a non-supported OS.

@jeffkreeftmeijer can you test this somehow?