### PR TITLE
Don't handle :error events in ErrorHandler

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -61,10 +61,6 @@ defmodule Appsignal.ErrorHandler do
     end
   end
 
-  # inspect the 'reason' argument to see if it is a supervisor
-  # event. if so, we skip submitting it, because the original event
-  # has already been processed.
-
   def handle_call(:get_last_transaction, state) do
     {:ok, state, state}
   end

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -33,15 +33,9 @@ defmodule Appsignal.ErrorHandler do
     state =
      case match_event(event) do
         {origin, reason, message, stack, conn} ->
-          case supervisor_event?(reason) do
-            false ->
-              transaction = Transaction.lookup_or_create_transaction(origin)
-              if transaction != nil do
-                submit_transaction(transaction, normalize_reason(reason), message, stack, %{}, conn)
-              end
-            true ->
-              # ignore this event; we have already handled it.
-              state
+          transaction = Transaction.lookup_or_create_transaction(origin)
+          if transaction != nil do
+            submit_transaction(transaction, normalize_reason(reason), message, stack, %{}, conn)
           end
         :nomatch ->
           state
@@ -70,28 +64,13 @@ defmodule Appsignal.ErrorHandler do
   # inspect the 'reason' argument to see if it is a supervisor
   # event. if so, we skip submitting it, because the original event
   # has already been processed.
-  defp supervisor_event?({:exit, {_reason, [entry|_]}}) do
-    case entry do
-      {_,_,_} -> true
-      {_,_,_,_} -> true
-      _ -> false
-    end
-  end
-  defp supervisor_event?(_) do
-    false
-  end
-
 
   def handle_call(:get_last_transaction, state) do
     {:ok, state, state}
   end
 
-
   @doc false
   @spec match_event(term) :: {pid, term, String.t, list, Map.t} | :nomatch
-  def match_event({:error, _gleader, {_pid, format, data}}) do
-    match_error_format(format, data)
-  end
   def match_event({:error_report, _gleader, {origin, :crash_report, report}}) do
     match_error_report(origin, report)
   end
@@ -102,46 +81,11 @@ defmodule Appsignal.ErrorHandler do
   defp match_error_report(origin, [[{:initial_call, _},
                                     {:pid, pid},
                                     {:registered_name, name},
-                                    {:error_info, {kind, exception, stack}} | _], _linked]) do
-    reason = {kind, exception}
-    case supervisor_event?(reason) do
-      false ->
-        msg = "Process #{crash_name(pid, name)} terminating"
-        {origin, "#{inspect reason}", msg, Backtrace.from_stacktrace(stack), nil}
-      true ->
-        :nomatch
-    end
-  end
+                                    {:error_info, {_kind, exception, stack}} | _], _linked]) do
 
-
-  # Match on the various format strings that OTP gives us to extract the
-  # error information like stack traces et cetera.
-  # TODO: Add crashes caused by gen_event handlers
-  defp match_error_format('Error in process ' ++ _, [pid, {reason, stack}]) do
-    msg = "Process #{inspect pid} raised an exception"
-    {reason, msg} = extract_reason_and_message(reason, msg)
-    {pid, reason, msg, Backtrace.from_stacktrace(stack), nil}
-  end
-
-  defp match_error_format('** Generic server ' ++ _, [pid, _last, _state, reason]) do
-    {reason, stack} = maybe_extract_stack(reason)
-    {reason, msg} = extract_reason_and_message(reason, "GenServer #{inspect pid} terminating")
-    {pid, reason, msg, Backtrace.from_stacktrace(stack), nil}
-  end
-
-  defp match_error_format('** Task ' ++ _, [pid, starter, function, args, reason]) do
-    {reason, stack} = maybe_extract_stack(reason)
-    msg = "Task #{inspect pid} started from #{inspect starter} terminating. Function: #{inspect function}, args: #{inspect args}"
-    {reason, msg} = extract_reason_and_message(reason, msg)
-    {pid, reason, msg, Backtrace.from_stacktrace(stack), nil}
-  end
-
-  # FIXME add test coverage for this one
-  defp match_error_format('Ranch listener ' ++ _, [_, _, pid, {{reason, stack}, initial}]) do
-    conn = extract_conn(initial)
-    msg = "HTTP request #{inspect pid} crashed"
-    {reason, msg} = extract_reason_and_message(reason, msg)
-    {pid, reason, msg, Backtrace.from_stacktrace(stack), conn}
+    msg = "Process #{crash_name(pid, name)} terminating"
+    {reason, message} = extract_reason_and_message(exception, msg)
+    {origin, reason, message, Backtrace.from_stacktrace(stack), nil}
   end
 
   @doc false
@@ -150,28 +94,8 @@ defmodule Appsignal.ErrorHandler do
     Backtrace.from_stacktrace(stacktrace)
   end
 
-  # Extract stack trace from GenServer crash report reason
-  defp maybe_extract_stack({maybe_exception, [_ | _ ] = maybe_stacktrace} = reason) do
-    try do
-      {maybe_exception, maybe_stacktrace}
-    catch
-      :error, _ ->
-        {reason, []}
-    end
-  end
-
-  defp maybe_extract_stack(reason) do
-    {reason, []}
-  end
-
   defp crash_name(pid, []), do: inspect(pid)
   defp crash_name(pid, name), do: "#{inspect(name)} (#{inspect(pid)})"
-
-  if Appsignal.phoenix? do
-    defp extract_conn({_, :call, [%Plug.Conn{} = conn, _params]}), do: conn
-  end
-  defp extract_conn(_), do: nil
-
 
   @doc """
   Extract a consise reason from the given error reason, stripping it from long stack traces and the like.

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -29,9 +29,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end
   end
 
-
   defmodule CustomErrorHandler do
-
     use GenEvent
 
     def init(_) do
@@ -45,7 +43,6 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     def handle_call(:get_matched_crash, state) do
       {:remove_handler, state}
     end
-
   end
 
   @error_handler Appsignal.ErrorHandler.ErrorMatcherTest.CustomErrorHandler
@@ -67,7 +64,6 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     for s <- stacktrace do
       assert is_binary(s)
-      # IO.puts("- #{s}")
     end
     {reason, message}
   end

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -38,12 +38,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       {:ok, nil}
     end
 
-    def handle_event(event, nil) do
+    def handle_event(event, _state) do
       {:ok, Appsignal.ErrorHandler.match_event(event)}
-    end
-    def handle_event(_event, state) do
-      # ignore other events when we already have caught one error event
-      {:ok, state}
     end
 
     def handle_call(:get_matched_crash, state) do
@@ -76,7 +72,6 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     {reason, message}
   end
 
-
   setup do
     :error_logger.add_report_handler(@error_handler)
     on_exit(fn() ->
@@ -85,52 +80,13 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     :timer.sleep 100
   end
 
-
-  test "bare spawn + throw" do
-    spawn(fn() ->
-      throw(:crash_bare_throw)
-    end)
-    |> assert_crash_caught
-    |> reason("{:nocatch, :crash_bare_throw}")
-    |> message_regex(~r/Process #PID<[\d.]+> raised an exception/)
-  end
-
-  test "bare spawn + :erlang.error" do
-    spawn(fn() ->
-      :erlang.error(:crash_bare_error)
-    end)
-    |> assert_crash_caught
-    |> reason(":crash_bare_error")
-    |> message_regex(~r/Process #PID<[\d.]+> raised an exception/)
-  end
-
-  test "bare spawn + function error" do
-    spawn(fn() ->
-      String.length(:notastring)
-    end)
-    |> assert_crash_caught
-    |> reason(":function_clause")
-    |> message_regex(~r(Process #PID<[\d.]+> raised an exception))
-  end
-
-  test "bare spawn + badmatch error" do
-    spawn(fn() ->
-      1 = 2
-    end)
-    |> assert_crash_caught
-    |> reason("{:badmatch, 2}")
-    |> message_regex(~r(Process #PID<[\d.]+> raised an exception))
-  end
-
-
-
   test "proc_lib.spawn + exit" do
     :proc_lib.spawn(fn() ->
       exit(:crash_proc_lib_spawn)
     end)
     |> assert_crash_caught
     |> reason("{:exit, :crash_proc_lib_spawn}")
-    |> message_regex(~r(Process #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating$))
   end
 
   test "proc_lib.spawn + erlang.error" do
@@ -139,7 +95,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
     |> assert_crash_caught
     |> reason("{:error, :crash_proc_lib_error}")
-    |> message_regex(~r(Process #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating$))
   end
 
   test "proc_lib.spawn + function error" do
@@ -148,7 +104,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
     |> assert_crash_caught
     |> reason("{:error, :function_clause}")
-    |> message_regex(~r(Process #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating$))
   end
 
   test "proc_lib.spawn + badmatch error" do
@@ -157,30 +113,29 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
     |> assert_crash_caught
     |> reason("{:error, {:badmatch, 2}}")
-    |> message_regex(~r(Process #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating: {:badmatch, 2}))
   end
-
 
   test "Crashing GenServer with throw" do
     CrashingGenServer.start(:throw)
     |> assert_crash_caught
     # http://erlang.org/pipermail/erlang-bugs/2012-April/002862.html
-    |> reason("{:bad_return_value, :crashed_gen_server_throw}")
-    |> message_regex(~r(GenServer #PID<[\d.]+> terminating))
+    |> reason("{:exit, {:bad_return_value, :crashed_gen_server_throw}}")
+    |> message(~r(Process #PID<[\d.]+> terminating: {:bad_return_valu...))
   end
 
   test "Crashing GenServer with exit" do
     CrashingGenServer.start(:exit)
     |> assert_crash_caught
-    |> reason(":crashed_gen_server_exit")
-    |> message_regex(~r(GenServer #PID<[\d.]+> terminating))
+    |> reason("{:exit, :crashed_gen_server_exit}")
+    |> message(~r(Process #PID<[\d.]+> terminating$))
   end
 
   test "Crashing GenServer with function error" do
     CrashingGenServer.start(:function_error)
     |> assert_crash_caught
     |> reason(":function_clause")
-    |> message_regex(~r(GenServer #PID<[\d.]+> terminating))
+    |> message(~r(Process #PID<[\d.]+> terminating: {:function_clause...))
   end
 
   test "Task" do
@@ -189,8 +144,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
     |> assert_crash_caught
     |> reason(":function_clause")
-    |> message_regex(
-      ~r(Task #PID<[\d.]+> started from #PID<[\d.]+> terminating. Function: #Function<[\d.]+/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test Task/1>, args: \[\])
+    |> message(
+      ~r(Process #PID<[\d.]+> terminating: {:function_clause, \[{String.Uni...)
     )
   end
 
@@ -202,7 +157,10 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       |> Task.await(1)
     end)
     |> assert_crash_caught
-    |> reason_regex(~r/^{:exit, {:timeout/)
+    |> reason(":timeout")
+    |> message(
+      ~r(Process #PID<[\d.]+> terminating: {:timeout, {Task, :await, \[%Tas...)
+    )
   end
 
   defp reason({reason, _message} = data, expected) do
@@ -210,12 +168,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     data
   end
 
-  defp reason_regex({reason, _message} = data, expected) do
-    assert reason =~ expected
-    data
-  end
-
-  defp message_regex({_reason, message} = data, expected) do
+  defp message({_reason, message} = data, expected) do
     assert message =~ expected
     data
   end

--- a/test/appsignal/error_handler_test.exs
+++ b/test/appsignal/error_handler_test.exs
@@ -17,19 +17,17 @@ defmodule Appsignal.ErrorHandlerTest do
 
 
   test "whether we can send error reports without current transaction" do
-    Task.start(fn() ->
+    :proc_lib.spawn(fn() ->
       :erlang.error(:error_task)
     end)
 
     :timer.sleep 100
   end
 
-
   test "whether we can send error reports with a current transaction" do
-
     id = Transaction.generate_id()
 
-    Task.start(fn() ->
+    :proc_lib.spawn(fn() ->
       Transaction.start(id, :http_request)
       |> Transaction.set_action("AppsignalErrorHandlerTest#test")
 


### PR DESCRIPTION
This is a continuation of #190, which was closed but can’t be reopened because the branch was rebased.

Closes #157 & #173.

Before, the ErrorHandler had to match on :error events (besides
:error_report events) to be able to catch errors that were already
caught by Plug.ErrorHandler.

After merging #187, we can drop support for :error events. This drops
support for unsupervised "bare" spawns, and only triggers an error when
a process actually crashes. Also, this removes a lot of code that dealt
with not sending error reports twice (after the :error event and the
:error_report event).