### PR TITLE
Remove the %Plug.Conn{} clause of Instrumentation.Helpers.instrument/5

### DIFF
--- a/lib/appsignal/instrumentation/helpers.ex
+++ b/lib/appsignal/instrumentation/helpers.ex
@@ -52,12 +52,6 @@ defmodule Appsignal.Instrumentation.Helpers do
     end
   end
 
-  if Appsignal.phoenix? do
-    def instrument(%Plug.Conn{} = conn, name, title, body, body_format, function) do
-      instrument(conn.assigns.appsignal_transaction, name, title, body, body_format, function)
-    end
-  end
-
   def instrument(%Transaction{} = transaction, name, title, body, body_format, function) do
     Transaction.start_event(transaction)
     result = function.()

--- a/lib/appsignal/instrumentation/helpers.ex
+++ b/lib/appsignal/instrumentation/helpers.ex
@@ -8,6 +8,15 @@ defmodule Appsignal.Instrumentation.Helpers do
   @type instrument_arg :: Transaction.t | Plug.Conn.t | pid()
 
   @doc """
+  Execute the given function in start / finish event calls in the current
+  transaction. See `instrument/6`.
+  """
+  @spec instrument(String.t, String.t, function) :: any
+  def instrument(name, title, function) do
+    instrument(self(), name, title, "", function)
+  end
+
+  @doc """
   Execute the given function in start / finish event calls. See `instrument/6`.
   """
   @spec instrument(instrument_arg, String.t, String.t, function) :: any
@@ -34,7 +43,7 @@ defmodule Appsignal.Instrumentation.Helpers do
   import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
 
   def index(conn, _params) do
-    result = instrument conn, "net.http", "Some slow backend call", fn() ->
+    result = instrument "net.http", "Some slow backend call", fn() ->
       Backend.get_result()
     end
     json conn, result
@@ -58,5 +67,4 @@ defmodule Appsignal.Instrumentation.Helpers do
     Transaction.finish_event(transaction, name, title, body, body_format)
     result
   end
-
 end

--- a/test/appsignal/instrumentation/helpers_test.exs
+++ b/test/appsignal/instrumentation/helpers_test.exs
@@ -1,13 +1,11 @@
 defmodule AppsignalHelpersTest do
   use ExUnit.Case
-  # use Plug.Test
 
   import Mock
 
   alias Appsignal.{Transaction, Instrumentation.Helpers}
 
   test_with_mock "instrument with transaction", Appsignal.Transaction, [:passthrough], [] do
-
     t = Transaction.start("foo", :http_request)
     call_instrument(t)
     assert called Transaction.start_event(t)
@@ -29,5 +27,4 @@ defmodule AppsignalHelpersTest do
     end)
     assert :result == r
   end
-
 end


### PR DESCRIPTION
Fixes #174.

Remove the %Plug.Conn{} clause of Instrumentation.Helpers.instrument/5, add Instrumentation.Helpers.instrument/3 instead, which can be called without passing a Transaction. A usage example of this can be found in [the instrumentation branch in appsignal-phoenix-example](https://github.com/jeffkreeftmeijer/appsignal-phoenix-example/blob/instrumentation/web/controllers/page_controller.ex#L19-L27).