### PR TITLE
Catch errors caught by Plug.ErrorHandler

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -201,6 +201,9 @@ defmodule Appsignal.ErrorHandler do
     msg = Exception.message(r)
     {"#{inspect r.__struct__}", prefixed(message, msg)}
   end
+  def extract_reason_and_message({kind, _} = reason, message) do
+    {inspect(kind), prefixed(message, inspect(reason))}
+  end
   def extract_reason_and_message(any, message) do
     # inspect any term; truncate it
     {"#{inspect any}", message}

--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -31,7 +31,10 @@ if Appsignal.phoenix? do
               Plug.ErrorHandler.__catch__(conn, kind, reason, fn(conn, _exception) ->
                 stacktrace = System.stacktrace
                 import Appsignal.Phoenix
-                case {Appsignal.TransactionRegistry.lookup(self()), extract_error_metadata(reason, conn, stacktrace)} do
+                case {
+                  Appsignal.TransactionRegistry.lookup(self()),
+                  Appsignal.Phoenix.Plug.extract_error_metadata(reason, conn, stacktrace)
+                } do
                   {nil, _} -> :skip
                   {_, nil} -> :skip
                   {transaction, {reason, message, stack, conn}} ->

--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -19,7 +19,6 @@ if Appsignal.phoenix? do
 
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
     alias Appsignal.TransactionRegistry
-    alias Appsignal.ErrorHandler
 
     @doc false
     defmacro __using__(_) do
@@ -46,20 +45,10 @@ if Appsignal.phoenix? do
       end
     end
 
-    @phoenix_message "HTTP request error"
-
     @doc false
-    def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason = %{}, conn: conn}, _conn, stack) do
-      {reason, message} = ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
-      {reason, message, stack, conn}
-    end
-    def extract_error_metadata(%{plug_status: s}, _conn, _stack) when s < 500 do
-      # Do not submit regular HTTP errors which have a status code
-      nil
-    end
     def extract_error_metadata(reason, conn, stack) do
-      {reason, message} = ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
-      {reason, message, stack, conn}
+      IO.warn "Appsignal.Phoenix.extract_error_metadata/3 is deprecated. Use Appsignal.Phoenix.Plug.extract_error_metadata/3 instead."
+      Appsignal.Phoenix.Plug.extract_error_metadata(reason, conn, stack)
     end
 
     @doc false

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -24,5 +24,24 @@ if Appsignal.phoenix? do
         end
       end
     end
+
+    @phoenix_message "HTTP request error"
+
+    @doc """
+    Returns a tuple with the exception's reason, message, stacktrace and the
+    conn when passing the exception, a conn, and a stacktrace.
+    """
+    def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason = %{}, conn: conn}, _conn, stack) do
+      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
+      {reason, message, stack, conn}
+    end
+    def extract_error_metadata(%{plug_status: s}, _conn, _stack) when s < 500 do
+      # Do not submit regular HTTP errors which have a status code
+      nil
+    end
+    def extract_error_metadata(reason, conn, stack) do
+      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
+      {reason, message, stack, conn}
+    end
   end
 end

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -39,9 +39,6 @@ if Appsignal.phoenix? do
       # Do not submit regular HTTP errors which have a status code
       nil
     end
-    def extract_error_metadata({type, _} = reason, conn, stack) do
-      {inspect(type), inspect(reason), stack, conn}
-    end
     def extract_error_metadata(reason, conn, stack) do
       {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
       {reason, message, stack, conn}

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -39,6 +39,9 @@ if Appsignal.phoenix? do
       # Do not submit regular HTTP errors which have a status code
       nil
     end
+    def extract_error_metadata({type, _} = reason, conn, stack) do
+      {inspect(type), inspect(reason), stack, conn}
+    end
     def extract_error_metadata(reason, conn, stack) do
       {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
       {reason, message, stack, conn}

--- a/test/appsignal/error_handler/error_extracter_test.exs
+++ b/test/appsignal/error_handler/error_extracter_test.exs
@@ -30,9 +30,12 @@ defmodule Appsignal.ErrorHandler.ErrorExtracterTest do
   end
 
   test "arbitrary term error" do
-    {r, m} = ErrorHandler.extract_reason_and_message({:error, :badarg}, "Badarg error")
-    assert "{:error, :badarg}" == r
-    assert "Badarg error" == m
+    error = {:timeout,
+      {Task, :await,
+        [%Task{owner: self(), pid: self(), ref: make_ref()},
+         1]}}
+    assert ErrorHandler.extract_reason_and_message(error, "Badarg error")
+      == {":timeout", "Badarg error: #{inspect error}"}
   end
 
   @undefined_error_extract %Protocol.UndefinedError{description: "", protocol: Enumerable, value: {:error, {%RuntimeError{}, []}}}

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -18,6 +18,16 @@ defmodule UsingAppsignalPhoenixWithException do
   use Appsignal.Phoenix
 end
 
+defmodule UsingAppsignalPhoenixWithTimeout do
+  def call(_conn, _opts) do
+    Task.async(fn -> :timer.sleep(10) end) |> Task.await(1)
+  end
+
+  defoverridable [call: 2]
+
+  use Appsignal.Phoenix
+end
+
 defmodule Appsignal.PhoenixTest do
   use ExUnit.Case
   import Mock
@@ -50,22 +60,46 @@ defmodule Appsignal.PhoenixTest do
   end
 
   describe "concerning catching errors" do
-    test "reports an error" do
-      result = try do
-        %Plug.Conn{}
-        |> Plug.Conn.put_private(:phoenix_controller, "foo")
-        |> Plug.Conn.put_private(:phoenix_action, "bar")
-        |> UsingAppsignalPhoenixWithException.call(%{})
-      rescue
-        e -> e
+    setup do
+      conn = %Plug.Conn{}
+      |> Plug.Conn.put_private(:phoenix_controller, "foo")
+      |> Plug.Conn.put_private(:phoenix_action, "bar")
+
+      [conn: conn]
+    end
+
+    test "reports an error for an exception", %{conn: conn} do
+      :ok = try do
+        UsingAppsignalPhoenixWithException.call(conn, %{})
+      catch
+        :error, %RuntimeError{message: "exception!"} -> :ok
+        type, reason -> {type, reason}
       end
 
-      assert %RuntimeError{message: "exception!"} == result
       assert FakeTransaction.started_transaction?
       assert [{
         %Appsignal.Transaction{} = transaction,
         "RuntimeError",
         "HTTP request error: exception!",
+        _stack
+      }] = FakeTransaction.errors
+      assert [transaction] == FakeTransaction.finished_transactions
+      assert [transaction] == FakeTransaction.completed_transactions
+    end
+
+    test "reports an error for a timeout", %{conn: conn} do
+      :ok = try do
+        UsingAppsignalPhoenixWithTimeout.call(conn, %{})
+      catch
+        :exit, {:timeout, {Task, :await, _}} -> :ok
+        type, reason -> {type, reason}
+      end
+
+      assert FakeTransaction.started_transaction?
+      assert [{
+        %Appsignal.Transaction{} = transaction,
+        ":timeout",
+        "{:timeout, {Task, :await, [%Task{owner: " <> _,
         _stack
       }] = FakeTransaction.errors
       assert [transaction] == FakeTransaction.finished_transactions

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -99,7 +99,7 @@ defmodule Appsignal.PhoenixTest do
       assert [{
         %Appsignal.Transaction{} = transaction,
         ":timeout",
-        "{:timeout, {Task, :await, [%Task{owner: " <> _,
+        "HTTP request error: {:timeout, {Task, :await, [%Task{owner: " <> _,
         _stack
       }] = FakeTransaction.errors
       assert [transaction] == FakeTransaction.finished_transactions

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -63,13 +63,13 @@ defmodule Appsignal.PhoenixTest do
       assert %RuntimeError{message: "exception!"} == result
       assert FakeTransaction.started_transaction?
       assert [{
-        %Appsignal.Transaction{},
+        %Appsignal.Transaction{} = transaction,
         "RuntimeError",
         "HTTP request error: exception!",
         _stack
       }] = FakeTransaction.errors
-      assert [%Appsignal.Transaction{}] = FakeTransaction.finished_transactions
-      assert [%Appsignal.Transaction{}] = FakeTransaction.completed_transactions
+      assert [transaction] == FakeTransaction.finished_transactions
+      assert [transaction] == FakeTransaction.completed_transactions
     end
   end
 

--- a/test/phoenix/plug_test.exs
+++ b/test/phoenix/plug_test.exs
@@ -95,7 +95,7 @@ defmodule Appsignal.Phoenix.PlugTest do
          1]}}
 
       assert Appsignal.Phoenix.Plug.extract_error_metadata(error, conn, stack)
-        == {":timeout", inspect(error), stack, conn}
+        == {":timeout", "HTTP request error: #{inspect(error)}", stack, conn}
     end
 
     test "ignores errors with a plug_status < 500", %{conn: conn, stack: stack} do


### PR DESCRIPTION
Instead of rescuing from exceptions and re-raising them using a rescue
block, this switches it over to a catch block, which uses
`Plug.ErrorHandler.__catch__/4` to re-raise the error. This allows us to
catch errors caused by crashing processes (like the timeout in the added
test).

This can be merged on its own, but not released without #190, as that could cause duplicate errors to be registered.