### PR TITLE
Call Transaction.try_set_action/1 in phoenix_controller_call/3

### DIFF
--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -65,7 +65,6 @@ if Appsignal.phoenix? do
     @doc false
     def submit_http_error(reason, message, stack, transaction, conn) do
       @transaction.set_error(transaction, reason, message, stack)
-      @transaction.try_set_action(transaction, conn)
       if @transaction.finish(transaction) == :sample do
         @transaction.set_request_metadata(transaction, conn)
       end

--- a/lib/appsignal/phoenix/instrumenter.ex
+++ b/lib/appsignal/phoenix/instrumenter.ex
@@ -25,7 +25,10 @@ if Appsignal.phoenix? do
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 
     @doc false
-    def phoenix_controller_call(:start, _, args), do: start_event(args)
+    def phoenix_controller_call(:start, _, args) do
+      @transaction.try_set_action(args[:conn])
+      start_event(args)
+    end
 
     @doc false
     def phoenix_controller_call(:stop, _diff, {%Appsignal.Transaction{} = transaction, args}) do

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -10,6 +10,7 @@ defmodule Appsignal.TransactionBehaviour do
   @callback complete(Transaction.t | nil) :: :ok
   @callback set_error(Transaction.t | nil, String.t, String.t, any) :: Transaction.t
   if Appsignal.phoenix? do
+    @callback try_set_action(Plug.Conn.t) :: :ok
     @callback try_set_action(Appsignal.Transaction.t, Plug.Conn.t) :: :ok
     @callback set_request_metadata(Transaction.t | nil, Plug.Conn.t) :: Transaction.t
   end
@@ -431,6 +432,7 @@ defmodule Appsignal.Transaction do
     @doc """
     Given the transaction and a %Plug.Conn{}, try to set the Phoenix controller module / action in the transaction.
     """
+    def try_set_action(conn), do: try_set_action(lookup(), conn)
     def try_set_action(transaction, conn) do
       try do
         action_str = "#{Phoenix.Controller.controller_module(conn)}##{Phoenix.Controller.action_name(conn)}"

--- a/test/phoenix/instrumenter_test.exs
+++ b/test/phoenix/instrumenter_test.exs
@@ -7,17 +7,23 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
 
     transaction = Transaction.start("test", :http_request)
 
-    conn = %Plug.Conn{}
-    |> Plug.Conn.put_private(:phoenix_controller, "foo")
-    |> Plug.Conn.put_private(:phoenix_action, "bar")
-
-    [transaction: transaction, conn: conn]
+    [transaction: transaction]
   end
 
   test "starts an event in phoenix_controller_call", context do
     arguments = %{foo: "bar"}
     assert {context[:transaction], arguments} ==
       Instrumenter.phoenix_controller_call(:start, nil, arguments)
+  end
+
+  test "sets the action name in phoenix_controller_call", context do
+    conn = %Plug.Conn{}
+    |> Plug.Conn.put_private(:phoenix_controller, "foo")
+    |> Plug.Conn.put_private(:phoenix_action, "bar")
+
+    arguments = %{foo: "bar", conn: conn}
+    Instrumenter.phoenix_controller_call(:start, nil, arguments)
+    assert "foo#bar" == FakeTransaction.action
   end
 
   test "starts an event in phoenix_controller_render", context do
@@ -27,7 +33,7 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
   end
 
   test "finishes an event in phoenix_controller_call", context do
-    Instrumenter.phoenix_controller_call(:stop, nil, {context[:transaction], %{conn: context[:conn]}})
+    Instrumenter.phoenix_controller_call(:stop, nil, {context[:transaction], %{conn: %Plug.Conn{}}})
     assert [
       %{
         transaction: context[:transaction],
@@ -45,7 +51,7 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
   end
 
   test "finishes an event in phoenix_controller_render", context do
-    Instrumenter.phoenix_controller_render(:stop, nil, {context[:transaction], %{conn: context[:conn]}})
+    Instrumenter.phoenix_controller_render(:stop, nil, {context[:transaction], %{conn: %Plug.Conn{}}})
     assert [
       %{
         transaction: context[:transaction],

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -62,7 +62,6 @@ defmodule Appsignal.PhoenixTest do
 
       assert %RuntimeError{message: "exception!"} == result
       assert FakeTransaction.started_transaction?
-      assert "foo#bar" == FakeTransaction.action
       assert [{
         %Appsignal.Transaction{},
         "RuntimeError",

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -34,7 +34,8 @@ defmodule Appsignal.FakeTransaction do
     Agent.get(__MODULE__, &Map.get(&1, :finished_events, []))
   end
 
-  def try_set_action(_transaction, conn) do
+  def try_set_action(_transaction, conn), do: try_set_action(conn)
+  def try_set_action(conn) do
     try do
       value = "#{conn.private.phoenix_controller}##{conn.private.phoenix_action}"
       Agent.update(__MODULE__, &Map.put(&1, :action, value))


### PR DESCRIPTION
Instead of calling `try_set_action/1` in `submit_http_error/5`, where
the `:phoenix_controller` and `:phoenix_action` keys are not present in
the conn, we'll set the action name in `phoenix_controller_call/3`.

`phoenix_controller_call(:start, _, %{conn: conn})` is immediately
called after setting the controller and action keys
(https://github.com/phoenixframework/phoenix/blob/2f475135b8ee5e4cbbd7b6e616ad6eb91e04c3fa/lib/phoenix/controller/pipeline.ex#L26-L28), and is triggered before exceptions
in the controller happen.

Closes #11.