### PR TITLE
Load agent.ex only once and set on project data

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -3,6 +3,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   alias Appsignal.Utils.PushApiKeyValidator
 
   @appsignal_version Mix.Project.config[:version]
+  @agent_version Mix.Project.config[:agent_version]
   @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
   @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
@@ -18,7 +19,6 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     host_information()
     empty_line()
 
-    load_agent_config()
     start_appsignal_in_diagnose_mode()
 
     configuration()
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts "  Language: Elixir"
     IO.puts "  Package version: #{@appsignal_version}"
 
-    IO.puts "  Agent version: #{Appsignal.Agent.version}"
+    IO.puts "  Agent version: #{@agent_version}"
     IO.puts "  Nif loaded: #{yes_or_no(@nif.loaded?)}"
   end
 
@@ -60,12 +60,6 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
       IO.puts "  Heroku: yes"
     end
     IO.puts "  Container: #{yes_or_no(@nif.running_in_container?)}"
-  end
-
-  defp load_agent_config do
-    unless Code.ensure_loaded?(Appsignal.Agent) do
-      {_, _} = Code.eval_file("agent.ex")
-    end
   end
 
   defp start_appsignal_in_diagnose_mode do

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,12 @@
+unless Code.ensure_loaded?(Appsignal.Agent) do
+  {_, _} = Code.eval_file("agent.ex")
+end
+
 defmodule Mix.Tasks.Compile.Appsignal do
   use Mix.Task
 
   def run(_args) do
     {_, _} = Code.eval_file("mix_helpers.exs")
-
-    unless Code.ensure_loaded?(Appsignal.Agent) do
-      {_, _} = Code.eval_file("agent.ex")
-    end
 
     case Mix.Appsignal.Helper.verify_system_architecture() do
       {:ok, arch} ->
@@ -21,6 +21,7 @@ end
 
 defmodule Appsignal.Mixfile do
   use Mix.Project
+  @agent_version Appsignal.Agent.version
 
   def project do
     [app: :appsignal,
@@ -35,7 +36,8 @@ defmodule Appsignal.Mixfile do
      compilers: compilers(Mix.env),
      elixirc_paths: elixirc_paths(Mix.env),
      deps: deps(),
-     docs: [logo: "logo.png", extras: ["Roadmap.md"]]
+     docs: [logo: "logo.png", extras: ["Roadmap.md"]],
+     agent_version: @agent_version
     ]
   end
 


### PR DESCRIPTION
If we load `agent.ex` in the function it gets loaded at runtime, which
doesn't work for released apps.

Instead we load/compile the file first thing when compiling the
AppSignal package. Once it is loaded we set the data on the project's
data and make it accessible to the diagnose task through
`Mix.Project.config[:agent_version]`

Fixes #145 