### PR TITLE
Send diagnostics data report to AppSignal

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,4 +10,5 @@ if Mix.env in [:test, :test_phoenix, :test_no_nif] do
   config :appsignal, appsignal_nif: Appsignal.FakeNif
   config :appsignal, appsignal_demo: Appsignal.FakeDemo
   config :appsignal, appsignal_transaction: Appsignal.FakeTransaction
+  config :appsignal, appsignal_diagnose_report: Appsignal.Diagnose.FakeReport
 end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -6,6 +6,7 @@ defmodule Appsignal.Config do
     debug: false,
     enable_host_metrics: true,
     endpoint: "https://push.appsignal.com",
+    diagnose_endpoint: "https://appsignal.com/diag",
     env: :dev,
     filter_parameters: nil,
     ignore_actions: [],

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -1,0 +1,94 @@
+defmodule Appsignal.Diagnose.Agent do
+  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+  def report do
+    if @nif.loaded? do
+      System.put_env("_APPSIGNAL_DIAGNOSE", "true")
+      report_string = @nif.diagnose
+      report = case Poison.decode(report_string) do
+        {:ok, report} -> {:ok, report}
+        {:error, _} -> {:error, report_string}
+      end
+      System.delete_env("_APPSIGNAL_DIAGNOSE")
+      report
+    else
+      {:error, :nif_not_loaded}
+    end
+  end
+
+  # Start AppSignal as usual, in diagnose mode, so that it exits early, but
+  # does go through the whole process of setting the config to the
+  # environment.
+  def print(report) do
+    IO.puts "Agent diagnostics"
+    if report["error"] do
+      IO.puts "  Error: #{report["error"]}"
+    else
+      Enum.each(report_definition(), fn({component, categories}) ->
+        print_component(report[component] || %{}, categories)
+      end)
+    end
+    IO.puts ""
+  end
+
+  defp print_component(report, categories) do
+    Enum.each(categories, fn({category, tests}) ->
+      print_category(report[category] || %{}, tests)
+    end)
+  end
+
+  defp print_category(report, tests) do
+    Enum.each(tests, fn({test, definition}) ->
+      print_test(report[test] || %{}, definition)
+    end)
+  end
+
+  defp print_test(report, definition) do
+    IO.write "  #{definition[:label]}: "
+    case Map.fetch(definition[:values], report["result"]) do
+      {:ok, value} -> IO.puts value
+      :error -> IO.puts "-"
+    end
+    if report["error"], do: IO.puts "    Error: #{report["error"]}"
+    if report["output"], do: IO.puts "    Output: #{report["output"]}"
+  end
+
+  defp report_definition do
+    %{
+      "extension" => %{
+        "config" => %{
+          "valid" => %{
+            :label => "Extension config",
+            :values => %{ true => "valid", false => "invalid" }
+          }
+        }
+      },
+      "agent" => %{
+        "boot" => %{
+          "started" => %{
+            :label => "Agent started",
+            :values => %{ true => "started", false => "not started" }
+          }
+        },
+        "config" => %{
+          "valid" => %{
+            :label => "Agent config",
+            :values => %{ true => "valid", false => "invalid" }
+          }
+        },
+        "logger" => %{
+          "started" => %{
+            :label => "Agent logger",
+            :values => %{ true => "started", false => "not started" }
+          }
+        },
+        "lock_path" => %{
+          "created" => %{
+            :label => "Agent lock path",
+            :values => %{ true => "writable", false => "not writable" }
+          }
+        }
+      }
+    }
+  end
+end

--- a/lib/appsignal/diagnose/host.ex
+++ b/lib/appsignal/diagnose/host.ex
@@ -1,0 +1,15 @@
+defmodule Appsignal.Diagnose.Host do
+  @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
+  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+  def info do
+    %{
+      architecture: to_string(:erlang.system_info(:system_architecture)),
+      language_version: System.version,
+      otp_version: System.otp_release,
+      heroku: @system.heroku?,
+      root: @system.root?,
+      running_in_container: @nif.running_in_container?
+    }
+  end
+end

--- a/lib/appsignal/diagnose/library.ex
+++ b/lib/appsignal/diagnose/library.ex
@@ -1,0 +1,14 @@
+defmodule Appsignal.Diagnose.Library do
+  @appsignal_version Mix.Project.config[:version]
+  @agent_version Mix.Project.config[:agent_version]
+  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+  def info do
+    %{
+      language: "elixir",
+      agent_version: @agent_version,
+      package_version: @appsignal_version,
+      extension_loaded: @nif.loaded?
+    }
+  end
+end

--- a/lib/appsignal/diagnose/paths.ex
+++ b/lib/appsignal/diagnose/paths.ex
@@ -1,0 +1,37 @@
+defmodule Appsignal.Diagnose.Paths do
+  def info(config) do
+    log_file_path = config[:log_path] || "/tmp/appsignal.log"
+    log_dir_path = Path.dirname(log_file_path)
+    %{
+      log_dir_path: path_report(log_dir_path),
+      log_file_path: path_report(log_file_path)
+    }
+  end
+
+  defp path_report(path) do
+    report = %{
+      path: path,
+      configured: true,
+      exists: false,
+      writable: false
+    }
+
+    path_details =
+      if File.exists? path do
+        case File.stat(path) do
+          {:ok, %{access: access, uid: uid}} ->
+            case access do
+              p when p in [:write, :read_write] ->
+                %{writable: true}
+              _ -> %{}
+            end
+            |> Map.merge(%{ownership: %{uid: uid}})
+          {:error, reason} -> %{error: reason}
+        end
+        |> Map.merge(%{exists: true})
+      else
+        %{}
+      end
+    Map.merge(report, path_details)
+  end
+end

--- a/lib/appsignal/diagnose/report.ex
+++ b/lib/appsignal/diagnose/report.ex
@@ -1,0 +1,31 @@
+defmodule Appsignal.Diagnose.ReportBehaviour do
+  @callback send(Appsignal.Config.t, %{}) :: {:ok, String.t}
+end
+
+defmodule Appsignal.Diagnose.Report do
+  @behaviour Appsignal.Diagnose.ReportBehaviour
+
+  def send(config, report) do
+    HTTPoison.start
+    params = URI.encode_query(%{
+      api_key: config[:push_api_key],
+      name: config[:name],
+      environment: config[:environment],
+      hostname: config[:hostname]
+    })
+    url = "#{config[:diagnose_endpoint]}?#{params}"
+    body = Poison.encode!(%{diagnose: report})
+    headers = [{"Content-Type", "application/json; charset=UTF-8"}]
+    case HTTPoison.post url, body, headers do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        case Poison.decode(body) do
+          {:ok, response} -> {:ok, response["token"]}
+          {:error, _} -> {:error, %{status_code: 200, body: body}}
+        end
+      {_, %HTTPoison.Response{status_code: status_code, body: body}} ->
+        {:error, %{status_code: status_code, body: body}}
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, %{reason: reason}}
+    end
+  end
+end

--- a/lib/appsignal/diagnose/validation.ex
+++ b/lib/appsignal/diagnose/validation.ex
@@ -1,0 +1,14 @@
+defmodule Appsignal.Diagnose.Validation do
+  alias Appsignal.Utils.PushApiKeyValidator
+
+  def validate(config) do
+    case PushApiKeyValidator.validate(config) do
+      :ok ->
+        %{push_api_key: "valid"}
+      {:error, :invalid} ->
+        %{push_api_key: "invalid"}
+      {:error, reason} ->
+        %{push_api_key: "error: #{reason}"}
+    end
+  end
+end

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -471,6 +471,7 @@ defmodule Appsignal.ConfigTest do
       debug: false,
       enable_host_metrics: true,
       endpoint: "https://push.appsignal.com",
+      diagnose_endpoint: "https://appsignal.com/diag",
       env: :dev,
       filter_parameters: nil,
       ignore_actions: [],

--- a/test/appsignal/diagnose/report_test.exs
+++ b/test/appsignal/diagnose/report_test.exs
@@ -1,0 +1,80 @@
+defmodule Mix.Tasks.Appsignal.Diagnose.ReportTest do
+  use ExUnit.Case
+  import AppsignalTest.Utils
+
+  defp send() do
+    Appsignal.Diagnose.Report.send(
+      Application.get_env(:appsignal, :config, %{}),
+      %{}
+    )
+  end
+
+  setup do
+    diagnose_bypass = Bypass.open
+    setup_with_config(%{
+      api_key: "foo",
+      name: "My app",
+      environment: "production",
+      hostname: "foo",
+      diagnose_endpoint: "http://localhost:#{diagnose_bypass.port}/diag"
+    })
+
+    {:ok, diagnose_bypass: diagnose_bypass}
+  end
+
+  describe "with valid response" do
+    setup %{diagnose_bypass: diagnose_bypass} do
+      Bypass.expect diagnose_bypass, fn conn ->
+        assert "/diag" == conn.request_path
+        assert "POST" == conn.method
+        Plug.Conn.resp(conn, 200, ~s({"token": "support token"}))
+      end
+      :ok
+    end
+
+    test "sends the diagnostics report to AppSignal and returns support token" do
+      assert send() == {:ok, "support token"}
+    end
+  end
+
+  describe "with invalid response" do
+    setup %{diagnose_bypass: diagnose_bypass} do
+      Bypass.expect diagnose_bypass, fn conn ->
+        assert "/diag" == conn.request_path
+        assert "POST" == conn.method
+        Plug.Conn.resp(conn, 200, ~s({"foo": bar}))
+      end
+      :ok
+    end
+
+    test "sends the diagnostics report to AppSignal and returns an error" do
+      assert send() == {:error, %{body: ~s({"foo": bar}), status_code: 200}}
+    end
+  end
+
+  describe "with error response" do
+    setup %{diagnose_bypass: diagnose_bypass} do
+      Bypass.expect diagnose_bypass, fn conn ->
+        assert "/diag" == conn.request_path
+        assert "POST" == conn.method
+        Plug.Conn.resp(conn, 500, ~s(woops))
+      end
+      :ok
+    end
+
+    test "sends the diagnostics report to AppSignal and returns an error" do
+      assert send() == {:error, %{body: "woops", status_code: 500}}
+    end
+  end
+
+  describe "with no server response" do
+    setup %{diagnose_bypass: diagnose_bypass} do
+      Bypass.down(diagnose_bypass)
+      :ok
+    end
+
+    test "sends the diagnostics report to AppSignal and returns an error" do
+      assert send() == {:error, %{reason: :econnrefused}}
+    end
+  end
+end

--- a/test/support/fake_diagnose_report.ex
+++ b/test/support/fake_diagnose_report.ex
@@ -1,0 +1,21 @@
+defmodule Appsignal.Diagnose.FakeReport do
+  @behaviour Appsignal.Diagnose.ReportBehaviour
+
+  def start_link do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  def get(key) do
+    Agent.get(__MODULE__, &Map.get(&1, key))
+  end
+
+  def set(key, value) do
+    Agent.update(__MODULE__, &Map.put(&1, key, value))
+  end
+
+  def send(_, report) do
+    Agent.update(__MODULE__, &Map.put(&1, :report_sent?, true))
+    Agent.update(__MODULE__, &Map.put(&1, :sent_report, report))
+    get(:response) || {:error, %{reason: "response not set"}}
+  end
+end


### PR DESCRIPTION
This change will allow users to send the diagnostics report to
AppSignal. We'll ask before sending if the user wants this, but because
we see how useful this can be when debugging an issue it sends the
report by default. When you press enter, no input, "Y" (yes) is
submitted.

Why this change?
We've seen that in every support request we get we'll ask for the
diagnostics report. To make it easier for everyone this change allows
users to send it directly to AppSignal so our support team can review it
without valuable data getting lost by formatting by our support system
for example.

We also provide the user with a support token when they send the report.
This can be useful for a user if they see a problem with the output and
want to dive right in with the report. They can contact us with the
support token, after which we can immediately review the report.

Depends on #196 
Related Ruby gem PR https://github.com/appsignal/appsignal-ruby/pull/270
Closes the parent Epic: https://github.com/appsignal/appsignal-agent/issues/245