### PR TITLE
Poison is a development dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Appsignal.Mixfile do
 
   defp deps do
     [
-      {:poison, "~> 2.1"},
+      {:poison, ">= 0.0.0", optional: true},
       {:decorator, "~> 1.0"},
       {:phoenix, "~> 1.2.0", optional: true, only: [:prod, :test_phoenix]},
       {:mock, "~> 0.1.1", only: [:test, :test_phoenix, :test_no_nif]},


### PR DESCRIPTION
Since the agent upgrade, we're only using Poison  to [read the agent.json file](https://github.com/appsignal/appsignal-elixir/blob/develop/mix_helpers.exs#L22), so it's not needed outside of the development environment anymore.