### PR TITLE
Update agent diagnostics logic in diagnose task

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     Config.write_to_environment
 
     agent_path = Path.join(List.to_string(:code.priv_dir(:appsignal)), "appsignal-agent")
-    env = [{"APPSIGNAL_ACTIVE", "true"}, {"APPSIGNAL_DIAGNOSE", "true"}]
+    env = [{"APPSIGNAL_DIAGNOSE", "true"}]
     case System.cmd(agent_path, [], env: env) do
       {output, 0} -> IO.puts output
       {output, exit_code} ->

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -137,6 +137,21 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert String.contains? output, "Agent diagnose finished"
   end
 
+  @tag :skip_env_test_no_nif
+  describe "when config is not active" do
+    test "runs agent in diagnose mode, but doesn't change the active state" do
+      merge_appsignal_config %{active: false}
+      output = run()
+      assert String.contains? output, "active: false"
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "Running agent in diagnose mode"
+      assert String.contains? output, "Valid config present"
+      assert String.contains? output, "Logger initialized successfully"
+      assert String.contains? output, "Lock path is writable"
+      assert String.contains? output, "Agent diagnose finished"
+    end
+  end
+
   test "outputs configuration" do
     output = run()
     assert String.contains? output, "Configuration"


### PR DESCRIPTION
APPSIGNAL_ACTIVE=true isn't needed, because we directly call the agent
executable. It is needed in the Ruby gem because we don't directly call the executable and route the start through `Appsignal.start`

Added a test to make sure the agent still runs when the config has
`active: false`.

Follow up of #132