### PR TITLE
Add `Backtrace.from_stacktrace` to format `System.stacktrace`

### DIFF
--- a/lib/appsignal/backtrace.ex
+++ b/lib/appsignal/backtrace.ex
@@ -11,11 +11,24 @@ defmodule Appsignal.Backtrace do
       ...>  {:elixir_translator, :translate, 2,
       ...>  [file: 'src/elixir_translator.erl', line: 280]}]
       ...>  |> Appsignal.Backtrace.from_stacktrace
-      ["(stdlib) erl_internal.erl:212: :erl_internal.op_type(:get_stacktrace, 0)",
-       "(elixir) src/elixir_translator.erl:317: :elixir_translator.guard_op/2",
+      ["(elixir) src/elixir_translator.erl:317: :elixir_translator.guard_op/2",
        "(elixir) src/elixir_translator.erl:280: :elixir_translator.translate/2"]
   """
   def from_stacktrace(stacktrace) do
+    stacktrace
+    |> remove_error_entries
+    |> format_stacktrace
+  end
+
+  defp remove_error_entries([]), do: []
+  defp remove_error_entries([{_, _, arity, _}|tail]) when is_list(arity) do
+    remove_error_entries(tail)
+  end
+  defp remove_error_entries([entry|tail]) do
+    [entry|remove_error_entries(tail)]
+  end
+
+  defp format_stacktrace(stacktrace) do
     Enum.map(stacktrace, &Exception.format_stacktrace_entry(&1))
   end
 end

--- a/lib/appsignal/backtrace.ex
+++ b/lib/appsignal/backtrace.ex
@@ -1,0 +1,21 @@
+defmodule Appsignal.Backtrace do
+  @doc ~S"""
+  Parses the given stacktrace into a backtrace list.
+
+  ## Examples
+
+      iex> [{:erl_internal, :op_type, [:get_stacktrace, 0],
+      ...>  [file: 'erl_internal.erl', line: 212]},
+      ...>  {:elixir_translator, :guard_op, 2,
+      ...>  [file: 'src/elixir_translator.erl', line: 317]},
+      ...>  {:elixir_translator, :translate, 2,
+      ...>  [file: 'src/elixir_translator.erl', line: 280]}]
+      ...>  |> Appsignal.Backtrace.from_stacktrace
+      ["(stdlib) erl_internal.erl:212: :erl_internal.op_type(:get_stacktrace, 0)",
+       "(elixir) src/elixir_translator.erl:317: :elixir_translator.guard_op/2",
+       "(elixir) src/elixir_translator.erl:280: :elixir_translator.translate/2"]
+  """
+  def from_stacktrace(stacktrace) do
+    Enum.map(stacktrace, &Exception.format_stacktrace_entry(&1))
+  end
+end

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -38,7 +38,7 @@ defmodule Appsignal.Transaction do
 
   defstruct [:resource, :id]
 
-  alias Appsignal.{Nif, Transaction, TransactionRegistry}
+  alias Appsignal.{Nif, Transaction, TransactionRegistry, Backtrace}
 
   @typedoc """
   Datatype which is used as a handle to the current AppSignal transaction.
@@ -194,7 +194,7 @@ defmodule Appsignal.Transaction do
       transaction,
       name,
       message,
-      Appsignal.ErrorHandler.format_stack(backtrace)
+      Backtrace.from_stacktrace(backtrace)
     )
   end
   def set_error(%Transaction{} = transaction, name, message, backtrace) do

--- a/test/appsignal/backtrace_test.exs
+++ b/test/appsignal/backtrace_test.exs
@@ -4,8 +4,17 @@ defmodule Appsignal.BacktraceTest do
 
   test "formats stacktrace lines" do
     assert Appsignal.Backtrace.from_stacktrace([
+      {:elixir_translator, :guard_op, 2,
+        [file: 'src/elixir_translator.erl', line: 317]}
+    ]) == ["(elixir) src/elixir_translator.erl:317: :elixir_translator.guard_op/2"]
+  end
+
+  test "removes error lines" do
+    assert Appsignal.Backtrace.from_stacktrace([
       {:erl_internal, :op_type, [:get_stacktrace, 0],
-        [file: 'erl_internal.erl', line: 212]}
-    ]) == ["(stdlib) erl_internal.erl:212: :erl_internal.op_type(:get_stacktrace, 0)"]
+        [file: 'erl_internal.erl', line: 212]},
+      {:elixir_translator, :guard_op, 2,
+        [file: 'src/elixir_translator.erl', line: 317]},
+    ]) == ["(elixir) src/elixir_translator.erl:317: :elixir_translator.guard_op/2"]
   end
 end

--- a/test/appsignal/backtrace_test.exs
+++ b/test/appsignal/backtrace_test.exs
@@ -1,0 +1,11 @@
+defmodule Appsignal.BacktraceTest do
+  use ExUnit.Case, async: true
+  doctest Appsignal.Backtrace
+
+  test "formats stacktrace lines" do
+    assert Appsignal.Backtrace.from_stacktrace([
+      {:erl_internal, :op_type, [:get_stacktrace, 0],
+        [file: 'erl_internal.erl', line: 212]}
+    ]) == ["(stdlib) erl_internal.erl:212: :erl_internal.op_type(:get_stacktrace, 0)"]
+  end
+end

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -96,7 +96,8 @@ defmodule AppsignalTransactionTest do
 
   test "handles unformatted stacktraces" do
     transaction = Transaction.start("test1", :http_request)
-    assert ^transaction = Transaction.set_error(transaction, "Error", "error message", System.stacktrace)
+    stacktrace =  [{:elixir_translator, :guard_op, 2, [file: 'src/elixir_translator.erl', line: 317]}]
+    assert ^transaction = Transaction.set_error(transaction, "Error", "error message", stacktrace)
     assert ^transaction = Transaction.start_event(transaction)
     assert ^transaction = Transaction.finish_event(transaction, "render.phoenix_controller", "phoenix_controller_render", %{format: "html", template: "index.html"}, 0)
   end


### PR DESCRIPTION
Backtrace removes backtrace entries with an argument list, and formats the remaining lines. Closes #182.