### PR TITLE
Force agent to run in diagnostics mode in diagnose

### DIFF
--- a/agent.ex
+++ b/agent.ex
@@ -1,27 +1,27 @@
 defmodule Appsignal.Agent do
-  def version, do: "5464697"
+  def version, do: "557cdf6"
 
   def triples do
     %{
       "x86_64-linux" => %{
-        checksum: "a70f22af18f50ea1a02adf4ef88f68047b353a185fd100e8a61bc7ade87095bc",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/5464697/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "ebf3da9dfd753596295db62af5e786cc2d39fd75d23bf2b3b986763e853db87a",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-linux-all-static.tar.gz"
        },
       "i686-linux" => %{
-        checksum: "2101667a3c56dfe78436c4f25b763a1db2028dd6ebe247b64d3c616066269879",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/5464697/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "853c7d58b6c84f702351cf5690c606b8d51ab686494f989133dde42171ea691e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86-linux" => %{
-        checksum: "2101667a3c56dfe78436c4f25b763a1db2028dd6ebe247b64d3c616066269879",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/5464697/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "853c7d58b6c84f702351cf5690c606b8d51ab686494f989133dde42171ea691e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86_64-darwin" => %{
-        checksum: "496f3348ae0e957b2610bb82ae23ab3c9878483a01e447a9f27537c99bd9f69d",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/5464697/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "80815cf70a783cf0bcef586361fcbd4460b379ac4876cb824388345cd1cbecbb",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-darwin-all-static.tar.gz"
        },
       "universal-darwin" => %{
-        checksum: "496f3348ae0e957b2610bb82ae23ab3c9878483a01e447a9f27537c99bd9f69d",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/5464697/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "80815cf70a783cf0bcef586361fcbd4460b379ac4876cb824388345cd1cbecbb",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-darwin-all-static.tar.gz"
        },
     }
   end

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -17,7 +17,7 @@ defmodule Appsignal.Nif do
   Internally, the AppSignal NIF works as follows: it fork/execs a
   separate agent process, to which the NIF sends its data (protobuf)
   over a unix socket. This agent process (which is a separate unix
-  process!) then takes care of sending the data the the server
+  process!) then takes care of sending the data the server
   periodically.
 
   The C library that the NIF interfaces with, is specifically written


### PR DESCRIPTION
It's very difficult to capture the Nif STDOUT output using `ExUnit.capture_io`. Now we run the agent executable separately to capture the output.

Also force the `APPSIGNAL_ACTIVE` env to be true, otherwise it doesn't run properly -- Double check this, if we should do that or let the env config decide it. (That's how Ruby does it currently).
