### PR TITLE
:running_in_container in diagnose

### DIFF
--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -696,6 +696,14 @@ static ERL_NIF_TERM _data_list_new(ErlNifEnv* env, int UNUSED(argc), const ERL_N
   return make_ok_tuple(env, data_ref);
 }
 
+static ERL_NIF_TERM _running_in_container(ErlNifEnv* env, int UNUSED(argc), const ERL_NIF_TERM UNUSED(argv[])) {
+  if(appsignal_running_in_container() == 1) {
+    return enif_make_atom(env, "true");
+  } else {
+    return enif_make_atom(env, "false");
+  }
+}
+
 #ifdef TEST
 static ERL_NIF_TERM _data_to_json(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   data_ptr *ptr;
@@ -792,6 +800,7 @@ static ErlNifFunc nif_funcs[] =
     {"_data_set_data", 3, _data_set_data, 0},
     {"_data_set_data", 2, _data_set_data, 0},
     {"_data_list_new", 0, _data_list_new, 0},
+    {"_running_in_container", 0, _running_in_container, 0},
 #ifdef TEST
     {"_data_to_json", 1, _data_to_json, 0},
 #endif

--- a/config/agent.exs
+++ b/config/agent.exs
@@ -1,0 +1,28 @@
+use Mix.Config
+
+config :appsignal,
+  agent: %{
+    version: "f81fe90",
+    triples: %{
+      "x86_64-linux" =>
+      %{checksum: "5336a1fe0e59e542095463698f5acd2038ecd9899544284f68bc8a312c66a1ef",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f81fe90/appsignal-x86_64-linux-all-static.tar.gz"
+       },
+      "i686-linux" =>
+        %{checksum: "84b72b1dd43e8e58af11658d13b57508a8975bf347f0625d56bd7e69ed7ad382",
+          download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f81fe90/appsignal-i686-linux-all-static.tar.gz"
+         },
+      "x86-linux" =>
+        %{checksum: "84b72b1dd43e8e58af11658d13b57508a8975bf347f0625d56bd7e69ed7ad382",
+          download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f81fe90/appsignal-i686-linux-all-static.tar.gz"
+         },
+      "x86_64-darwin" =>
+        %{checksum: "2a7179ab79ad28af88bed8db37cbd52b3a8065393f476ae9b5e3d7b027020b72",
+          download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f81fe90/appsignal-x86_64-darwin-all-static.tar.gz"
+         },
+      "universal-darwin" =>
+        %{checksum: "2a7179ab79ad28af88bed8db37cbd52b3a8065393f476ae9b5e3d7b027020b72",
+          download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f81fe90/appsignal-x86_64-darwin-all-static.tar.gz"
+         }
+    }
+  }

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,3 +8,5 @@ if Mix.env in [:test, :test_phoenix, :test_no_nif] do
 
   config :appsignal, appsignal_system: Appsignal.FakeSystem
 end
+
+import_config "agent.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,7 @@ if Mix.env in [:test, :test_phoenix, :test_no_nif] do
     handle_sasl_reports: false
 
   config :appsignal, appsignal_system: Appsignal.FakeSystem
+  config :appsignal, appsignal_nif: Appsignal.FakeNif
 end
 
 import_config "agent.exs"

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -177,6 +177,10 @@ defmodule Appsignal.Nif do
     _data_list_new()
   end
 
+  def running_in_container? do
+    _running_in_container()
+  end
+
   def loaded? do
     _loaded()
   end
@@ -303,6 +307,10 @@ defmodule Appsignal.Nif do
 
   def _data_list_new() do
     {:ok, nil}
+  end
+
+  def _running_in_container do
+    false
   end
 
   def _loaded do

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -1,5 +1,6 @@
 defmodule Appsignal.NifBehaviour do
   @callback loaded?() :: boolean()
+  @callback running_in_container?() :: boolean()
 end
 
 defmodule Appsignal.Nif do

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -1,4 +1,9 @@
+defmodule Appsignal.NifBehaviour do
+  @callback loaded?() :: boolean()
+end
+
 defmodule Appsignal.Nif do
+  @behaviour Appsignal.NifBehaviour
   @moduledoc """
 
   It's a NIF! Oh no!

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -3,6 +3,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   use Mix.Task
 
   @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
+  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   @shortdoc "Starts and tests AppSignal while validating the configuration."
 
@@ -44,7 +45,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts "  Package version: #{Appsignal.Mixfile.project[:version]}"
 
     IO.puts "  Agent version: #{Appsignal.Agent.version}"
-    IO.puts "  Nif loaded: #{yes_or_no(Appsignal.Nif.loaded?)}"
+    IO.puts "  Nif loaded: #{yes_or_no(@nif.loaded?)}"
   end
 
   defp host_information do

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -58,6 +58,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     if @system.heroku? do
       IO.puts "  Heroku: yes"
     end
+    IO.puts "  Container: #{yes_or_no(@nif.running_in_container?)}"
   end
 
   defp load_agent_config do

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -88,6 +88,24 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     end
   end
 
+  describe "when running in a container" do
+    setup do: @nif.set(:running_in_container?, true)
+
+    test "outputs Container: yes" do
+      output = run()
+      assert String.contains? output, "Container: yes"
+    end
+  end
+
+  describe "when not running in a container" do
+    setup do: @nif.set(:running_in_container?, false)
+
+    test "outputs Container: no" do
+      output = run()
+      assert String.contains? output, "Container: no"
+    end
+  end
+
   describe "when not root user" do
     test "outputs root user: no" do
       output = run()

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   import Mock
 
   @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
+  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   defp run do
     capture_io(fn -> Mix.Tasks.Appsignal.Diagnose.run(nil) end)
@@ -11,6 +12,8 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
   setup do
     @system.start_link
+    @nif.start_link
+
     original_config = appsignal_config()
 
     # By default, Push API key is valid
@@ -59,7 +62,9 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   end
 
   describe "when Nif is not loaded" do
-    test_with_mock "outputs that the Nif is not loaded", Appsignal.Nif, [:passthrough], [loaded?: fn -> false end] do
+    setup do: @nif.set(:loaded?, false)
+
+    test "outputs that the Nif is not loaded" do
       output = run()
       assert String.contains? output, "Nif loaded: no"
     end

--- a/test/support/fake_nif.ex
+++ b/test/support/fake_nif.ex
@@ -1,0 +1,19 @@
+defmodule Appsignal.FakeNif do
+  @behaviour Appsignal.NifBehaviour
+
+  def start_link do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  def set(key, value) do
+    Agent.update(__MODULE__, &Map.put(&1, key, value))
+  end
+
+  def loaded? do
+    Agent.get(__MODULE__, &Map.get(&1, :loaded?, true))
+  end
+
+  def running_in_container? do
+    Agent.get(__MODULE__, &Map.get(&1, :running_in_container?, true))
+  end
+end


### PR DESCRIPTION
Display whether or not the agent is running in a container in `mix appsignal.diagnose`.