### PR TITLE
Rename Phoenix framework event names

### DIFF
--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -23,15 +23,15 @@ defmodule Appsignal.Demo do
   def create_transaction_performance_request do
     transaction = create_demo_transaction()
 
-    instrument(transaction, "template.render", "Rendering something slow", fn() ->
+    instrument(transaction, "render.phoenix_template", "Rendering something slow", fn() ->
       :timer.sleep(1000)
-      instrument(transaction, "ecto.query", "Slow query", fn() ->
+      instrument(transaction, "query.ecto", "Slow query", fn() ->
         :timer.sleep(300)
       end)
-      instrument(transaction, "ecto.query", "Slow query", fn() ->
+      instrument(transaction, "query.ecto", "Slow query", fn() ->
         :timer.sleep(500)
       end)
-      instrument(transaction, "template.render", "Rendering something slow", fn() ->
+      instrument(transaction, "render.phoenix_template", "Rendering something slow", fn() ->
         :timer.sleep(100)
       end)
     end)

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -28,7 +28,7 @@ defmodule Appsignal.Ecto do
         # record the event
         total_time = (entry.queue_time || 0) + (entry.query_time || 0) + (entry.decode_time || 0)
         duration = trunc(total_time / @nano_seconds)
-        Transaction.record_event(transaction, "ecto.query", "", entry.query, duration, 1)
+        Transaction.record_event(transaction, "query.ecto", "", entry.query, duration, 1)
     end
     entry
   end

--- a/lib/appsignal/phoenix/instrumenter.ex
+++ b/lib/appsignal/phoenix/instrumenter.ex
@@ -29,7 +29,7 @@ if Appsignal.phoenix? do
 
     @doc false
     def phoenix_controller_call(:stop, _diff, {%Appsignal.Transaction{} = transaction, args}) do
-      finish_event(transaction, "controller_call.phoenix", args)
+      finish_event(transaction, "call.phoenix_controller", args)
     end
     def phoenix_controller_call(:stop, _, _), do: nil
 
@@ -38,7 +38,7 @@ if Appsignal.phoenix? do
 
     @doc false
     def phoenix_controller_render(:stop, _diff, {%Appsignal.Transaction{} = transaction, args}) do
-      finish_event(transaction, "controller_render.phoenix", args)
+      finish_event(transaction, "render.phoenix_controller", args)
     end
     def phoenix_controller_render(:stop, _, _), do: nil
 

--- a/lib/appsignal/phoenix/template_instrumenter.ex
+++ b/lib/appsignal/phoenix/template_instrumenter.ex
@@ -39,7 +39,12 @@ if Appsignal.phoenix? do
         def compile(path, name) do
           expr = unquote(opts[:engine]).compile(path, name)
           quote do
-            Appsignal.Instrumentation.Helpers.instrument(self(), "template.render", unquote(name), fn() -> unquote(expr) end)
+            Appsignal.Instrumentation.Helpers.instrument(
+              self(),
+              "render.phoenix_template",
+              unquote(name),
+              fn() -> unquote(expr) end
+            )
           end
         end
       end

--- a/test/appsignal/demo_test.exs
+++ b/test/appsignal/demo_test.exs
@@ -21,7 +21,7 @@ defmodule AppsignalDemoTest do
     assert called Appsignal.Transaction.set_action(t, "DemoController#hello")
     assert called Appsignal.Transaction.set_meta_data(t, "demo_sample", "true")
     assert called Appsignal.Transaction.start_event(t)
-    assert called Appsignal.Transaction.finish_event(t, "template.render", "Rendering something slow", "", 0)
+    assert called Appsignal.Transaction.finish_event(t, "render.phoenix_template", "Rendering something slow", "", 0)
     assert called Appsignal.Transaction.finish(t)
     assert called Appsignal.Transaction.complete(t)
   end

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -91,14 +91,14 @@ defmodule AppsignalTransactionTest do
     assert %Transaction{} = transaction
 
     assert ^transaction = Transaction.start_event(transaction)
-    assert ^transaction = Transaction.finish_event(transaction, "phoenix_controller_render", "phoenix_controller_render", %{format: "html", template: "index.html"}, 0)
+    assert ^transaction = Transaction.finish_event(transaction, "render.phoenix_controller", "phoenix_controller_render", %{format: "html", template: "index.html"}, 0)
   end
 
   test "handles unformatted stacktraces" do
     transaction = Transaction.start("test1", :http_request)
     assert ^transaction = Transaction.set_error(transaction, "Error", "error message", System.stacktrace)
     assert ^transaction = Transaction.start_event(transaction)
-    assert ^transaction = Transaction.finish_event(transaction, "phoenix_controller_render", "phoenix_controller_render", %{format: "html", template: "index.html"}, 0)
+    assert ^transaction = Transaction.finish_event(transaction, "render.phoenix_controller", "phoenix_controller_render", %{format: "html", template: "index.html"}, 0)
   end
 
   describe "concerning skipping session data" do

--- a/test/phoenix/instrumenter_test.exs
+++ b/test/phoenix/instrumenter_test.exs
@@ -16,7 +16,7 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
 
   test "starts an event in phoenix_controller_call", context do
     arguments = %{foo: "bar"}
-    assert {context[:transaction], arguments} == 
+    assert {context[:transaction], arguments} ==
       Instrumenter.phoenix_controller_call(:start, nil, arguments)
   end
 
@@ -31,8 +31,8 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
     assert [
       %{
         transaction: context[:transaction],
-        name: "controller_call.phoenix",
-        title: "controller_call.phoenix",
+        name: "call.phoenix_controller",
+        title: "call.phoenix_controller",
         body: %{},
         body_format: 0
       }
@@ -49,8 +49,8 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
     assert [
       %{
         transaction: context[:transaction],
-        name: "controller_render.phoenix",
-        title: "controller_render.phoenix",
+        name: "render.phoenix_controller",
+        title: "render.phoenix_controller",
         body: %{},
         body_format: 0
       }


### PR DESCRIPTION
Follows this guide to name events:
http://docs.appsignal.com/api/event-names.html

The group names will become:

- phoenix_controller
- phoenix_template
- ecto

and were:

- phoenix
- render
- query

This allows users to more easily distinguish where what event is from.