### PR TITLE
Don't handle :error events in ErrorHandler

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -33,15 +33,9 @@ defmodule Appsignal.ErrorHandler do
     state =
      case match_event(event) do
         {origin, reason, message, stack, conn} ->
-          case supervisor_event?(reason) do
-            false ->
-              transaction = Transaction.lookup_or_create_transaction(origin)
-              if transaction != nil do
-                submit_transaction(transaction, normalize_reason(reason), message, stack, %{}, conn)
-              end
-            true ->
-              # ignore this event; we have already handled it.
-              state
+          transaction = Transaction.lookup_or_create_transaction(origin)
+          if transaction != nil do
+            submit_transaction(transaction, normalize_reason(reason), message, stack, %{}, conn)
           end
         :nomatch ->
           state
@@ -70,28 +64,13 @@ defmodule Appsignal.ErrorHandler do
   # inspect the 'reason' argument to see if it is a supervisor
   # event. if so, we skip submitting it, because the original event
   # has already been processed.
-  defp supervisor_event?({:exit, {_reason, [entry|_]}}) do
-    case entry do
-      {_,_,_} -> true
-      {_,_,_,_} -> true
-      _ -> false
-    end
-  end
-  defp supervisor_event?(_) do
-    false
-  end
-
 
   def handle_call(:get_last_transaction, state) do
     {:ok, state, state}
   end
 
-
   @doc false
   @spec match_event(term) :: {pid, term, String.t, list, Map.t} | :nomatch
-  def match_event({:error, _gleader, {_pid, format, data}}) do
-    match_error_format(format, data)
-  end
   def match_event({:error_report, _gleader, {origin, :crash_report, report}}) do
     match_error_report(origin, report)
   end
@@ -102,46 +81,11 @@ defmodule Appsignal.ErrorHandler do
   defp match_error_report(origin, [[{:initial_call, _},
                                     {:pid, pid},
                                     {:registered_name, name},
-                                    {:error_info, {kind, exception, stack}} | _], _linked]) do
-    reason = {kind, exception}
-    case supervisor_event?(reason) do
-      false ->
-        msg = "Process #{crash_name(pid, name)} terminating"
-        {origin, "#{inspect reason}", msg, Backtrace.from_stacktrace(stack), nil}
-      true ->
-        :nomatch
-    end
-  end
+                                    {:error_info, {_kind, exception, stack}} | _], _linked]) do
 
-
-  # Match on the various format strings that OTP gives us to extract the
-  # error information like stack traces et cetera.
-  # TODO: Add crashes caused by gen_event handlers
-  defp match_error_format('Error in process ' ++ _, [pid, {reason, stack}]) do
-    msg = "Process #{inspect pid} raised an exception"
-    {reason, msg} = extract_reason_and_message(reason, msg)
-    {pid, reason, msg, Backtrace.from_stacktrace(stack), nil}
-  end
-
-  defp match_error_format('** Generic server ' ++ _, [pid, _last, _state, reason]) do
-    {reason, stack} = maybe_extract_stack(reason)
-    {reason, msg} = extract_reason_and_message(reason, "GenServer #{inspect pid} terminating")
-    {pid, reason, msg, Backtrace.from_stacktrace(stack), nil}
-  end
-
-  defp match_error_format('** Task ' ++ _, [pid, starter, function, args, reason]) do
-    {reason, stack} = maybe_extract_stack(reason)
-    msg = "Task #{inspect pid} started from #{inspect starter} terminating. Function: #{inspect function}, args: #{inspect args}"
-    {reason, msg} = extract_reason_and_message(reason, msg)
-    {pid, reason, msg, Backtrace.from_stacktrace(stack), nil}
-  end
-
-  # FIXME add test coverage for this one
-  defp match_error_format('Ranch listener ' ++ _, [_, _, pid, {{reason, stack}, initial}]) do
-    conn = extract_conn(initial)
-    msg = "HTTP request #{inspect pid} crashed"
-    {reason, msg} = extract_reason_and_message(reason, msg)
-    {pid, reason, msg, Backtrace.from_stacktrace(stack), conn}
+    msg = "Process #{crash_name(pid, name)} terminating"
+    {reason, message} = extract_reason_and_message(exception, msg)
+    {origin, reason, message, Backtrace.from_stacktrace(stack), nil}
   end
 
   @doc false
@@ -150,28 +94,8 @@ defmodule Appsignal.ErrorHandler do
     Backtrace.from_stacktrace(stacktrace)
   end
 
-  # Extract stack trace from GenServer crash report reason
-  defp maybe_extract_stack({maybe_exception, [_ | _ ] = maybe_stacktrace} = reason) do
-    try do
-      {maybe_exception, maybe_stacktrace}
-    catch
-      :error, _ ->
-        {reason, []}
-    end
-  end
-
-  defp maybe_extract_stack(reason) do
-    {reason, []}
-  end
-
   defp crash_name(pid, []), do: inspect(pid)
   defp crash_name(pid, name), do: "#{inspect(name)} (#{inspect(pid)})"
-
-  if Appsignal.phoenix? do
-    defp extract_conn({_, :call, [%Plug.Conn{} = conn, _params]}), do: conn
-  end
-  defp extract_conn(_), do: nil
-
 
   @doc """
   Extract a consise reason from the given error reason, stripping it from long stack traces and the like.

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -201,6 +201,9 @@ defmodule Appsignal.ErrorHandler do
     msg = Exception.message(r)
     {"#{inspect r.__struct__}", prefixed(message, msg)}
   end
+  def extract_reason_and_message({kind, _} = reason, message) do
+    {inspect(kind), prefixed(message, inspect(reason))}
+  end
   def extract_reason_and_message(any, message) do
     # inspect any term; truncate it
     {"#{inspect any}", message}

--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -31,7 +31,10 @@ if Appsignal.phoenix? do
               Plug.ErrorHandler.__catch__(conn, kind, reason, fn(conn, _exception) ->
                 stacktrace = System.stacktrace
                 import Appsignal.Phoenix
-                case {Appsignal.TransactionRegistry.lookup(self()), extract_error_metadata(reason, conn, stacktrace)} do
+                case {
+                  Appsignal.TransactionRegistry.lookup(self()),
+                  Appsignal.Phoenix.Plug.extract_error_metadata(reason, conn, stacktrace)
+                } do
                   {nil, _} -> :skip
                   {_, nil} -> :skip
                   {transaction, {reason, message, stack, conn}} ->

--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -19,7 +19,6 @@ if Appsignal.phoenix? do
 
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
     alias Appsignal.TransactionRegistry
-    alias Appsignal.ErrorHandler
 
     @doc false
     defmacro __using__(_) do
@@ -46,20 +45,10 @@ if Appsignal.phoenix? do
       end
     end
 
-    @phoenix_message "HTTP request error"
-
     @doc false
-    def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason = %{}, conn: conn}, _conn, stack) do
-      {reason, message} = ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
-      {reason, message, stack, conn}
-    end
-    def extract_error_metadata(%{plug_status: s}, _conn, _stack) when s < 500 do
-      # Do not submit regular HTTP errors which have a status code
-      nil
-    end
     def extract_error_metadata(reason, conn, stack) do
-      {reason, message} = ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
-      {reason, message, stack, conn}
+      IO.warn "Appsignal.Phoenix.extract_error_metadata/3 is deprecated. Use Appsignal.Phoenix.Plug.extract_error_metadata/3 instead."
+      Appsignal.Phoenix.Plug.extract_error_metadata(reason, conn, stack)
     end
 
     @doc false

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -24,5 +24,24 @@ if Appsignal.phoenix? do
         end
       end
     end
+
+    @phoenix_message "HTTP request error"
+
+    @doc """
+    Returns a tuple with the exception's reason, message, stacktrace and the
+    conn when passing the exception, a conn, and a stacktrace.
+    """
+    def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason = %{}, conn: conn}, _conn, stack) do
+      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
+      {reason, message, stack, conn}
+    end
+    def extract_error_metadata(%{plug_status: s}, _conn, _stack) when s < 500 do
+      # Do not submit regular HTTP errors which have a status code
+      nil
+    end
+    def extract_error_metadata(reason, conn, stack) do
+      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
+      {reason, message, stack, conn}
+    end
   end
 end

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -39,9 +39,6 @@ if Appsignal.phoenix? do
       # Do not submit regular HTTP errors which have a status code
       nil
     end
-    def extract_error_metadata({type, _} = reason, conn, stack) do
-      {inspect(type), inspect(reason), stack, conn}
-    end
     def extract_error_metadata(reason, conn, stack) do
       {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
       {reason, message, stack, conn}

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -39,6 +39,9 @@ if Appsignal.phoenix? do
       # Do not submit regular HTTP errors which have a status code
       nil
     end
+    def extract_error_metadata({type, _} = reason, conn, stack) do
+      {inspect(type), inspect(reason), stack, conn}
+    end
     def extract_error_metadata(reason, conn, stack) do
       {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
       {reason, message, stack, conn}

--- a/test/appsignal/error_handler/error_extracter_test.exs
+++ b/test/appsignal/error_handler/error_extracter_test.exs
@@ -30,9 +30,12 @@ defmodule Appsignal.ErrorHandler.ErrorExtracterTest do
   end
 
   test "arbitrary term error" do
-    {r, m} = ErrorHandler.extract_reason_and_message({:error, :badarg}, "Badarg error")
-    assert "{:error, :badarg}" == r
-    assert "Badarg error" == m
+    error = {:timeout,
+      {Task, :await,
+        [%Task{owner: self(), pid: self(), ref: make_ref()},
+         1]}}
+    assert ErrorHandler.extract_reason_and_message(error, "Badarg error")
+      == {":timeout", "Badarg error: #{inspect error}"}
   end
 
   @undefined_error_extract %Protocol.UndefinedError{description: "", protocol: Enumerable, value: {:error, {%RuntimeError{}, []}}}

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -38,12 +38,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       {:ok, nil}
     end
 
-    def handle_event(event, nil) do
+    def handle_event(event, _state) do
       {:ok, Appsignal.ErrorHandler.match_event(event)}
-    end
-    def handle_event(_event, state) do
-      # ignore other events when we already have caught one error event
-      {:ok, state}
     end
 
     def handle_call(:get_matched_crash, state) do
@@ -76,7 +72,6 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     {reason, message}
   end
 
-
   setup do
     :error_logger.add_report_handler(@error_handler)
     on_exit(fn() ->
@@ -85,52 +80,13 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     :timer.sleep 100
   end
 
-
-  test "bare spawn + throw" do
-    spawn(fn() ->
-      throw(:crash_bare_throw)
-    end)
-    |> assert_crash_caught
-    |> reason("{:nocatch, :crash_bare_throw}")
-    |> message_regex(~r/Process #PID<[\d.]+> raised an exception/)
-  end
-
-  test "bare spawn + :erlang.error" do
-    spawn(fn() ->
-      :erlang.error(:crash_bare_error)
-    end)
-    |> assert_crash_caught
-    |> reason(":crash_bare_error")
-    |> message_regex(~r/Process #PID<[\d.]+> raised an exception/)
-  end
-
-  test "bare spawn + function error" do
-    spawn(fn() ->
-      String.length(:notastring)
-    end)
-    |> assert_crash_caught
-    |> reason(":function_clause")
-    |> message_regex(~r(Process #PID<[\d.]+> raised an exception))
-  end
-
-  test "bare spawn + badmatch error" do
-    spawn(fn() ->
-      1 = 2
-    end)
-    |> assert_crash_caught
-    |> reason("{:badmatch, 2}")
-    |> message_regex(~r(Process #PID<[\d.]+> raised an exception))
-  end
-
-
-
   test "proc_lib.spawn + exit" do
     :proc_lib.spawn(fn() ->
       exit(:crash_proc_lib_spawn)
     end)
     |> assert_crash_caught
     |> reason("{:exit, :crash_proc_lib_spawn}")
-    |> message_regex(~r(Process #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating$))
   end
 
   test "proc_lib.spawn + erlang.error" do
@@ -139,7 +95,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
     |> assert_crash_caught
     |> reason("{:error, :crash_proc_lib_error}")
-    |> message_regex(~r(Process #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating$))
   end
 
   test "proc_lib.spawn + function error" do
@@ -148,7 +104,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
     |> assert_crash_caught
     |> reason("{:error, :function_clause}")
-    |> message_regex(~r(Process #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating$))
   end
 
   test "proc_lib.spawn + badmatch error" do
@@ -157,30 +113,29 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
     |> assert_crash_caught
     |> reason("{:error, {:badmatch, 2}}")
-    |> message_regex(~r(Process #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating: {:badmatch, 2}))
   end
-
 
   test "Crashing GenServer with throw" do
     CrashingGenServer.start(:throw)
     |> assert_crash_caught
     # http://erlang.org/pipermail/erlang-bugs/2012-April/002862.html
-    |> reason("{:bad_return_value, :crashed_gen_server_throw}")
-    |> message_regex(~r(GenServer #PID<[\d.]+> terminating))
+    |> reason("{:exit, {:bad_return_value, :crashed_gen_server_throw}}")
+    |> message(~r(Process #PID<[\d.]+> terminating: {:bad_return_valu...))
   end
 
   test "Crashing GenServer with exit" do
     CrashingGenServer.start(:exit)
     |> assert_crash_caught
-    |> reason(":crashed_gen_server_exit")
-    |> message_regex(~r(GenServer #PID<[\d.]+> terminating))
+    |> reason("{:exit, :crashed_gen_server_exit}")
+    |> message(~r(Process #PID<[\d.]+> terminating$))
   end
 
   test "Crashing GenServer with function error" do
     CrashingGenServer.start(:function_error)
     |> assert_crash_caught
     |> reason(":function_clause")
-    |> message_regex(~r(GenServer #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating: {:function_clause...))
   end
 
   test "Task" do
@@ -189,8 +144,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
     |> assert_crash_caught
     |> reason(":function_clause")
-    |> message_regex(
-      ~r(Task #PID<[\d.]+> started from #PID<[\d.]+> terminating. Function: #Function<[\d.]+/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test Task/1>, args: \[\])
+    |> message(
+      ~r(Process #PID<[\d.]+> terminating: {:function_clause, \[{String.Uni...)
     )
   end
 
@@ -202,7 +157,10 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       |> Task.await(1)
     end)
     |> assert_crash_caught
-    |> reason_regex(~r/^{:exit, {:timeout/)
+    |> reason(":timeout")
+    |> message(
+      ~r(Process #PID<[\d.]+> terminating: {:timeout, {Task, :await, \[%Tas...)
+    )
   end
 
   defp reason({reason, _message} = data, expected) do
@@ -210,12 +168,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     data
   end
 
-  defp reason_regex({reason, _message} = data, expected) do
-    assert reason =~ expected
-    data
-  end
-
-  defp message_regex({_reason, message} = data, expected) do
+  defp message({_reason, message} = data, expected) do
     assert message =~ expected
     data
   end

--- a/test/appsignal/error_handler_test.exs
+++ b/test/appsignal/error_handler_test.exs
@@ -17,19 +17,17 @@ defmodule Appsignal.ErrorHandlerTest do
 
 
   test "whether we can send error reports without current transaction" do
-    Task.start(fn() ->
+    :proc_lib.spawn(fn() ->
       :erlang.error(:error_task)
     end)
 
     :timer.sleep 100
   end
 
-
   test "whether we can send error reports with a current transaction" do
-
     id = Transaction.generate_id()
 
-    Task.start(fn() ->
+    :proc_lib.spawn(fn() ->
       Transaction.start(id, :http_request)
       |> Transaction.set_action("AppsignalErrorHandlerTest#test")
 

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -18,6 +18,16 @@ defmodule UsingAppsignalPhoenixWithException do
   use Appsignal.Phoenix
 end
 
+defmodule UsingAppsignalPhoenixWithTimeout do
+  def call(_conn, _opts) do
+    Task.async(fn -> :timer.sleep(10) end) |> Task.await(1)
+  end
+
+  defoverridable [call: 2]
+
+  use Appsignal.Phoenix
+end
+
 defmodule Appsignal.PhoenixTest do
   use ExUnit.Case
   import Mock
@@ -50,22 +60,46 @@ defmodule Appsignal.PhoenixTest do
   end
 
   describe "concerning catching errors" do
-    test "reports an error" do
-      result = try do
-        %Plug.Conn{}
-        |> Plug.Conn.put_private(:phoenix_controller, "foo")
-        |> Plug.Conn.put_private(:phoenix_action, "bar")
-        |> UsingAppsignalPhoenixWithException.call(%{})
-      rescue
-        e -> e
+    setup do
+      conn = %Plug.Conn{}
+      |> Plug.Conn.put_private(:phoenix_controller, "foo")
+      |> Plug.Conn.put_private(:phoenix_action, "bar")
+
+      [conn: conn]
+    end
+
+    test "reports an error for an exception", %{conn: conn} do
+      :ok = try do
+        UsingAppsignalPhoenixWithException.call(conn, %{})
+      catch
+        :error, %RuntimeError{message: "exception!"} -> :ok
+        type, reason -> {type, reason}
       end
 
-      assert %RuntimeError{message: "exception!"} == result
       assert FakeTransaction.started_transaction?
       assert [{
         %Appsignal.Transaction{} = transaction,
         "RuntimeError",
         "HTTP request error: exception!",
+        _stack
+      }] = FakeTransaction.errors
+      assert [transaction] == FakeTransaction.finished_transactions
+      assert [transaction] == FakeTransaction.completed_transactions
+    end
+
+    test "reports an error for a timeout", %{conn: conn} do
+      :ok = try do
+        UsingAppsignalPhoenixWithTimeout.call(conn, %{})
+      catch
+        :exit, {:timeout, {Task, :await, _}} -> :ok
+        type, reason -> {type, reason}
+      end
+
+      assert FakeTransaction.started_transaction?
+      assert [{
+        %Appsignal.Transaction{} = transaction,
+        ":timeout",
+        "{:timeout, {Task, :await, [%Task{owner: " <> _,
         _stack
       }] = FakeTransaction.errors
       assert [transaction] == FakeTransaction.finished_transactions

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -105,25 +105,6 @@ defmodule Appsignal.PhoenixTest do
       assert [transaction] == FakeTransaction.finished_transactions
       assert [transaction] == FakeTransaction.completed_transactions
     end
-
-    test "reports an error for a timeout", %{conn: conn} do
-      result = try do
-        UsingAppsignalPhoenixWithTimeout.call(conn, %{})
-      catch
-        _kind, exception -> exception
-      end
-
-      assert result = {:timeout, {Task, :await, []}}
-      assert FakeTransaction.started_transaction?
-      assert [{
-        %Appsignal.Transaction{} = transaction,
-        ":timeout",
-        "{:timeout, {Task, :await, [%Task{owner: " <> _,
-        _stack
-      }] = FakeTransaction.errors
-      assert [transaction] = FakeTransaction.finished_transactions
-      assert [transaction] = FakeTransaction.completed_transactions
-    end
   end
 
   test_with_mock "send_error with metadata and conn", Appsignal.Transaction, [:passthrough], [] do

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -99,7 +99,7 @@ defmodule Appsignal.PhoenixTest do
       assert [{
         %Appsignal.Transaction{} = transaction,
         ":timeout",
-        "{:timeout, {Task, :await, [%Task{owner: " <> _,
+        "HTTP request error: {:timeout, {Task, :await, [%Task{owner: " <> _,
         _stack
       }] = FakeTransaction.errors
       assert [transaction] == FakeTransaction.finished_transactions

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -63,13 +63,13 @@ defmodule Appsignal.PhoenixTest do
       assert %RuntimeError{message: "exception!"} == result
       assert FakeTransaction.started_transaction?
       assert [{
-        %Appsignal.Transaction{},
+        %Appsignal.Transaction{} = transaction,
         "RuntimeError",
         "HTTP request error: exception!",
         _stack
       }] = FakeTransaction.errors
-      assert [%Appsignal.Transaction{}] = FakeTransaction.finished_transactions
-      assert [%Appsignal.Transaction{}] = FakeTransaction.completed_transactions
+      assert [transaction] == FakeTransaction.finished_transactions
+      assert [transaction] == FakeTransaction.completed_transactions
     end
   end
 

--- a/test/phoenix/plug_test.exs
+++ b/test/phoenix/plug_test.exs
@@ -95,7 +95,7 @@ defmodule Appsignal.Phoenix.PlugTest do
          1]}}
 
       assert Appsignal.Phoenix.Plug.extract_error_metadata(error, conn, stack)
-        == {":timeout", inspect(error), stack, conn}
+        == {":timeout", "HTTP request error: #{inspect(error)}", stack, conn}
     end
 
     test "ignores errors with a plug_status < 500", %{conn: conn, stack: stack} do


### PR DESCRIPTION
Closes #157 & #173.

Before, the ErrorHandler had to match on :error events (besides
:error_report events) to be able to catch errors that were already
caught by Plug.ErrorHandler.

After merging #187, we can drop support for :error events. This drops
support for unsupervised "bare" spawns, and only triggers an error when
a process actually crashes. Also, this removes a lot of code that dealt
with not sending error reports twice (after the :error event _and_ the
:error_report event).
