### PR TITLE
Configure agent with underscored config env vars

### DIFF
--- a/agent.ex
+++ b/agent.ex
@@ -1,27 +1,27 @@
 defmodule Appsignal.Agent do
-  def version, do: "557cdf6"
+  def version, do: "413c222"
 
   def triples do
     %{
       "x86_64-linux" => %{
-        checksum: "ebf3da9dfd753596295db62af5e786cc2d39fd75d23bf2b3b986763e853db87a",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "0154d797bf3873b40e2499140284e05c91070a13f25ec54a0df6d60c2e0f7c36",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-x86_64-linux-all-static.tar.gz"
        },
       "i686-linux" => %{
-        checksum: "853c7d58b6c84f702351cf5690c606b8d51ab686494f989133dde42171ea691e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "f7773d34618b742edeac39bf41ee6588ac0d5c8d182a459a86dc12c26020f188",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86-linux" => %{
-        checksum: "853c7d58b6c84f702351cf5690c606b8d51ab686494f989133dde42171ea691e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "f7773d34618b742edeac39bf41ee6588ac0d5c8d182a459a86dc12c26020f188",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86_64-darwin" => %{
-        checksum: "80815cf70a783cf0bcef586361fcbd4460b379ac4876cb824388345cd1cbecbb",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "dafa8467812ceaeecb96c8ca2768f4b667fc404935c7ef53e6d7c758dc6259c0",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-x86_64-darwin-all-static.tar.gz"
        },
       "universal-darwin" => %{
-        checksum: "80815cf70a783cf0bcef586361fcbd4460b379ac4876cb824388345cd1cbecbb",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "dafa8467812ceaeecb96c8ca2768f4b667fc404935c7ef53e6d7c758dc6259c0",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-x86_64-darwin-all-static.tar.gz"
        },
     }
   end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -160,43 +160,60 @@ defmodule Appsignal.Config do
   end
 
   defp write_to_environment(config) do
-    System.put_env("APPSIGNAL_ACTIVE", Atom.to_string(config[:active]))
-    System.put_env("APPSIGNAL_AGENT_PATH", List.to_string(:code.priv_dir(:appsignal)))
-    System.put_env("APPSIGNAL_AGENT_VERSION", @agent_version)
-    System.put_env("APPSIGNAL_APP_PATH", List.to_string(:code.priv_dir(:appsignal))) # FIXME - app_path should not be necessary
+    reset_environment_config!()
+
+    System.put_env("_APPSIGNAL_ACTIVE", Atom.to_string(config[:active]))
+    System.put_env("_APPSIGNAL_AGENT_PATH", List.to_string(:code.priv_dir(:appsignal)))
+    System.put_env("_APPSIGNAL_AGENT_VERSION", @agent_version)
+    System.put_env("_APPSIGNAL_APP_PATH", List.to_string(:code.priv_dir(:appsignal))) # FIXME - app_path should not be necessary
     unless empty?(config[:name]) do
-      System.put_env("APPSIGNAL_APP_NAME", app_name_to_string(config[:name]))
+      System.put_env("_APPSIGNAL_APP_NAME", app_name_to_string(config[:name]))
     end
     unless empty?(config[:ca_file_path]) do
-      System.put_env("APPSIGNAL_CA_FILE_PATH", config[:ca_file_path])
+      System.put_env("_APPSIGNAL_CA_FILE_PATH", config[:ca_file_path])
     end
-    System.put_env("APPSIGNAL_DEBUG_LOGGING", Atom.to_string(config[:debug]))
+    System.put_env("_APPSIGNAL_DEBUG_LOGGING", Atom.to_string(config[:debug]))
 
-    System.put_env("APPSIGNAL_ENABLE_HOST_METRICS", Atom.to_string(config[:enable_host_metrics]))
-    System.put_env("APPSIGNAL_ENVIRONMENT", Atom.to_string(config[:env]))
+    System.put_env("_APPSIGNAL_ENABLE_HOST_METRICS", Atom.to_string(config[:enable_host_metrics]))
+    System.put_env("_APPSIGNAL_ENVIRONMENT", Atom.to_string(config[:env]))
     unless empty?(config[:filter_parameters]) do
-      System.put_env("APPSIGNAL_FILTER_PARAMETERS", config[:filter_parameters] |> Enum.join(","))
+      System.put_env("_APPSIGNAL_FILTER_PARAMETERS", config[:filter_parameters] |> Enum.join(","))
     end
-    System.put_env("APPSIGNAL_HOSTNAME", config[:hostname])
+    System.put_env("_APPSIGNAL_HOSTNAME", config[:hostname])
     unless empty?(config[:http_proxy]) do
-      System.put_env("APPSIGNAL_HTTP_PROXY", config[:http_proxy])
+      System.put_env("_APPSIGNAL_HTTP_PROXY", config[:http_proxy])
     end
-    System.put_env("APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
-    System.put_env("APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))
-    System.put_env("APPSIGNAL_LANGUAGE_INTEGRATION_VERSION", "elixir-" <> @language_integration_version)
-    System.put_env("APPSIGNAL_LOG", config[:log])
+    System.put_env("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
+    System.put_env("_APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))
+    System.put_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION", "elixir-" <> @language_integration_version)
+    System.put_env("_APPSIGNAL_LOG", config[:log])
     unless empty?(config[:log_path]) do
-      System.put_env("APPSIGNAL_LOG_FILE_PATH", config[:log_path])
+      System.put_env("_APPSIGNAL_LOG_FILE_PATH", config[:log_path])
     end
-    System.put_env("APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
-    System.put_env("APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")
+    System.put_env("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
+    System.put_env("_APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")
     unless empty?(config[:running_in_container]) do
-      System.put_env("APPSIGNAL_RUNNING_IN_CONTAINER", Atom.to_string(config[:running_in_container]))
+      System.put_env("_APPSIGNAL_RUNNING_IN_CONTAINER", Atom.to_string(config[:running_in_container]))
     end
-    System.put_env("APPSIGNAL_SEND_PARAMS", Atom.to_string(config[:send_params]))
+    System.put_env("_APPSIGNAL_SEND_PARAMS", Atom.to_string(config[:send_params]))
     unless empty?(config[:working_dir_path]) do
-      System.put_env("APPSIGNAL_WORKING_DIR_PATH", config[:working_dir_path])
+      System.put_env("_APPSIGNAL_WORKING_DIR_PATH", config[:working_dir_path])
     end
+  end
+
+  @doc """
+  Reset the config written to the environment by `write_to_environment/1`.
+  This makes sure no existing config gets reused and the configuration for the
+  agent gets set again.
+  """
+  def reset_environment_config! do
+    System.get_env
+    |> Enum.filter(
+      fn({"_APPSIGNAL_" <> _, _}) -> true;
+      (_) -> false end
+    ) |> Enum.each(fn({key, _}) ->
+      System.delete_env(key)
+    end)
   end
 
   defp app_name_to_string(name) when is_atom(name), do: Atom.to_string(name)

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     Config.write_to_environment
 
     agent_path = Path.join(List.to_string(:code.priv_dir(:appsignal)), "appsignal-agent")
-    env = [{"APPSIGNAL_DIAGNOSE", "true"}]
+    env = [{"_APPSIGNAL_DIAGNOSE", "true"}]
     case System.cmd(agent_path, [], env: env) do
       {output, 0} -> IO.puts output
       {output, exit_code} ->

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -307,6 +307,14 @@ defmodule Appsignal.ConfigTest do
     end
   end
 
+  describe "reset_environment_config!" do
+    test "deletes existing configuration in environment" do
+      System.put_env("_APPSIGNAL_NAME", "foo")
+      Appsignal.Config.reset_environment_config!
+      assert System.get_env("_APPSIGNAL_NAME") == nil
+    end
+  end
+
   describe "write_to_environment" do
     setup do
       Application.put_env(:appsignal, :config, [])
@@ -319,15 +327,25 @@ defmodule Appsignal.ConfigTest do
 
     test "empty config options don't get written to the env" do
       write_to_environment()
-      assert System.get_env("APPSIGNAL_APP_NAME") == nil
-      assert System.get_env("APPSIGNAL_CA_FILE_PATH") == nil
-      assert System.get_env("APPSIGNAL_FILTER_PARAMETERS") == nil
-      assert System.get_env("APPSIGNAL_HTTP_PROXY") == nil
-      assert System.get_env("APPSIGNAL_IGNORE_ERRORS") == ""
-      assert System.get_env("APPSIGNAL_IGNORE_ACTIONS") == ""
-      assert System.get_env("APPSIGNAL_LOG_FILE_PATH") == nil
-      assert System.get_env("APPSIGNAL_WORKING_DIR_PATH") == nil
-      assert System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER") == nil
+      assert System.get_env("_APPSIGNAL_APP_NAME") == nil
+      assert System.get_env("_APPSIGNAL_CA_FILE_PATH") == nil
+      assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == nil
+      assert System.get_env("_APPSIGNAL_HTTP_PROXY") == nil
+      assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == ""
+      assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == ""
+      assert System.get_env("_APPSIGNAL_LOG_FILE_PATH") == nil
+      assert System.get_env("_APPSIGNAL_WORKING_DIR_PATH") == nil
+      assert System.get_env("_APPSIGNAL_RUNNING_IN_CONTAINER") == nil
+    end
+
+    test "deletes existing configuration in environment" do
+      # Name is present in the configuration
+      System.put_env("_APPSIGNAL_NAME", "foo")
+      # The new config doesn't have a name
+      add_to_application_env(:name, "")
+      write_to_environment()
+      # So it doesn't get written to the new agent environment configuration
+      assert System.get_env("_APPSIGNAL_NAME") == nil
     end
 
     test "writes valid AppSignal config options to the env" do
@@ -353,39 +371,39 @@ defmodule Appsignal.ConfigTest do
       add_to_application_env(:working_dir_path, "/tmp/appsignal")
       write_to_environment()
 
-      assert System.get_env("APPSIGNAL_ACTIVE") == "true"
-      assert System.get_env("APPSIGNAL_AGENT_PATH") == List.to_string(:code.priv_dir(:appsignal))
-      assert System.get_env("APPSIGNAL_AGENT_VERSION") == Appsignal.Agent.version
-      assert System.get_env("APPSIGNAL_APP_NAME") == "My awesome app"
-      assert System.get_env("APPSIGNAL_CA_FILE_PATH") == "/foo/bar/zab.ca"
-      assert System.get_env("APPSIGNAL_DEBUG_LOGGING") == "true"
-      assert System.get_env("APPSIGNAL_ENABLE_HOST_METRICS") == "false"
-      assert System.get_env("APPSIGNAL_ENVIRONMENT") == "prod"
-      assert System.get_env("APPSIGNAL_FILTER_PARAMETERS") == "password,secret"
-      assert System.get_env("APPSIGNAL_HOSTNAME") == "My hostname"
-      assert System.get_env("APPSIGNAL_HTTP_PROXY") == "http://10.10.10.10:8888"
-      assert System.get_env("APPSIGNAL_IGNORE_ACTIONS") == "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"
-      assert System.get_env("APPSIGNAL_IGNORE_ERRORS") == "VerySpecificError,AnotherError"
-      assert System.get_env("APPSIGNAL_LANGUAGE_INTEGRATION_VERSION") == "elixir-" <> Mix.Project.config[:version]
-      assert System.get_env("APPSIGNAL_LOG") == "stdout"
-      assert System.get_env("APPSIGNAL_LOG_FILE_PATH") == "log/appsignal.log"
-      assert System.get_env("APPSIGNAL_PUSH_API_ENDPOINT") == "https://push.staging.lol"
-      assert System.get_env("APPSIGNAL_PUSH_API_KEY") == "00000000-0000-0000-0000-000000000000"
-      assert System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER") == "false"
-      assert System.get_env("APPSIGNAL_SEND_PARAMS") == "true"
-      assert System.get_env("APPSIGNAL_WORKING_DIR_PATH") == "/tmp/appsignal"
+      assert System.get_env("_APPSIGNAL_ACTIVE") == "true"
+      assert System.get_env("_APPSIGNAL_AGENT_PATH") == List.to_string(:code.priv_dir(:appsignal))
+      assert System.get_env("_APPSIGNAL_AGENT_VERSION") == Appsignal.Agent.version
+      assert System.get_env("_APPSIGNAL_APP_NAME") == "My awesome app"
+      assert System.get_env("_APPSIGNAL_CA_FILE_PATH") == "/foo/bar/zab.ca"
+      assert System.get_env("_APPSIGNAL_DEBUG_LOGGING") == "true"
+      assert System.get_env("_APPSIGNAL_ENABLE_HOST_METRICS") == "false"
+      assert System.get_env("_APPSIGNAL_ENVIRONMENT") == "prod"
+      assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == "password,secret"
+      assert System.get_env("_APPSIGNAL_HOSTNAME") == "My hostname"
+      assert System.get_env("_APPSIGNAL_HTTP_PROXY") == "http://10.10.10.10:8888"
+      assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"
+      assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == "VerySpecificError,AnotherError"
+      assert System.get_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION") == "elixir-" <> Mix.Project.config[:version]
+      assert System.get_env("_APPSIGNAL_LOG") == "stdout"
+      assert System.get_env("_APPSIGNAL_LOG_FILE_PATH") == "log/appsignal.log"
+      assert System.get_env("_APPSIGNAL_PUSH_API_ENDPOINT") == "https://push.staging.lol"
+      assert System.get_env("_APPSIGNAL_PUSH_API_KEY") == "00000000-0000-0000-0000-000000000000"
+      assert System.get_env("_APPSIGNAL_RUNNING_IN_CONTAINER") == "false"
+      assert System.get_env("_APPSIGNAL_SEND_PARAMS") == "true"
+      assert System.get_env("_APPSIGNAL_WORKING_DIR_PATH") == "/tmp/appsignal"
     end
 
     test "name as atom" do
       add_to_application_env(:name, :my_application)
       write_to_environment()
-      assert System.get_env("APPSIGNAL_APP_NAME") == "my_application"
+      assert System.get_env("_APPSIGNAL_APP_NAME") == "my_application"
     end
 
     test "name as string" do
       add_to_application_env(:name, "My awesome application")
       write_to_environment()
-      assert System.get_env("APPSIGNAL_APP_NAME") == "My awesome application"
+      assert System.get_env("_APPSIGNAL_APP_NAME") == "My awesome application"
     end
   end
 
@@ -428,31 +446,14 @@ defmodule Appsignal.ConfigTest do
   defp clear_env() do
     Application.delete_env(:appsignal, :config)
 
-    ~w(
-      APPSIGNAL_ACTIVE
-      APPSIGNAL_APP_ENV
-      APPSIGNAL_APP_NAME
-      APPSIGNAL_CA_FILE_PATH
-      APPSIGNAL_DEBUG
-      APPSIGNAL_DEBUG_LOGGING
-      APPSIGNAL_ENABLE_HOST_METRICS
-      APPSIGNAL_ENVIRONMENT
-      APPSIGNAL_FILTER_PARAMETERS
-      APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH
-      APPSIGNAL_HOSTNAME
-      APPSIGNAL_HTTP_PROXY
-      APPSIGNAL_IGNORE_ACTIONS
-      APPSIGNAL_IGNORE_ERRORS
-      APPSIGNAL_LOG
-      APPSIGNAL_LOG_PATH
-      APPSIGNAL_LOG_FILE_PATH
-      APPSIGNAL_PUSH_API_ENDPOINT
-      APPSIGNAL_PUSH_API_KEY
-      APPSIGNAL_RUNNING_IN_CONTAINER
-      APPSIGNAL_SKIP_SESSION_DATA
-      APPSIGNAL_WORKING_DIR_PATH
-      DYNO
-    ) |> Enum.each(fn(key) ->
+    System.get_env
+    |> Enum.filter(
+      fn({"APPSIGNAL_" <> _, _}) -> true;
+      ({"_APPSIGNAL_" <> _, _}) -> true;
+      ({"APP_REVISION", _}) -> true;
+      ({"DYNO", _}) -> true;
+      (_) -> false end
+    ) |> Enum.each(fn({key, _}) ->
       System.delete_env(key)
     end)
   end


### PR DESCRIPTION
During a hot reload the AppSignal process is not reset/cleared/reloaded in any way to flush the previously set config env vars. When the AppSignal process starts it writes the current config to the environment so that the agent can read from this and be initialized with the same config.

During a hot reload the AppSignal process tries to initialize the config again, but because the system env still contains the config for the agent from the last time it initialized the config it reads the previous config. The env vars are loading in initializing the config, as
described here: http://docs.appsignal.com/elixir/configuration/load-order.html

The fix? Underscore all the config sent to the agent process so that it doesn't conflict with the application's config.

**Note:** Requires the agent to be updated first!

Fixes #134 