### PR TITLE
Pass 'TEST' define to .c source when compiling the NIF inside the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifeq ($(shell uname),Darwin)
 endif
 
 all:
-	@$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $(OUTPUT) c_src/$(LIB).c
+	@$(CC) $(CFLAGS) $(CFLAGS_ADD) -shared $(LDFLAGS) -o $(OUTPUT) c_src/$(LIB).c
 
 clean:
 	@$(RM) -r "$(LIB_DIR)"/$(LIB).so*

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -790,7 +790,9 @@ static ErlNifFunc nif_funcs[] =
     {"_data_set_data", 3, _data_set_data, 0},
     {"_data_set_data", 2, _data_set_data, 0},
     {"_data_list_new", 0, _data_list_new, 0},
+#ifdef TEST
     {"_data_to_json", 1, _data_to_json, 0},
+#endif
     {"_loaded", 0, _loaded, 0}
 };
 

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -98,7 +98,7 @@ defmodule Mix.Appsignal.Helper do
 
 
   def compile do
-    {result, error_code} = System.cmd("make", [])
+    {result, error_code} = System.cmd("make", make_args(to_string(Mix.env)))
     IO.binwrite(result)
 
     if error_code != 0 do
@@ -108,6 +108,9 @@ defmodule Mix.Appsignal.Helper do
     end
     :ok
   end
+
+  defp make_args("test" <> _), do: ["-e", "CFLAGS_ADD=-DTEST"]
+  defp make_args(_), do: []
 
   if Mix.env != :test_no_nif do
     defp map_arch('x86_64-redhat-linux-gnu' ++ _), do: "x86_64-linux"


### PR DESCRIPTION
And, don't declare the _data_to_json NIF function when we're not in
the test.