### PR TITLE
handle another Ranch listener error

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -136,6 +136,12 @@ defmodule Appsignal.ErrorHandler do
     {pid, reason, msg, Backtrace.from_stacktrace(stack), nil}
   end
 
+  defp match_error_format('Ranch listener ' ++ _, [_, _, pid, {reason, stack}]) do
+    msg = "HTTP request #{inspect pid} crashed"
+    {reason, msg} = extract_reason_and_message(reason, msg)
+    {pid, reason, msg, Backtrace.from_stacktrace(stack), nil}
+  end
+
   # FIXME add test coverage for this one
   defp match_error_format('Ranch listener ' ++ _, [_, _, pid, {{reason, stack}, initial}]) do
     conn = extract_conn(initial)

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -191,6 +191,20 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason_regex(~r/^{:exit, {:timeout/)
   end
 
+
+  test "Ranch no function clause matching in :cow_http_hd.token_ci_list_sep/3" do
+    pid = self()
+    msg = 'Ranch listener ~p had connection process started with ~p:start_link/4 at ~p exit with reason: ~999999p~n'
+    stacktrace = [
+      {:cow_http_hd, :token_ci_list_sep, ["Te", [], "keep-alive"], [file: '/app/deps/cowlib/src/cow_http_hd.erl', line: 191]},
+      {:cow_http_hd, :parse_connection, 1, [file: '/app/deps/cowlib/src/cow_http_hd.erl', line: 31]}
+    ]
+    :error_logger.error_msg msg, [__MODULE__, :cowboy_protocol, pid, {:function_clause, stacktrace}]
+    pid
+    |> assert_crash_caught
+    |> reason(":function_clause")
+  end
+
   defp reason(reason, expected) do
     assert expected == reason
   end


### PR DESCRIPTION
I noticed that cowboy was raising exception and triggered error in Appsignal.
Here's an exception log:
```
09:19:14.473 [error] Process #PID<0.28500.0> raised an exception
** (FunctionClauseError) no function clause matching in :cow_http_hd.token_ci_list_sep/3
    (cowlib) /app/deps/cowlib/src/cow_http_hd.erl:191: :cow_http_hd.token_ci_list_sep("Te", [], "keep-alive")
    (cowlib) /app/deps/cowlib/src/cow_http_hd.erl:31: :cow_http_hd.parse_connection/1
    (cowboy) /app/deps/cowboy/src/cowboy_req.erl:189: :cowboy_req.new/14
    (cowboy) /app/deps/cowboy/src/cowboy_protocol.erl:410: :cowboy_protocol.request/9
09:19:14.473 [error] Ranch protocol #PID<0.28500.0> (:cowboy_protocol) of listener MyApp.Endpoint.HTTP terminated
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in :cow_http_hd.token_ci_list_sep/3
        (cowlib) /app/deps/cowlib/src/cow_http_hd.erl:191: :cow_http_hd.token_ci_list_sep("Te", [], "keep-alive")
        (cowlib) /app/deps/cowlib/src/cow_http_hd.erl:31: :cow_http_hd.parse_connection/1
        (cowboy) /app/deps/cowboy/src/cowboy_req.erl:189: :cowboy_req.new/14
        (cowboy) /app/deps/cowboy/src/cowboy_protocol.erl:410: :cowboy_protocol.request/9
09:19:14.478 [error] GenEvent handler Appsignal.ErrorHandler installed in :error_logger terminating
** (FunctionClauseError) no function clause matching in Appsignal.ErrorHandler.match_error_format/2
    (appsignal) lib/appsignal/error_handler.ex:120: Appsignal.ErrorHandler.match_error_format('Ranch listener ~p had connection process started with ~p:start_link/4 at ~p exit with reason: ~999999p~n', [MyApp.Endpoint.HTTP, :cowboy_protocol, #PID<0.28500.0>, {:function_clause, [{:cow_http_hd, :token_ci_list_sep, ["Te", [], "keep-alive"], [file: '/app/deps/cowlib/src/cow_http_hd.erl', line: 191]}, {:cow_http_hd, :parse_connection, 1, [file: '/app/deps/cowlib/src/cow_http_hd.erl', line: 31]}, {:cowboy_req, :new, 14, [file: '/app/deps/cowboy/src/cowboy_req.erl', line: 189]}, {:cowboy_protocol, :request, 9, [file: '/app/deps/cowboy/src/cowboy_protocol.erl', line: 410]}]}])
    (appsignal) lib/appsignal/error_handler.ex:34: Appsignal.ErrorHandler.handle_event/2
    (stdlib) gen_event.erl:533: :gen_event.server_update/4
    (stdlib) gen_event.erl:515: :gen_event.server_notify/4
    (stdlib) gen_event.erl:256: :gen_event.handle_msg/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: {:error, #PID<0.366.0>, {#PID<0.404.0>, 'Ranch listener ~p had connection process started with ~p:start_link/4 at ~p exit with reason: ~999999p~n', [MyApp.Endpoint.HTTP, :cowboy_protocol, #PID<0.28500.0>, {:function_clause, [{:cow_http_hd, :token_ci_list_sep, ["Te", [], "keep-alive"], [file: '/app/deps/cowlib/src/cow_http_hd.erl', line: 191]}, {:cow_http_hd, :parse_connection, 1, [file: '/app/deps/cowlib/src/cow_http_hd.erl', line: 31]}, {:cowboy_req, :new, 14, [file: '/app/deps/cowboy/src/cowboy_req.erl', line: 189]}, {:cowboy_protocol, :request, 9, [file: '/app/deps/cowboy/src/cowboy_protocol.erl', line: 410]}]}]}}
```