### PR TITLE
Don't add ex_doc to runtime

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -83,7 +83,7 @@ defmodule Appsignal.Mixfile do
       {:phoenix, "~> 1.2.0", optional: true, only: [:prod, :test_phoenix]},
       {:mock, "~> 0.2.1", only: [:test, :test_phoenix, :test_no_nif]},
       {:bypass, "~> 0.5", only: [:test, :test_phoenix, :test_no_nif]},
-      {:ex_doc, "~> 0.12", only: :dev}
+      {:ex_doc, "~> 0.12", only: :dev, runtime: false}
     ]
   end
 end


### PR DESCRIPTION
As recommended by ex_doc in the README:
https://github.com/elixir-lang/ex_doc

What does runtime do?

`:runtime` - whether the dependency is part of runtime applications.
Defaults to true which automatically adds the application to the list of
apps that are started automatically and included in releases

Source: https://hexdocs.pm/mix/Mix.Tasks.Deps.html