### PR TITLE
Add ca_file_path config option

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -62,6 +62,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_APP_NAME" => :name,
     "APP_REVISION" => :revision,
     "APPSIGNAL_APP_ENV" => :env,
+    "APPSIGNAL_CA_FILE_PATH" => :ca_file_path,
     "APPSIGNAL_PUSH_API_ENDPOINT" => :endpoint,
     "APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH" => :frontend_error_catching_path,
     "APPSIGNAL_FILTER_PARAMETERS" => :filter_parameters,
@@ -77,7 +78,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data
   }
 
-  @string_keys ~w(APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH APP_REVISION)
+  @string_keys ~w(APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH APP_REVISION APPSIGNAL_CA_FILE_PATH)
   @bool_keys ~w(APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING APPSIGNAL_ENABLE_ALLOCATION_TRACKING APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA)
   @atom_keys ~w(APPSIGNAL_APP_NAME APPSIGNAL_APP_ENV)
   @string_list_keys ~w(APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS)
@@ -135,6 +136,9 @@ defmodule Appsignal.Config do
     System.put_env("APPSIGNAL_APP_PATH", List.to_string(:code.priv_dir(:appsignal))) # FIXME - app_path should not be necessary
     System.put_env("APPSIGNAL_AGENT_PATH", List.to_string(:code.priv_dir(:appsignal)))
     System.put_env("APPSIGNAL_ENVIRONMENT", Atom.to_string(config[:env]))
+    unless empty?(config[:ca_file_path]) do
+      System.put_env("APPSIGNAL_CA_FILE_PATH", config[:ca_file_path])
+    end
     System.put_env("APPSIGNAL_AGENT_VERSION", @agent_version)
     System.put_env("APPSIGNAL_LANGUAGE_INTEGRATION_VERSION", "elixir-" <> @language_integration_version)
     System.put_env("APPSIGNAL_DEBUG_LOGGING", Atom.to_string(config[:debug]))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -108,6 +108,12 @@ defmodule Appsignal.ConfigTest do
       assert "prod" == System.get_env("APPSIGNAL_ENVIRONMENT")
     end
 
+    test "ca_file_path" do
+      add_to_application_env(:ca_file_path, "/foo/bar/zab.ca")
+      assert valid_configuration() |> Map.put(:ca_file_path, "/foo/bar/zab.ca") == init_config()
+      assert "/foo/bar/zab.ca" == System.get_env("APPSIGNAL_CA_FILE_PATH")
+    end
+
     test "enable_host_metrics" do
       add_to_application_env(:enable_host_metrics, false)
       assert valid_configuration() |> Map.put(:enable_host_metrics, false) == init_config()
@@ -230,6 +236,12 @@ defmodule Appsignal.ConfigTest do
       assert valid_configuration() |> Map.put(:env, :prod) == init_config()
       assert "prod" == System.get_env("APPSIGNAL_APP_ENV")
       assert "prod" == System.get_env("APPSIGNAL_ENVIRONMENT")
+    end
+
+    test "ca_file_path" do
+      System.put_env("APPSIGNAL_CA_FILE_PATH", "/foo/bar/baz.ca")
+      assert valid_configuration() |> Map.put(:ca_file_path, "/foo/bar/baz.ca") == init_config()
+      assert "/foo/bar/baz.ca" == System.get_env("APPSIGNAL_CA_FILE_PATH")
     end
 
     test "enable_host_metrics" do
@@ -378,10 +390,11 @@ defmodule Appsignal.ConfigTest do
     ~w(
       APPSIGNAL_ACTIVE
       APPSIGNAL_APP_NAME
+      APPSIGNAL_APP_ENV
       APPSIGNAL_DEBUG
       APPSIGNAL_DEBUG_LOGGING
+      APPSIGNAL_CA_FILE_PATH
       APPSIGNAL_ENABLE_HOST_METRICS
-      APPSIGNAL_APP_ENV
       APPSIGNAL_ENVIRONMENT
       APPSIGNAL_FILTER_PARAMETERS
       APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH


### PR DESCRIPTION
Configure the path of the SSL certificate file. By default uses the
system's ca certificate files. Use this option to point to another
certificate file if there's a problem connecting to our API.

Only the agent does something with this config. So this looks fine for now?

Closes #97 