### PR TITLE
Add HTTPoison app to mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Appsignal.Mixfile do
 
   def application do
     [mod: {Appsignal, []},
-     applications: [:logger]]
+     applications: [:logger, :decorator, :httpoison]]
   end
 
   defp compilers(:test_phoenix), do: [:phoenix] ++ compilers(:prod)


### PR DESCRIPTION
That fixes the crash in the diagnose task in production about missing
the app.

**Note**: Just one error remaining until the diagnose task actually works in a built app