### PR TITLE
Depend on Phoenix >= 1.2.0 instead of ~> 1.2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -80,7 +80,7 @@ defmodule Appsignal.Mixfile do
     [
       {:httpoison, "~> 0.11"},
       {:decorator, "~> 1.0"},
-      {:phoenix, "~> 1.2.0", optional: true, only: [:prod, :test_phoenix]},
+      {:phoenix, ">= 1.2.0", optional: true, only: [:prod, :test_phoenix]},
       {:mock, "~> 0.2.1", only: [:test, :test_phoenix, :test_no_nif]},
       {:bypass, "~> 0.5", only: [:test, :test_phoenix, :test_no_nif]},
       {:ex_doc, "~> 0.12", only: :dev, runtime: false}


### PR DESCRIPTION
We're currently depending on Phoenix ~> 1.2.0, which matches all 1.2.x
versions, but not 1.3.0.

Instead, we're now depending on >= 1.2.0, which includes all versions
above 1.2.0 (including 1.3.x and 2.x), but no prereleases. This way, we
can make sure Phoenix support works in the prerelease versions, and we
won't have to bump the Phoenix dependency when a new release comes out.

https://hexdocs.pm/elixir/Version.html