### PR TITLE
Check valid state on Config.active?

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -52,7 +52,8 @@ defmodule Appsignal.Config do
   """
   @spec active?() :: boolean
   def active? do
-    Application.fetch_env!(:appsignal, :config).active
+    config = Application.fetch_env!(:appsignal, :config)
+    config.valid && config.active
   end
 
   @env_to_key_mapping %{

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -35,6 +35,23 @@ defmodule Appsignal.ConfigTest do
     assert default_configuration() == init_config()
   end
 
+  describe "active?" do
+    test "when active and valid" do
+      Application.put_env(:appsignal, :config, %{active: true, valid: true})
+      assert Config.active?
+    end
+
+    test "when active but not valid" do
+      Application.put_env(:appsignal, :config, %{active: true, valid: false})
+      refute Config.active?
+    end
+
+    test "when not active and not valid" do
+      Application.put_env(:appsignal, :config, %{active: false, valid: false})
+      refute Config.active?
+    end
+  end
+
   describe "using the application environment" do
     setup do
       Application.put_env(


### PR DESCRIPTION
The active function seemed to be missing specs so I added them and added
a check if the config is valid as well. Same behavior as in the Ruby
gem.

https://github.com/appsignal/appsignal-ruby/blob/ca0a92e2c0f140d4cc9a014c3e47ac0582c5a67d/lib/appsignal/config.rb#L114-L116

The valid and active behavior was linked before on the push_api_key
presence, but that was changed in PR #119 