### PR TITLE
Auto activate when push_api_key in env, not always

### DIFF
--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -39,181 +39,199 @@ defmodule Appsignal.ConfigTest do
     setup do
       Application.put_env(
         :appsignal, :config,
-        push_api_key: "00000000-0000-0000-0000-000000000000"
+        []
       )
     end
 
-    test "valid configuration" do
-      assert valid_configuration() == init_config()
-    end
-
     test "active" do
-      add_to_application_env(:active, false)
-      assert valid_configuration() |> Map.put(:active, false) == init_config()
-      assert "false" == System.get_env("APPSIGNAL_ACTIVE")
+      add_to_application_env(:active, true)
+      assert default_configuration() |> Map.put(:active, true) == init_config()
+      assert "true" == System.get_env("APPSIGNAL_ACTIVE")
     end
 
-    test "name" do
-      add_to_application_env(:name, :my_application)
-      assert valid_configuration() |> Map.put(:name, :my_application) == init_config()
-      assert "my_application" == System.get_env("APPSIGNAL_APP_NAME")
+    test "ca_file_path" do
+      add_to_application_env(:ca_file_path, "/foo/bar/zab.ca")
+      assert default_configuration() |> Map.put(:ca_file_path, "/foo/bar/zab.ca") == init_config()
+      assert "/foo/bar/zab.ca" == System.get_env("APPSIGNAL_CA_FILE_PATH")
     end
 
     test "debug" do
       add_to_application_env(:debug, true)
-      assert valid_configuration() |> Map.put(:debug, true) == init_config()
+      assert default_configuration() |> Map.put(:debug, true) == init_config()
       assert "true" == System.get_env("APPSIGNAL_DEBUG_LOGGING")
+    end
+
+    test "enable_host_metrics" do
+      add_to_application_env(:enable_host_metrics, false)
+      assert default_configuration() |> Map.put(:enable_host_metrics, false) == init_config()
+      assert "false" == System.get_env("APPSIGNAL_ENABLE_HOST_METRICS")
+    end
+
+    test "endpoint" do
+      add_to_application_env(:endpoint, "https://push.staging.lol")
+      assert default_configuration() |> Map.put(:endpoint, "https://push.staging.lol") == init_config()
+      assert "https://push.staging.lol" == System.get_env("APPSIGNAL_PUSH_API_ENDPOINT")
+    end
+
+    test "env" do
+      add_to_application_env(:env, :prod)
+      assert default_configuration() |> Map.put(:env, :prod) == init_config()
+      assert "prod" == System.get_env("APPSIGNAL_ENVIRONMENT")
     end
 
     test "filter_parameters" do
       add_to_application_env(:filter_parameters, ~w(password secret))
-      assert valid_configuration() |> Map.put(:filter_parameters, ~w(password secret)) == init_config()
+      assert default_configuration() |> Map.put(:filter_parameters, ~w(password secret)) == init_config()
       assert "password,secret" == System.get_env("APPSIGNAL_FILTER_PARAMETERS")
     end
 
     test "frontend_error_catching_path" do
       add_to_application_env(:frontend_error_catching_path, "/appsignal_error_catcher")
-      assert valid_configuration() |> Map.put(:frontend_error_catching_path, "/appsignal_error_catcher") == init_config()
+      assert default_configuration() |> Map.put(:frontend_error_catching_path, "/appsignal_error_catcher") == init_config()
+    end
+
+    test "hostname" do
+      add_to_application_env(:hostname, "Bobs-MPB.example.com")
+      assert default_configuration() |> Map.put(:hostname, "Bobs-MPB.example.com") == init_config()
+      assert "Bobs-MPB.example.com" == System.get_env("APPSIGNAL_HOSTNAME")
     end
 
     test "http_proxy" do
       add_to_application_env(:http_proxy, "http://10.10.10.10:8888")
-      assert valid_configuration() |> Map.put(:http_proxy, "http://10.10.10.10:8888") == init_config()
+      assert default_configuration() |> Map.put(:http_proxy, "http://10.10.10.10:8888") == init_config()
       assert "http://10.10.10.10:8888" == System.get_env("APPSIGNAL_HTTP_PROXY")
     end
 
     test "ignore_actions" do
       actions = ~w(
-          ExampleApplication.PageController#ignored
-          ExampleApplication.PageController#also_ignored
+        ExampleApplication.PageController#ignored
+        ExampleApplication.PageController#also_ignored
       )
       add_to_application_env(:ignore_actions, actions)
-      assert valid_configuration() |> Map.put(:ignore_actions, actions) == init_config()
+      assert default_configuration() |> Map.put(:ignore_actions, actions) == init_config()
       assert "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored" == System.get_env("APPSIGNAL_IGNORE_ACTIONS")
     end
 
     test "ignore_errors" do
       errors = ~w(VerySpecificError AnotherError)
       add_to_application_env(:ignore_errors, errors)
-      assert valid_configuration() |> Map.put(:ignore_errors, errors) == init_config()
+      assert default_configuration() |> Map.put(:ignore_errors, errors) == init_config()
       assert "VerySpecificError,AnotherError" == System.get_env("APPSIGNAL_IGNORE_ERRORS")
-    end
-
-    test "env" do
-      add_to_application_env(:env, :prod)
-      assert valid_configuration() |> Map.put(:env, :prod) == init_config()
-      assert "prod" == System.get_env("APPSIGNAL_ENVIRONMENT")
-    end
-
-    test "ca_file_path" do
-      add_to_application_env(:ca_file_path, "/foo/bar/zab.ca")
-      assert valid_configuration() |> Map.put(:ca_file_path, "/foo/bar/zab.ca") == init_config()
-      assert "/foo/bar/zab.ca" == System.get_env("APPSIGNAL_CA_FILE_PATH")
-    end
-
-    test "enable_host_metrics" do
-      add_to_application_env(:enable_host_metrics, false)
-      assert valid_configuration() |> Map.put(:enable_host_metrics, false) == init_config()
-      assert "false" == System.get_env("APPSIGNAL_ENABLE_HOST_METRICS")
     end
 
     test "log" do
       add_to_application_env(:log, "stdout")
-      assert valid_configuration() |> Map.put(:log, "stdout") == init_config()
+      assert default_configuration() |> Map.put(:log, "stdout") == init_config()
       assert "stdout" == System.get_env("APPSIGNAL_LOG")
     end
 
     test "log_path" do
       add_to_application_env(:log_path, "log/appsignal.log")
-      assert valid_configuration() |> Map.put(:log_path, "log/appsignal.log") == init_config()
+      assert default_configuration() |> Map.put(:log_path, "log/appsignal.log") == init_config()
       assert "log/appsignal.log" == System.get_env("APPSIGNAL_LOG_FILE_PATH")
     end
 
-    test "endpoint" do
-      add_to_application_env(:endpoint, "https://push.staging.lol")
-      assert valid_configuration() |> Map.put(:endpoint, "https://push.staging.lol") == init_config()
-      assert "https://push.staging.lol" == System.get_env("APPSIGNAL_PUSH_API_ENDPOINT")
+    test "name" do
+      add_to_application_env(:name, :my_application)
+      assert default_configuration() |> Map.put(:name, :my_application) == init_config()
+      assert "my_application" == System.get_env("APPSIGNAL_APP_NAME")
+    end
+
+    test "push_api_key" do
+      add_to_application_env(:push_api_key, "00000000-0000-0000-0000-000000000000")
+      assert valid_configuration() |> Map.put(:active, false) == init_config()
+      assert "00000000-0000-0000-0000-000000000000" == System.get_env("APPSIGNAL_PUSH_API_KEY")
+    end
+
+    test "revision" do
+      add_to_application_env(:revision, "03bd9e")
+      assert default_configuration() |> Map.put(:revision, "03bd9e") == init_config()
+      assert "03bd9e" == System.get_env("APP_REVISION")
     end
 
     test "running_in_container" do
       add_to_application_env(:running_in_container, true)
-      assert valid_configuration() |> Map.put(:running_in_container, true) == init_config()
+      assert default_configuration() |> Map.put(:running_in_container, true) == init_config()
       assert "true" == System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER")
     end
 
     test "send_params" do
       add_to_application_env(:send_params, true)
-      assert valid_configuration() |> Map.put(:send_params, true) == init_config()
+      assert default_configuration() |> Map.put(:send_params, true) == init_config()
       assert "true" == System.get_env("APPSIGNAL_SEND_PARAMS")
     end
 
     test "skip_session_data" do
       add_to_application_env(:skip_session_data, true)
-      assert valid_configuration() |> Map.put(:skip_session_data, true) == init_config()
+      assert default_configuration() |> Map.put(:skip_session_data, true) == init_config()
     end
 
     test "working_dir_path" do
       add_to_application_env(:working_dir_path, "/tmp/appsignal")
-      assert valid_configuration() |> Map.put(:working_dir_path, "/tmp/appsignal") == init_config()
+      assert default_configuration() |> Map.put(:working_dir_path, "/tmp/appsignal") == init_config()
       assert "/tmp/appsignal" == System.get_env("APPSIGNAL_WORKING_DIR_PATH")
-    end
-
-    test "revision" do
-      add_to_application_env(:revision, "03bd9e")
-      assert valid_configuration() |> Map.put(:revision, "03bd9e") == init_config()
-      assert "03bd9e" == System.get_env("APP_REVISION")
-    end
-
-    test "hostname" do
-      add_to_application_env(:hostname, "Bobs-MPB.example.com")
-      assert valid_configuration() |> Map.put(:hostname, "Bobs-MPB.example.com") == init_config()
-      assert "Bobs-MPB.example.com" == System.get_env("APPSIGNAL_HOSTNAME")
     end
   end
 
   describe "using the system environment" do
-    setup do
-      System.put_env(
-        "APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000"
-      )
-    end
-
-    test "valid configuration" do
-      assert valid_configuration() == init_config()
-    end
-
     test "active" do
-      System.put_env("APPSIGNAL_ACTIVE", "false")
-      assert valid_configuration() |> Map.put(:active, false) == init_config()
-      assert "false" == System.get_env("APPSIGNAL_ACTIVE")
+      System.put_env("APPSIGNAL_ACTIVE", "true")
+      assert default_configuration() |> Map.put(:active, true) == init_config()
+      assert "true" == System.get_env("APPSIGNAL_ACTIVE")
     end
 
-    test "name" do
-      System.put_env("APPSIGNAL_APP_NAME", "my_application")
-      assert valid_configuration() |> Map.put(:name, :my_application) == init_config()
-      assert "my_application" == System.get_env("APPSIGNAL_APP_NAME")
+    test "ca_file_path" do
+      System.put_env("APPSIGNAL_CA_FILE_PATH", "/foo/bar/baz.ca")
+      assert default_configuration() |> Map.put(:ca_file_path, "/foo/bar/baz.ca") == init_config()
+      assert "/foo/bar/baz.ca" == System.get_env("APPSIGNAL_CA_FILE_PATH")
     end
 
     test "debug" do
       System.put_env("APPSIGNAL_DEBUG", "true")
-      assert valid_configuration() |> Map.put(:debug, true) == init_config()
+      assert default_configuration() |> Map.put(:debug, true) == init_config()
       assert "true" == System.get_env("APPSIGNAL_DEBUG_LOGGING")
+    end
+
+    test "enable_host_metrics" do
+      System.put_env("APPSIGNAL_ENABLE_HOST_METRICS", "false")
+      assert default_configuration() |> Map.put(:enable_host_metrics, false) == init_config()
+      assert "false" == System.get_env("APPSIGNAL_ENABLE_HOST_METRICS")
+    end
+
+    test "endpoint" do
+      System.put_env("APPSIGNAL_PUSH_API_ENDPOINT", "https://push.staging.lol")
+      assert default_configuration() |> Map.put(:endpoint, "https://push.staging.lol") == init_config()
+      assert "https://push.staging.lol" == System.get_env("APPSIGNAL_PUSH_API_ENDPOINT")
+    end
+
+    test "env" do
+      System.put_env("APPSIGNAL_APP_ENV", "prod")
+      assert default_configuration() |> Map.put(:env, :prod) == init_config()
+      assert "prod" == System.get_env("APPSIGNAL_APP_ENV")
+      assert "prod" == System.get_env("APPSIGNAL_ENVIRONMENT")
     end
 
     test "filter_parameters" do
       System.put_env("APPSIGNAL_FILTER_PARAMETERS", "password,secret")
-      assert valid_configuration() |> Map.put(:filter_parameters, ~w(password secret)) == init_config()
+      assert default_configuration() |> Map.put(:filter_parameters, ~w(password secret)) == init_config()
       assert "password,secret" == System.get_env("APPSIGNAL_FILTER_PARAMETERS")
     end
 
     test "frontend_error_catching_path" do
       System.put_env("APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH", "/appsignal_error_catcher")
-      assert valid_configuration() |> Map.put(:frontend_error_catching_path, "/appsignal_error_catcher") == init_config()
+      assert default_configuration() |> Map.put(:frontend_error_catching_path, "/appsignal_error_catcher") == init_config()
+      assert "/appsignal_error_catcher" == System.get_env("APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH")
+    end
+
+    test "hostname" do
+      System.put_env("APPSIGNAL_HOSTNAME", "Bobs-MBP.example.com")
+      assert default_configuration() |> Map.put(:hostname, "Bobs-MBP.example.com") == init_config()
+      assert "Bobs-MBP.example.com" == System.get_env("APPSIGNAL_HOSTNAME")
     end
 
     test "http_proxy" do
       System.put_env("APPSIGNAL_HTTP_PROXY", "http://10.10.10.10:8888")
-      assert valid_configuration() |> Map.put(:http_proxy, "http://10.10.10.10:8888") == init_config()
+      assert default_configuration() |> Map.put(:http_proxy, "http://10.10.10.10:8888") == init_config()
       assert "http://10.10.10.10:8888" == System.get_env("APPSIGNAL_HTTP_PROXY")
     end
 
@@ -223,87 +241,76 @@ defmodule Appsignal.ConfigTest do
           ExampleApplication.PageController#ignored
           ExampleApplication.PageController#also_ignored
       )
-      assert valid_configuration() |> Map.put(:ignore_actions, actions) == init_config()
+      assert default_configuration() |> Map.put(:ignore_actions, actions) == init_config()
       assert "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored" == System.get_env("APPSIGNAL_IGNORE_ACTIONS")
     end
 
     test "ignore_errors" do
       System.put_env("APPSIGNAL_IGNORE_ERRORS", "VerySpecificError,AnotherError")
       errors = ~w(VerySpecificError AnotherError)
-      assert valid_configuration() |> Map.put(:ignore_errors, errors) == init_config()
+      assert default_configuration() |> Map.put(:ignore_errors, errors) == init_config()
       assert "VerySpecificError,AnotherError" == System.get_env("APPSIGNAL_IGNORE_ERRORS")
-    end
-
-    test "env" do
-      System.put_env("APPSIGNAL_APP_ENV", "prod")
-      assert valid_configuration() |> Map.put(:env, :prod) == init_config()
-      assert "prod" == System.get_env("APPSIGNAL_APP_ENV")
-      assert "prod" == System.get_env("APPSIGNAL_ENVIRONMENT")
-    end
-
-    test "ca_file_path" do
-      System.put_env("APPSIGNAL_CA_FILE_PATH", "/foo/bar/baz.ca")
-      assert valid_configuration() |> Map.put(:ca_file_path, "/foo/bar/baz.ca") == init_config()
-      assert "/foo/bar/baz.ca" == System.get_env("APPSIGNAL_CA_FILE_PATH")
-    end
-
-    test "enable_host_metrics" do
-      System.put_env("APPSIGNAL_ENABLE_HOST_METRICS", "false")
-      assert valid_configuration() |> Map.put(:enable_host_metrics, false) == init_config()
-      assert "false" == System.get_env("APPSIGNAL_ENABLE_HOST_METRICS")
     end
 
     test "log" do
       System.put_env("APPSIGNAL_LOG", "stdout")
-      assert valid_configuration() |> Map.put(:log, "stdout") == init_config()
+      assert default_configuration() |> Map.put(:log, "stdout") == init_config()
       assert "stdout" == System.get_env("APPSIGNAL_LOG")
     end
 
     test "log_path" do
       System.put_env("APPSIGNAL_LOG_PATH", "log/appsignal.log")
-      assert valid_configuration() |> Map.put(:log_path, "log/appsignal.log") == init_config()
+      assert default_configuration() |> Map.put(:log_path, "log/appsignal.log") == init_config()
       assert "log/appsignal.log" == System.get_env("APPSIGNAL_LOG_FILE_PATH")
     end
 
-    test "endpoint" do
-      System.put_env("APPSIGNAL_PUSH_API_ENDPOINT", "https://push.staging.lol")
-      assert valid_configuration() |> Map.put(:endpoint, "https://push.staging.lol") == init_config()
-      assert "https://push.staging.lol" == System.get_env("APPSIGNAL_PUSH_API_ENDPOINT")
+    test "name" do
+      System.put_env("APPSIGNAL_APP_NAME", "my_application")
+      assert default_configuration() |> Map.put(:name, :my_application) == init_config()
+      assert "my_application" == System.get_env("APPSIGNAL_APP_NAME")
+    end
+
+    test "push_api_key" do
+      System.put_env("APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000")
+      assert valid_configuration() == init_config()
+      assert "true" == System.get_env("APPSIGNAL_ACTIVE")
+      assert "00000000-0000-0000-0000-000000000000" == System.get_env("APPSIGNAL_PUSH_API_KEY")
+    end
+
+    test "without push_api_key" do
+      assert default_configuration() == init_config()
+      assert "false" == System.get_env("APPSIGNAL_ACTIVE")
+      assert "" == System.get_env("APPSIGNAL_PUSH_API_KEY")
+    end
+
+    test "revision" do
+      System.put_env("APP_REVISION", "03bd9e")
+      assert default_configuration() |> Map.put(:revision, "03bd9e") == init_config()
+      assert "03bd9e" == System.get_env("APP_REVISION")
     end
 
     test "running_in_container" do
       System.put_env("APPSIGNAL_RUNNING_IN_CONTAINER", "true")
-      assert valid_configuration() |> Map.put(:running_in_container, true) == init_config()
+      assert default_configuration() |> Map.put(:running_in_container, true) == init_config()
       assert "true" == System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER")
     end
 
     test "send_params" do
       System.put_env("APPSIGNAL_SEND_PARAMS", "true")
-      assert valid_configuration() |> Map.put(:send_params, true) == init_config()
+      assert default_configuration() |> Map.put(:send_params, true) == init_config()
       assert "true" == System.get_env("APPSIGNAL_SEND_PARAMS")
     end
 
     test "skip_session_data" do
       System.put_env("APPSIGNAL_SKIP_SESSION_DATA", "true")
-      assert valid_configuration() |> Map.put(:skip_session_data, true) == init_config()
+      assert default_configuration() |> Map.put(:skip_session_data, true) == init_config()
+      assert "true" == System.get_env("APPSIGNAL_SKIP_SESSION_DATA")
     end
 
     test "working_dir_path" do
       System.put_env("APPSIGNAL_WORKING_DIR_PATH", "/tmp/appsignal")
-      assert valid_configuration() |> Map.put(:working_dir_path, "/tmp/appsignal") == init_config()
+      assert default_configuration() |> Map.put(:working_dir_path, "/tmp/appsignal") == init_config()
       assert "/tmp/appsignal" == System.get_env("APPSIGNAL_WORKING_DIR_PATH")
-    end
-
-    test "revision" do
-      System.put_env("APP_REVISION", "03bd9e")
-      assert valid_configuration() |> Map.put(:revision, "03bd9e") == init_config()
-      assert "03bd9e" == System.get_env("APP_REVISION")
-    end
-
-    test "hostname" do
-      System.put_env("APPSIGNAL_HOSTNAME", "Bobs-MBP.example.com")
-      assert valid_configuration() |> Map.put(:hostname, "Bobs-MBP.example.com") == init_config()
-      assert "Bobs-MBP.example.com" == System.get_env("APPSIGNAL_HOSTNAME")
     end
   end
 
@@ -312,9 +319,7 @@ defmodule Appsignal.ConfigTest do
       :appsignal, :config,
       push_api_key: "11111111-1111-1111-1111-111111111111"
     )
-    System.put_env(
-      "APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000"
-    )
+    System.put_env("APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000")
 
     assert valid_configuration() == init_config()
     assert "00000000-0000-0000-0000-000000000000" == System.get_env("APPSIGNAL_PUSH_API_KEY")
@@ -322,12 +327,11 @@ defmodule Appsignal.ConfigTest do
 
   describe "on Heroku" do
     setup do
-      System.put_env("APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000")
       System.put_env("DYNO", "web.1")
     end
 
     test ":running_in_container and :log" do
-      assert valid_heroku_configuration() == init_config()
+      assert default_heroku_configuration() == init_config()
       assert "true" == System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER")
       assert "stdout" == System.get_env("APPSIGNAL_LOG")
     end
@@ -337,7 +341,7 @@ defmodule Appsignal.ConfigTest do
         :appsignal, :config,
         running_in_container: false
       )
-      assert valid_heroku_configuration() |> Map.put(:running_in_container, false) == init_config()
+      assert default_heroku_configuration() |> Map.put(:running_in_container, false) == init_config()
       assert "false" == System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER")
     end
 
@@ -346,8 +350,17 @@ defmodule Appsignal.ConfigTest do
         :appsignal, :config,
         log: "file"
       )
-      assert valid_heroku_configuration() |> Map.put(:log, "file") == init_config()
+      assert default_heroku_configuration() |> Map.put(:log, "file") == init_config()
       assert "file" == System.get_env("APPSIGNAL_LOG")
+    end
+
+    test "push_api_key" do
+      System.put_env("APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000")
+      assert valid_heroku_configuration() == init_config()
+      assert "true" == System.get_env("APPSIGNAL_ACTIVE")
+      assert "true" == System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER")
+      assert "stdout" == System.get_env("APPSIGNAL_LOG")
+      assert "00000000-0000-0000-0000-000000000000" == System.get_env("APPSIGNAL_PUSH_API_KEY")
     end
   end
 
@@ -373,8 +386,14 @@ defmodule Appsignal.ConfigTest do
   defp valid_configuration() do
     default_configuration()
     |> Map.put(:active, true)
-    |> Map.put(:push_api_key, "00000000-0000-0000-0000-000000000000")
     |> Map.put(:valid, true)
+    |> Map.put(:push_api_key, "00000000-0000-0000-0000-000000000000")
+  end
+
+  defp default_heroku_configuration() do
+    default_configuration()
+    |> Map.put(:running_in_container, true)
+    |> Map.put(:log, "stdout")
   end
 
   defp valid_heroku_configuration() do


### PR DESCRIPTION
Don't activate AppSignal always, when the push_api_key is in any config
type (system, app, env), but only activate AppSignal by default when the
push_api_key is found in the system environment variable
APPSIGNAL_PUSH_API_KEY.

This change makes the activation behavior the same for Elixir as for our
Ruby gem (https://github.com/appsignal/appsignal-ruby), which is more
flexible.

As discussed in https://github.com/appsignal/appsignal-elixir/issues/86

What this change means in practice. Before:

```
config :appsignal, :config,
  name: :my_app,
  push_api_key: "your-hex-appsignal-key"
```

This would make AppSignal active _always_, as long as the push_api_key
was set. The only exception was when `active` was explicitly set to
`false`.

After this change you need to explicitly set `active: true` to activate
AppSignal.

```
// config/config.exs
config :appsignal, :config,
  name: :my_app,
  active: true,
  push_api_key: "your-hex-appsignal-key"
```

Or as is probably be more common, activation per environment:

```
// config/config.exs
config :appsignal, :config,
  name: :my_app,
  push_api_key: "your-hex-appsignal-key"
```

```
// config/prod.exs
config :appsignal, :config,
  active: true
```

The exception to this rule is the APPSIGNAL_PUSH_API_KEY environment
variable. When this environment variable is found in the system
environment AppSignal also becomes active: `active: true`.
Unless explicitly set to `active: false` in the application config or
in the environment `APPSIGNAL_ACTIVE=false`.


Closes #86 