### PR TITLE
Allow local agent releases to be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ priv
 /doc
 /cover
 /tmp
+/c_src/appsignal-agent
+/c_src/appsignal.h
+/c_src/appsignal.version
+/c_src/libappsignal.a

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,11 @@ defmodule Mix.Tasks.Compile.Appsignal do
         :ok = Mix.Appsignal.Helper.ensure_downloaded(arch)
         :ok = Mix.Appsignal.Helper.compile
       {:error, {:unsupported, arch}} ->
-        Mix.Shell.IO.error("Unsupported target platform #{arch}, AppSignal integration disabled!\nPlease check http://docs.appsignal.com/support/operating-systems.html")
+        Mix.Shell.IO.error(
+          "Unsupported target platform #{arch}, AppSignal integration " <>
+          "disabled!\nPlease check " <>
+          "http://docs.appsignal.com/support/operating-systems.html"
+        )
         :ok
     end
   end


### PR DESCRIPTION
When testing the Elixir integration, using the agent repository, you can
now use a local agent build.

Use the `rake integrations:install` task in the agent repository to
install the agent and extension to the local integrations, the Ruby gem
and Elixir package.

With this change the Elixir package will pick up the local agent version
and install that rather than pull the latest version from the agent CDN.

Do make sure you remove the local files from the `c_ext` directory when
you want to use a proper released version again.

Depends on PR in Agent repo: https://github.com/appsignal/appsignal-agent/pull/244
Closes #156 