### PR TITLE
Check agent version in Mix.Appsignal.Helper.ensure_downloaded/1

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -146,6 +146,6 @@ defmodule Mix.Appsignal.Helper do
 
   defp has_correct_agent_version? do
     path = priv_path("appsignal.version")
-    File.read(path) == {:ok, Appsignal.Agent.version}
+    File.read(path) == {:ok, "#{Appsignal.Agent.version}\n"}
   end
 end

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -131,7 +131,7 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp priv_path(filename) do
-    priv_dir() <> "/" <> filename
+    Path.join(priv_dir(), filename)
   end
 
   defp has_file(filename) do

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -19,12 +19,12 @@ defmodule Mix.Appsignal.Helper do
 
   def ensure_downloaded(arch) do
     arch_config = Appsignal.Agent.triples[arch]
-    version = Appsignal.Agent.version
 
     System.put_env("LIB_DIR", priv_dir())
 
-    unless has_file("appsignal-agent") and has_file("appsignal.h") and has_file("appsignal_extension.so") do
-
+    unless has_files?() and has_correct_agent_version?() do
+      version = Appsignal.Agent.version
+      File.rm_rf!(priv_dir())
       File.mkdir_p!(priv_dir())
       try do
         download_and_extract(arch_config[:download_url], version, arch_config[:checksum])
@@ -130,8 +130,22 @@ defmodule Mix.Appsignal.Helper do
     List.to_string(path)
   end
 
-  defp has_file(filename) do
-    File.exists?(priv_dir() <> "/" <> filename)
+  defp priv_path(filename) do
+    priv_dir() <> "/" <> filename
   end
 
+  defp has_file(filename) do
+    filename |> priv_path |> File.exists?
+  end
+
+  defp has_files? do
+    has_file("appsignal-agent") and
+    has_file("appsignal.h") and
+    has_file("appsignal_extension.so")
+  end
+
+  defp has_correct_agent_version? do
+    path = priv_path("appsignal.version")
+    File.read(path) == {:ok, Appsignal.Agent.version}
+  end
 end


### PR DESCRIPTION
Closes #138. Needs a new version of the agent that includes a file named appsignal.version that holds the agent build's revision. 

TODO:

- [x] Update agent version once available
- [x] Test locally with old agents installed

**Note**: this is a hotfix on master.