### PR TITLE
Phoenix.extract_error_metadata handles non-map reasons

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -205,7 +205,7 @@ defmodule Appsignal.ErrorHandler do
   end
   def extract_reason_and_message(any, message) do
     # inspect any term; truncate it
-    {"#{inspect any}", message}
+    {"#{inspect(any) |> normalize_reason}", message}
   end
 
   defp prefixed(nil, msg), do: msg

--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -49,7 +49,7 @@ if Appsignal.phoenix? do
     @phoenix_message "HTTP request error"
 
     @doc false
-    def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason = %{}, conn: conn}, _conn, stack) do
+    def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason, conn: conn}, _conn, stack) do
       {reason, message} = ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
       {reason, message, stack, conn}
     end


### PR DESCRIPTION
Closes #173, meaning timeouts won't crash the ErrorHandler anymore. We'll improve the reported errors while working on #183.