### PR TITLE
Print APPSIGNAL_APP_ENV for env var config install

### DIFF
--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -93,6 +93,7 @@ defmodule Mix.Tasks.Appsignal.Install do
     IO.puts "Configuring with environment variables."
     IO.puts "Please put the following variables in your environment to configure AppSignal.\n"
     IO.puts ~s(  export APPSIGNAL_APP_NAME="#{config[:name]}")
+    IO.puts ~s(  export APPSIGNAL_APP_ENV="production")
     IO.puts ~s(  export APPSIGNAL_PUSH_API_KEY="#{config[:push_api_key]}")
   end
 

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -151,6 +151,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? output, "What is your preferred configuration method? (1/2): "
       assert String.contains? output, "Configuring with environment variables."
       assert String.contains? output, ~s(APPSIGNAL_APP_NAME="My app's name")
+      assert String.contains? output, ~s(APPSIGNAL_APP_ENV="production")
       assert String.contains? output, ~s(APPSIGNAL_PUSH_API_KEY="my_push_api_key")
     end
 


### PR DESCRIPTION
APPSIGNAL_APP_ENV is a required key for env config, because we can't
detect the env at runtime.