### PR TITLE
Add Appsignal.Nif.loaded?/0

### DIFF
--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -711,6 +711,10 @@ static ERL_NIF_TERM _data_to_json(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
   return make_ok_tuple(env, enif_make_string(env, json.buf, ERL_NIF_LATIN1));
 }
 
+static ERL_NIF_TERM _loaded(ErlNifEnv *env, int UNUSED(argc), const ERL_NIF_TERM UNUSED(argv[])) {
+  return enif_make_atom(env, "true");
+}
+
 static int on_load(ErlNifEnv* env, void** UNUSED(priv), ERL_NIF_TERM UNUSED(info))
 {
     ErlNifResourceType *transaction_resource_type;
@@ -786,7 +790,8 @@ static ErlNifFunc nif_funcs[] =
     {"_data_set_data", 3, _data_set_data, 0},
     {"_data_set_data", 2, _data_set_data, 0},
     {"_data_list_new", 0, _data_list_new, 0},
-    {"_data_to_json", 1, _data_to_json, 0}
+    {"_data_to_json", 1, _data_to_json, 0},
+    {"_loaded", 0, _loaded, 0}
 };
 
 ERL_NIF_INIT(Elixir.Appsignal.Nif, nif_funcs, on_load, on_reload, on_upgrade, NULL)

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -170,6 +170,10 @@ defmodule Appsignal.Nif do
     _data_list_new()
   end
 
+  def loaded? do
+    _loaded()
+  end
+
   def _start do
     :ok
   end
@@ -296,5 +300,9 @@ defmodule Appsignal.Nif do
 
   def _data_to_json(resource) do
     resource
+  end
+
+  def _loaded do
+    false
   end
 end

--- a/test/appsignal/nif_test.exs
+++ b/test/appsignal/nif_test.exs
@@ -13,4 +13,8 @@ defmodule Appsignal.NifTest do
     assert {:ok, transaction} = Appsignal.Nif.start_transaction("transaction id", "http_request")
     assert is_binary(transaction)
   end
+
+  test "the nif is loaded" do
+    assert true = Appsignal.Nif.loaded?
+  end
 end


### PR DESCRIPTION
Since #93, we can be in a state where the Nif is not loaded, but Appsignal is still running. For #81, we need a way for the diagnose Mix task to know wether or not the Nif was loaded properly. 

The most reliable way I could think of would be to implement `Appsignal.Nif.loaded?/0` as a function that returns `false` by default, but gets overwritten by the C code when the Nif loads successfully. @arjan @tombruijn wdyt?