### PR TITLE
Use :channels namespace in Appsignal.Phoenix.Channel

### DIFF
--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -51,7 +51,7 @@ if Appsignal.phoenix? do
     def channel_action(module, name, %Phoenix.Socket{} = socket, function) do
       alias Appsignal.Transaction
 
-      transaction = Transaction.start(Transaction.generate_id(), :background_job)
+      transaction = Transaction.start(Transaction.generate_id(), :channel)
 
       action_str = "#{module}##{name}"
       <<"Elixir.", action :: binary>> = action_str

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -1,7 +1,5 @@
 defmodule Appsignal.TransactionBehaviour do
-  @type namespace :: :http_request | :background_job
-
-  @callback start(String.t, namespace) :: Appsignal.Transaction.t
+  @callback start(String.t, String.t) :: Appsignal.Transaction.t
   @callback start_event() :: Appsignal.Transaction.t
   @callback finish_event(Appsignal.Transaction.t | nil, String.t, String.t, any, integer) :: Appsignal.Transaction.t
   @callback finish() :: :sample | :no_sample
@@ -45,22 +43,14 @@ defmodule Appsignal.Transaction do
   """
   @type t :: %Transaction{}
 
-  @typedoc """
-  The transaction's namespace
-  """
-  @type namespace :: :http_request | :background_job
-
-  @valid_namespaces [:http_request, :background_job]
-
-
   @doc """
   Start a transaction
 
   Call this when a transaction such as a http request or background job starts.
 
   Parameters:
-  - `transaction_id` The unique identifier of this transaction
-  - `namespace` The namespace of this transaction. Must be one of `:http_request`, `:background_job`.
+  - `transaction_id` The unique identifier of this transaction.
+  - `namespace` The namespace of this transaction. Defaults to :background_job.
 
   The function returns a `%Transaction{}` struct for use with the
   other transaction functions in this module.
@@ -71,8 +61,8 @@ defmodule Appsignal.Transaction do
   `Appsignal.TransactionRegistry`.
 
   """
-  @spec start(String.t, namespace) :: Transaction.t
-  def start(transaction_id, namespace) when is_binary(transaction_id) and namespace in @valid_namespaces do
+  @spec start(String.t, String.t) :: Transaction.t
+  def start(transaction_id, namespace) when is_binary(transaction_id) do
     {:ok, resource} = Nif.start_transaction(transaction_id, Atom.to_string(namespace))
     transaction = %Appsignal.Transaction{resource: resource, id: transaction_id}
     TransactionRegistry.register(transaction)

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -27,7 +27,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
   test_with_mock "channel_action function decorator", Appsignal.Transaction, [:passthrough], [] do
     SomeApp.MyChannel.handle_in("ping", :payload, %Socket{})
     t = Appsignal.TransactionRegistry.lookup(self())
-    assert called Transaction.start(t.id, :background_job)
+    assert called Transaction.start(t.id, :channel)
     assert called Transaction.set_action(t, "Appsignal.Phoenix.ChannelTest.SomeApp.MyChannel#ping")
     assert called Transaction.finish(t)
     assert called Transaction.complete(t)
@@ -36,7 +36,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
   test_with_mock "direct calling of channel_action function", Appsignal.Transaction, [:passthrough], [] do
     SomeApp.MyChannel.handle_in("pong", :payload, %Socket{})
     t = Appsignal.TransactionRegistry.lookup(self())
-    assert called Transaction.start(t.id, :background_job)
+    assert called Transaction.start(t.id, :channel)
     assert called Transaction.set_action(t, "Appsignal.Phoenix.ChannelTest.SomeApp.MyChannel#pong")
     assert called Transaction.finish(t)
     assert called Transaction.complete(t)


### PR DESCRIPTION
Closes #194.

Instead of using the :background_job namespace,
Appsignal.Phoenix.Channel will use :channels instead. This also allows
users to set their own custom namespaces in
Appsignal.Transaction.start/2.