### PR TITLE
Move package version to a module attribute

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -2,6 +2,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   require Logger
   use Mix.Task
 
+  @appsignal_version Mix.Project.config[:version]
   @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
   @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
@@ -42,7 +43,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   defp agent_version do
     IO.puts "AppSignal agent"
     IO.puts "  Language: Elixir"
-    IO.puts "  Package version: #{Appsignal.Mixfile.project[:version]}"
+    IO.puts "  Package version: #{@appsignal_version}"
 
     IO.puts "  Agent version: #{Appsignal.Agent.version}"
     IO.puts "  Nif loaded: #{yes_or_no(@nif.loaded?)}"


### PR DESCRIPTION
Appsignal.Mixfile.project isn't available during runtime, only at
compile time. The first time you would run `mix appsignal.diagnose` from
the package it would work if you ran `mix appsignal.diagnose` as the
very first thing after installing/compiling AppSignal.

By moving the "fetch version" call to a module attribute this value is
read at compile time and is available at runtime in that module
attribute.

Tested in a compiled Elixir app. Seems to work.

**Note: This is a fix on master**