### PR TITLE
Remove extra comma from generated config/appsignal.exs

### DIFF
--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -157,7 +157,7 @@ defmodule Mix.Tasks.Appsignal.Install do
     "use Mix.Config\n\n" <>
       "config :appsignal, :config,\n" <>
       ~s(  name: "#{config[:name]}",\n) <>
-      ~s(  push_api_key: "#{config[:push_api_key]}",\n)
+      ~s(  push_api_key: "#{config[:push_api_key]}"\n)
   end
 
   # Append a line to Mix configuration environment files which activate

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -170,7 +170,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? appsignal_config, ~s(use Mix.Config\n\n) <>
         ~s(config :appsignal, :config,\n) <>
         ~s(  name: "My app's name",\n) <>
-        ~s(  push_api_key: "my_push_api_key",\n)
+        ~s(  push_api_key: "my_push_api_key"\n)
 
       # Imports AppSignal config in config.exs file
       app_config = File.read!(Path.join(@test_config_directory, "config.exs"))


### PR DESCRIPTION
Since removing the revision from the generated configuration file in
`config/appsignal.exs`, the install tasks adds an extra comma to the end
of the config file, which produces a syntax error:

    ** (Mix.Config.LoadError) could not load config config/appsignal.exs
        ** (TokenMissingError) config/appsignal.exs:5: syntax error: expression is incomplete
        (elixir) lib/code.ex:170: Code.eval_string/3
        (mix) lib/mix/config.ex:180: Mix.Config.read!/2
        (mix) lib/mix/config.ex:217: anonymous fn/3 in Mix.Config.read_wildcard!/2
        (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
        (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
        (stdlib) erl_eval.erl:878: :erl_eval.expr_list/6

This patch removes the extra comma.