### PR TITLE
Parse new report from agent diagnose mode

### DIFF
--- a/agent.ex
+++ b/agent.ex
@@ -1,27 +1,27 @@
 defmodule Appsignal.Agent do
-  def version, do: "7ade8ff"
+  def version, do: "da14f3b"
 
   def triples do
     %{
       "x86_64-linux" => %{
-        checksum: "4c9a40b6215aa5598f546050817448e698479a2e6594feb8f7d46b755ae959e9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "690ae21a087fc9bc8089f492bd2f751c77d9e9573441aa5b2b9427ab8b1e5433",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-linux-all-static.tar.gz"
        },
       "i686-linux" => %{
-        checksum: "0caf5d0ef96f663b03b36d4c37741856ded851d205e0c1403550d6c04266eb6b",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86-linux" => %{
-        checksum: "0caf5d0ef96f663b03b36d4c37741856ded851d205e0c1403550d6c04266eb6b",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86_64-darwin" => %{
-        checksum: "bc72d9f7485b66802f9642e1d2fee4d2fe2f1b5b363f1378c46469d112b9442e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz"
        },
       "universal-darwin" => %{
-        checksum: "bc72d9f7485b66802f9642e1d2fee4d2fe2f1b5b363f1378c46469d112b9442e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz"
        },
     }
   end

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -41,6 +41,10 @@ static appsignal_string_t make_appsignal_string(ErlNifBinary binary)
     return retval;
 }
 
+static ERL_NIF_TERM make_elixir_string(ErlNifEnv* env, appsignal_string_t binary) {
+  return enif_make_string_len(env, binary.buf, binary.len, ERL_NIF_LATIN1);
+}
+
 static ERL_NIF_TERM _start(ErlNifEnv* env, int UNUSED(arc), const ERL_NIF_TERM UNUSED(argv[]))
 {
     appsignal_start();
@@ -51,6 +55,10 @@ static ERL_NIF_TERM _stop(ErlNifEnv* env, int UNUSED(arc), const ERL_NIF_TERM UN
 {
     appsignal_stop();
     return enif_make_atom(env, "ok");
+}
+
+static ERL_NIF_TERM _diagnose(ErlNifEnv* env, int UNUSED(arc), const ERL_NIF_TERM UNUSED(argv[])) {
+  return make_elixir_string(env, appsignal_diagnose());
 }
 
 static ERL_NIF_TERM _start_transaction(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -771,6 +779,7 @@ static ErlNifFunc nif_funcs[] =
 {
     {"_start", 0, _start, 0},
     {"_stop", 0, _stop, 0},
+    {"_diagnose", 0, _diagnose, 0},
     {"_start_transaction", 2, _start_transaction, 0},
     {"_start_event", 1, _start_event, 0},
     {"_finish_event", 5, _finish_event, 0},

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -56,6 +56,10 @@ defmodule Appsignal.Nif do
     _stop()
   end
 
+  def diagnose do
+    _diagnose()
+  end
+
   def start_transaction(transaction_id, namespace) do
     _start_transaction(transaction_id, namespace)
   end
@@ -192,6 +196,10 @@ defmodule Appsignal.Nif do
 
   def _stop do
     :ok
+  end
+
+  def _diagnose do
+    :error
   end
 
   def _start_transaction(_id, _namespace) do

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -35,9 +35,13 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     end
 
     defp print_report(report) do
-      Enum.each(report_definition(), fn({component, categories}) ->
-        print_component(report[component] || %{}, categories)
-      end)
+      if report["error"] do
+        IO.puts "  Error: #{report["error"]}"
+      else
+        Enum.each(report_definition(), fn({component, categories}) ->
+          print_component(report[component] || %{}, categories)
+        end)
+      end
     end
 
     defp print_component(report, categories) do

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
           {:ok, report} -> print_report report
           {:error, _} ->
             IO.puts "  Error: Could not parse the agent report:"
-            IO.puts "    Output: " <> report_string
+            IO.puts "    Output: #{report_string}"
         end
         System.delete_env("_APPSIGNAL_DIAGNOSE")
       else
@@ -53,13 +53,13 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     end
 
     defp print_test(report, definition) do
-      IO.write "  " <> definition[:label] <> ": "
+      IO.write "  #{definition[:label]}: "
       case Map.fetch(definition[:values], report["result"]) do
         {:ok, value} -> IO.puts value
         :error -> IO.puts "-"
       end
-      if report["error"], do: IO.puts "    Error: " <> report["error"]
-      if report["output"], do: IO.puts "    Output" <> report["output"]
+      if report["error"], do: IO.puts "    Error: #{report["error"]}"
+      if report["output"], do: IO.puts "    Output: #{report["output"]}"
     end
 
     defp report_definition do

--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,7 @@ defmodule Appsignal.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.11"},
+      {:poison, ">= 1.3.0"},
       {:decorator, "~> 1.0"},
       {:phoenix, ">= 1.2.0", optional: true, only: [:prod, :test_phoenix]},
       {:mock, "~> 0.2.1", only: [:test, :test_phoenix, :test_no_nif]},

--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -24,7 +24,7 @@ defmodule Appsignal.ReleaseUpgradeTest do
     config_reload_pid = Appsignal.config_change([], [], [])
     # The config is reloaded in a separate process so we wait for it here
     assert Process.alive?(config_reload_pid)
-    :timer.sleep 1500
+    :timer.sleep 3500
     refute Process.alive?(config_reload_pid)
 
     assert config()[:name] == "My app v2"

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -199,7 +199,19 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     end
   end
 
-  describe "when agent diagnose report contains an error" do
+  describe "when the agent diagnose report contains an error" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, ~s({ "error": "fatal error" }))
+    end
+
+    test "prints the error" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics\n  Error: fatal error"
+    end
+  end
+
+  describe "when an agent diagnose report test contains an error" do
     setup do
       @nif.set(:loaded?, true)
       @nif.set(:diagnose, ~s(
@@ -216,7 +228,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     end
   end
 
-  describe "when agent diagnose report contains command output" do
+  describe "when an agent diagnose report test contains command output" do
     setup do
       @nif.set(:loaded?, true)
       @nif.set(:diagnose, ~s(

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -128,27 +128,74 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
   @tag :skip_env_test_no_nif
   test "runs agent in diagnose mode" do
+    @nif.set(:run_diagnose, true)
     output = run()
     assert String.contains? output, "Agent diagnostics"
-    assert String.contains? output, "Running agent in diagnose mode"
-    assert String.contains? output, "Valid config present"
-    assert String.contains? output, "Logger initialized successfully"
-    assert String.contains? output, "Lock path is writable"
-    assert String.contains? output, "Agent diagnose finished"
+    assert String.contains? output, "  Extension config: valid"
+    assert String.contains? output, "  Agent started: started"
+    assert String.contains? output, "  Agent config: valid"
+    assert String.contains? output, "  Agent lock path: writable"
+    assert String.contains? output, "  Agent logger: started"
   end
 
   @tag :skip_env_test_no_nif
   describe "when config is not active" do
     test "runs agent in diagnose mode, but doesn't change the active state" do
+      @nif.set(:run_diagnose, true)
       merge_appsignal_config %{active: false}
       output = run()
       assert String.contains? output, "active: false"
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "Running agent in diagnose mode"
-      assert String.contains? output, "Valid config present"
-      assert String.contains? output, "Logger initialized successfully"
-      assert String.contains? output, "Lock path is writable"
-      assert String.contains? output, "Agent diagnose finished"
+      assert String.contains? output, "  Extension config: valid"
+      assert String.contains? output, "  Agent started: started"
+      assert String.contains? output, "  Agent config: valid"
+      assert String.contains? output, "  Agent lock path: writable"
+      assert String.contains? output, "  Agent logger: started"
+    end
+  end
+
+  describe "when extension is not loaded" do
+    setup do: @nif.set(:loaded?, false)
+
+    test "agent diagnostics is not run" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Error: Nif not loaded, aborting."
+    end
+  end
+
+  describe "when extension output is invalid JSON" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, "agent_report_string")
+    end
+
+    test "agent diagnostics report prints an error" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Error: Could not parse the agent report:"
+      assert String.contains? output, "    Output: agent_report_string"
+    end
+  end
+
+  describe "when extension output is missing a test" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, ~s(
+        {
+          "extension": { "config": { "valid": { "result": true } } }
+        }
+      ))
+    end
+
+    test "agent diagnostics report prints the tests, but shows a dash `-` for missed results" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Extension config: valid"
+      assert String.contains? output, "  Agent started: -"
+      assert String.contains? output, "  Agent config: -"
+      assert String.contains? output, "  Agent lock path: -"
+      assert String.contains? output, "  Agent logger: -"
     end
   end
 
@@ -213,6 +260,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
     @tag :skip_env_test_no_nif
     test "outputs writable and creates log file", %{log_dir_path: log_dir_path, log_file_path: log_file_path} do
+      @nif.set(:run_diagnose, true)
       output = run()
       assert String.contains? output, "log_dir_path: #{log_dir_path}\n    - Writable?: yes"
       assert String.contains? output, "log_file_path: #{log_file_path}\n    - Writable?: yes"

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -199,6 +199,40 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     end
   end
 
+  describe "when agent diagnose report contains an error" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, ~s(
+        {
+          "agent": { "boot": { "started": { "result": false, "error": "my error" } } }
+        }
+      ))
+    end
+
+    test "prints the error" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Agent started: not started\n    Error: my error"
+    end
+  end
+
+  describe "when agent diagnose report contains command output" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, ~s(
+        {
+          "agent": { "boot": { "started": { "result": false, "output": "my output" } } }
+        }
+      ))
+    end
+
+    test "prints the output" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Agent started: not started\n    Output: my output"
+    end
+  end
+
   test "outputs configuration" do
     output = run()
     assert String.contains? output, "Configuration"

--- a/test/support/fake_nif.ex
+++ b/test/support/fake_nif.ex
@@ -16,4 +16,12 @@ defmodule Appsignal.FakeNif do
   def running_in_container? do
     Agent.get(__MODULE__, &Map.get(&1, :running_in_container?, true))
   end
+
+  def diagnose do
+    if Agent.get(__MODULE__, &Map.get(&1, :run_diagnose, false)) do
+      Appsignal.Nif.diagnose
+    else
+      Agent.get(__MODULE__, &Map.get(&1, :diagnose, "{}"))
+    end
+  end
 end


### PR DESCRIPTION
The extension returns a JSON object, as a string, which contains the
agent diagnostics report.

The report definition is defined in the diagnose CLI task so we can
check all the tests and display them in a human readable format.

This change makes it possible to return the agent diagnostics report
without capturing the STDOUT while the agent is running. This proved
difficult to do in Elixir, where we previously called the agent
executable directly.

Instead of printing the report to STDOUT the extension will now return
the report as a JSON object, which is formatted as a string which needs
to be parsed into JSON first.

This report may be incomplete when the agent fails to start or something
else goes wrong. Any error will be captured and added to the agent
report.

Depends on #195 