### PR TITLE
Remove revision logic

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -58,7 +58,6 @@ defmodule Appsignal.Config do
     "APPSIGNAL_ACTIVE" => :active,
     "APPSIGNAL_PUSH_API_KEY" => :push_api_key,
     "APPSIGNAL_APP_NAME" => :name,
-    "APP_REVISION" => :revision,
     "APPSIGNAL_APP_ENV" => :env,
     "APPSIGNAL_CA_FILE_PATH" => :ca_file_path,
     "APPSIGNAL_PUSH_API_ENDPOINT" => :endpoint,
@@ -77,7 +76,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data
   }
 
-  @string_keys ~w(APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH APP_REVISION APPSIGNAL_CA_FILE_PATH)
+  @string_keys ~w(APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_CA_FILE_PATH)
   @bool_keys ~w(APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING APPSIGNAL_ENABLE_ALLOCATION_TRACKING APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA)
   @atom_keys ~w(APPSIGNAL_APP_ENV)
   @string_list_keys ~w(APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS)
@@ -198,9 +197,6 @@ defmodule Appsignal.Config do
     unless empty?(config[:working_dir_path]) do
       System.put_env("APPSIGNAL_WORKING_DIR_PATH", config[:working_dir_path])
     end
-    unless empty?(config[:revision]) do
-      System.put_env("APP_REVISION", config[:revision])
-    end
   end
 
   defp app_name_to_string(name) when is_atom(name), do: Atom.to_string(name)
@@ -210,7 +206,6 @@ defmodule Appsignal.Config do
     System.get_env
     |> Enum.filter(
     fn({"APPSIGNAL_" <> _, _}) -> true;
-      ({"APP_REVISION", _}) -> true;
       (_) -> false end)
       |> Enum.into(%{})
   end

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -157,8 +157,7 @@ defmodule Mix.Tasks.Appsignal.Install do
     "use Mix.Config\n\n" <>
       "config :appsignal, :config,\n" <>
       ~s(  name: "#{config[:name]}",\n) <>
-      ~s(  push_api_key: "#{config[:push_api_key]}",\n) <>
-      ~s(  revision: Mix.Project.config[:version]\n)
+      ~s(  push_api_key: "#{config[:push_api_key]}",\n)
   end
 
   # Append a line to Mix configuration environment files which activate

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -138,11 +138,6 @@ defmodule Appsignal.ConfigTest do
       assert valid_configuration() |> Map.put(:active, false) == init_config()
     end
 
-    test "revision" do
-      add_to_application_env(:revision, "03bd9e")
-      assert default_configuration() |> Map.put(:revision, "03bd9e") == init_config()
-    end
-
     test "running_in_container" do
       add_to_application_env(:running_in_container, true)
       assert default_configuration() |> Map.put(:running_in_container, true) == init_config()
@@ -251,11 +246,6 @@ defmodule Appsignal.ConfigTest do
       assert init_config()[:active] == true
     end
 
-    test "revision" do
-      System.put_env("APP_REVISION", "03bd9e")
-      assert default_configuration() |> Map.put(:revision, "03bd9e") == init_config()
-    end
-
     test "running_in_container" do
       System.put_env("APPSIGNAL_RUNNING_IN_CONTAINER", "true")
       assert default_configuration() |> Map.put(:running_in_container, true) == init_config()
@@ -338,7 +328,6 @@ defmodule Appsignal.ConfigTest do
       assert System.get_env("APPSIGNAL_LOG_FILE_PATH") == nil
       assert System.get_env("APPSIGNAL_WORKING_DIR_PATH") == nil
       assert System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER") == nil
-      assert System.get_env("APP_REVISION") == nil
     end
 
     test "writes valid AppSignal config options to the env" do
@@ -362,7 +351,6 @@ defmodule Appsignal.ConfigTest do
       add_to_application_env(:name, "My awesome app")
       add_to_application_env(:running_in_container, false)
       add_to_application_env(:working_dir_path, "/tmp/appsignal")
-      add_to_application_env(:revision, "03bd9e")
       write_to_environment()
 
       assert System.get_env("APPSIGNAL_ACTIVE") == "true"
@@ -386,7 +374,6 @@ defmodule Appsignal.ConfigTest do
       assert System.get_env("APPSIGNAL_RUNNING_IN_CONTAINER") == "false"
       assert System.get_env("APPSIGNAL_SEND_PARAMS") == "true"
       assert System.get_env("APPSIGNAL_WORKING_DIR_PATH") == "/tmp/appsignal"
-      assert System.get_env("APP_REVISION") == "03bd9e"
     end
 
     test "name as atom" do
@@ -464,7 +451,6 @@ defmodule Appsignal.ConfigTest do
       APPSIGNAL_RUNNING_IN_CONTAINER
       APPSIGNAL_SKIP_SESSION_DATA
       APPSIGNAL_WORKING_DIR_PATH
-      APP_REVISION
       DYNO
     ) |> Enum.each(fn(key) ->
       System.delete_env(key)

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -170,8 +170,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? appsignal_config, ~s(use Mix.Config\n\n) <>
         ~s(config :appsignal, :config,\n) <>
         ~s(  name: "My app's name",\n) <>
-        ~s(  push_api_key: "my_push_api_key",\n) <>
-        ~s(  revision: Mix.Project.config[:version]\n)
+        ~s(  push_api_key: "my_push_api_key",\n)
 
       # Imports AppSignal config in config.exs file
       app_config = File.read!(Path.join(@test_config_directory, "config.exs"))


### PR DESCRIPTION
Turns out that it wasn't meant to be used for app version, only git
commit SHA-s. Remove all the logic from the package, the AppSignal Rust
agent listens to this env var and manages the logic for us.