### PR TITLE
Allow nil transactions

### DIFF
--- a/lib/appsignal/instrumentation/helpers.ex
+++ b/lib/appsignal/instrumentation/helpers.ex
@@ -5,7 +5,7 @@ defmodule Appsignal.Instrumentation.Helpers do
 
   alias Appsignal.{Transaction, TransactionRegistry}
 
-  @type instrument_arg :: Transaction.t | Plug.Conn.t | pid()
+  @type instrument_arg :: Transaction.t | Plug.Conn.t | pid() | nil
 
   @doc """
   Execute the given function in start / finish event calls in the current
@@ -66,5 +66,9 @@ defmodule Appsignal.Instrumentation.Helpers do
     result = function.()
     Transaction.finish_event(transaction, name, title, body, body_format)
     result
+  end
+
+  def instrument(nil, _name, _title, _body, _body_format, function) do
+    function.()
   end
 end

--- a/lib/appsignal/instrumentation/helpers.ex
+++ b/lib/appsignal/instrumentation/helpers.ex
@@ -53,12 +53,8 @@ defmodule Appsignal.Instrumentation.Helpers do
   """
   @spec instrument(instrument_arg, String.t, String.t, String.t, integer, function) :: any
   def instrument(pid, name, title, body, body_format, function) when is_pid(pid) do
-    case TransactionRegistry.lookup(pid) do
-      nil ->
-        function.()
-      t = %Transaction{} ->
-        instrument(t, name, title, body, body_format, function)
-    end
+    t = TransactionRegistry.lookup(pid)
+    instrument(t, name, title, body, body_format, function)
   end
 
   def instrument(%Transaction{} = transaction, name, title, body, body_format, function) do

--- a/test/appsignal/instrumentation/helpers_test.exs
+++ b/test/appsignal/instrumentation/helpers_test.exs
@@ -19,6 +19,10 @@ defmodule AppsignalHelpersTest do
     assert called Transaction.finish_event(t, "name", "title", "", 0)
   end
 
+  test "instrument with nil" do
+    call_instrument(nil)
+  end
+
   defp call_instrument(arg) do
     r = Helpers.instrument(arg, "name", "title", fn() ->
       # some slow function


### PR DESCRIPTION
This change allows calls to `Appsignal.Instrumentation.Helpers.instrument/6` with `nil` as an argument. In a way, it tries to make `instrument/6` consistent with `instrument/3` when no transaction is found for the current process.

This helps avoiding clauses or conditionals in instrumented code. For example:

```elixir
defmodule HelloServer do
  use GenServer

  def handle_call({:hello, name, transaction}, _from, state) do
    instrument(transaction, "hello", "Handling hello request", fn ->
      {:reply, do_hello(name), state}
    end)
  end

  def handle_call({:hello, name, nil}, _from, state) do
    {:reply, do_hello(name), state}
  end

  defp do_hello(name) do
    "Hello, #{name}!"
  end
end
```

With this patch the second clause for `handle_call/3` can be dropped.

We ran into this issue in a production app where we need to report nested times for client and server processes. In order to do that, we pass in a transaction. But, in tests, instrumentation is not wanted and would rather avoid the duplication.