### PR TITLE
Make mix tasks available in releases

### DIFF
--- a/lib/appsignal/utils/tasks.ex
+++ b/lib/appsignal/utils/tasks.ex
@@ -1,0 +1,11 @@
+defmodule :appsignal_tasks do
+  def diagnose do
+    Mix.Tasks.Appsignal.Diagnose.run(nil)
+    :init.stop
+  end
+
+  def demo do
+    Mix.Tasks.Appsignal.Demo.run(nil)
+    :init.stop
+  end
+end


### PR DESCRIPTION
Add a module `:appsignal_tasks` that allows us to easily call mix tasks
in Elixir app releases. As inspired by
http://blog.plataformatec.com.br/2016/04/running-migration-in-an-exrm-release/

Usage:

```
_build/prod/rel/my_app/bin/my_app command appsignal_tasks diagnose|demo
```

**Note:** This doesn't fix the fact that the diagnose task will crash during its run, currently.