### PR TITLE
Fix unpacking agent tar as root

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -83,7 +83,7 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp extract(filename) do
-    case System.cmd("tar", ["zxf", filename], stderr_to_stdout: true, cd: priv_dir()) do
+    case System.cmd("tar", ["zxf", filename, "--no-same-owner"], stderr_to_stdout: true, cd: priv_dir()) do
       {_, 0} ->
         :ok
       {result, _exitcode} ->


### PR DESCRIPTION
When the installation is being run under the root user tar does not use
the `--no-same-owner` option by default. As described in the "tar" docs:

"--no-same-owner extract files as yourself (default for ordinary users)"

Root is not an ordinary user and thus this is not an option.

The problem then is that it tries to apply the same permissions as the
files that were packed, causing errors because those user ids don't
necessarily exist on a user's machine. And if they do it's unlikely that
they are from the user we want.

I was able to reproduce this with a Docker dingy setup as described in
issue #168: https://github.com/appsignal/appsignal-elixir/issues/168

Fixes #168 