### PR TITLE
Add `with_config` and `with_env` for testing purposes

### DIFF
--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -387,9 +387,10 @@ defmodule Appsignal.Transaction do
       |> Transaction.set_sample_data("environment", request_environment(conn))
 
       # Add session data
-      if not config()[:skip_session_data] and conn.private[:plug_session_fetch] == :done do
-        session_data = conn.private[:plug_session]
-        Transaction.set_sample_data(transaction, "session_data", session_data)
+      if !config()[:skip_session_data] and conn.private[:plug_session_fetch] == :done do
+        Transaction.set_sample_data(
+          transaction, "session_data", conn.private[:plug_session]
+        )
       else
         transaction
       end

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -1,6 +1,7 @@
 defmodule AppsignalTest do
   use ExUnit.Case
   import Mock
+  import AppsignalTest.Utils
 
   test "set gauge" do
     Appsignal.set_gauge("key", 10.0)
@@ -22,16 +23,15 @@ defmodule AppsignalTest do
   end
 
   test "Agent environment variables" do
-    System.put_env("APPSIGNAL_APP_ENV", "test")
-    Application.put_env(:appsignal, :config, env: :test)
+    with_env(%{"APPSIGNAL_APP_ENV" => "test"}, fn() ->
+      Appsignal.Config.initialize()
 
-    Appsignal.Config.initialize()
+      env = Appsignal.Config.get_system_env()
+      assert "test" = env["APPSIGNAL_APP_ENV"]
 
-    env = Appsignal.Config.get_system_env()
-    assert "test" = env["APPSIGNAL_APP_ENV"]
-
-    config = Application.get_env :appsignal, :config
-    assert :test = config[:env]
+      config = Application.get_env :appsignal, :config
+      assert :test = config[:env]
+    end)
   end
 
   alias Appsignal.{Transaction, TransactionRegistry}

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -8,8 +8,12 @@ defmodule Appsignal.ConfigTest do
   alias Appsignal.Config
 
   setup do
-    clear_env()
-    on_exit &clear_env/0
+    environment = freeze_environment()
+    Application.delete_env(:appsignal, :config)
+
+    ExUnit.Callbacks.on_exit fn() ->
+      unfreeze_environment(environment)
+    end
   end
 
   test "unconfigured" do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -17,16 +17,17 @@ defmodule Appsignal.ConfigTest do
   end
 
   test "minimum config from OS env" do
-    System.put_env("APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000")
-    assert :ok = Config.initialize()
+    assert with_env(
+      %{"APPSIGNAL_PUSH_API_KEY" => "00000000-0000-0000-0000-000000000000"},
+      &Config.initialize/0
+    ) == :ok
   end
 
   test "minimum config from application env" do
-    Application.put_env(
-      :appsignal, :config,
-      push_api_key: "00000000-0000-0000-0000-000000000000"
-    )
-    assert :ok = Config.initialize()
+    assert with_config(
+      %{push_api_key: "00000000-0000-0000-0000-000000000000"},
+      &Config.initialize/0
+    ) == :ok
   end
 
   test "default configuration" do
@@ -35,252 +36,298 @@ defmodule Appsignal.ConfigTest do
 
   describe "active?" do
     test "when active and valid" do
-      Application.put_env(:appsignal, :config, %{active: true, valid: true})
-      assert Config.active?
+      assert with_config(
+        %{active: true, valid: true},
+        &Config.active?/0
+      )
     end
 
     test "when active but not valid" do
-      Application.put_env(:appsignal, :config, %{active: true, valid: false})
-      refute Config.active?
+      refute with_config(
+        %{active: true, valid: false},
+        &Config.active?/0
+      )
     end
 
     test "when not active and not valid" do
-      Application.put_env(:appsignal, :config, %{active: false, valid: false})
-      refute Config.active?
+      refute with_config(
+        %{active: false, valid: true},
+        &Config.active?/0
+      )
     end
   end
 
   describe "using the application environment" do
-    setup do: Application.put_env(:appsignal, :config, [])
-
     test "active" do
-      add_to_application_env(:active, true)
-      assert default_configuration() |> Map.put(:active, true) == init_config()
+      assert with_config(%{active: true}, &init_config/0)
+        == default_configuration() |> Map.put(:active, true)
     end
 
     test "ca_file_path" do
-      add_to_application_env(:ca_file_path, "/foo/bar/zab.ca")
-      assert default_configuration() |> Map.put(:ca_file_path, "/foo/bar/zab.ca") == init_config()
+      assert with_config(%{ca_file_path: "/foo/bar/baz.ca"}, &init_config/0)
+        == default_configuration() |> Map.put(:ca_file_path, "/foo/bar/baz.ca")
     end
 
     test "debug" do
-      add_to_application_env(:debug, true)
-      assert default_configuration() |> Map.put(:debug, true) == init_config()
+      assert with_config(%{debug: true}, &init_config/0)
+        == default_configuration() |> Map.put(:debug, true)
     end
 
     test "enable_host_metrics" do
-      add_to_application_env(:enable_host_metrics, false)
-      assert default_configuration() |> Map.put(:enable_host_metrics, false) == init_config()
+      assert with_config(%{enable_host_metrics: false}, &init_config/0)
+        == default_configuration() |> Map.put(:enable_host_metrics, false)
     end
 
     test "endpoint" do
-      add_to_application_env(:endpoint, "https://push.staging.lol")
-      assert default_configuration() |> Map.put(:endpoint, "https://push.staging.lol") == init_config()
+      assert with_config(%{endpoint: "https://push.staging.lol"}, &init_config/0)
+        == default_configuration() |> Map.put(:endpoint, "https://push.staging.lol")
     end
 
     test "env" do
-      add_to_application_env(:env, :prod)
-      assert default_configuration() |> Map.put(:env, :prod) == init_config()
+      assert with_config(%{env: :prod}, &init_config/0)
+        == default_configuration() |> Map.put(:env, :prod)
     end
 
     test "filter_parameters" do
-      add_to_application_env(:filter_parameters, ~w(password secret))
-      assert default_configuration() |> Map.put(:filter_parameters, ~w(password secret)) == init_config()
+      assert with_config(%{filter_parameters: ~w(password secret)}, &init_config/0)
+        == default_configuration() |> Map.put(:filter_parameters, ~w(password secret))
     end
 
     test "frontend_error_catching_path" do
-      add_to_application_env(:frontend_error_catching_path, "/appsignal_error_catcher")
-      assert default_configuration() |> Map.put(:frontend_error_catching_path, "/appsignal_error_catcher") == init_config()
+      assert with_config(%{frontend_error_catching_path: "/appsignal_error_catcher"}, &init_config/0)
+        == default_configuration() |> Map.put(:frontend_error_catching_path, "/appsignal_error_catcher")
     end
 
     test "hostname" do
-      add_to_application_env(:hostname, "Bobs-MPB.example.com")
-      assert default_configuration() |> Map.put(:hostname, "Bobs-MPB.example.com") == init_config()
+      assert with_config(%{hostname: "Bobs-MBP.example.com"}, &init_config/0)
+        == default_configuration() |> Map.put(:hostname, "Bobs-MBP.example.com")
     end
 
     test "http_proxy" do
-      add_to_application_env(:http_proxy, "http://10.10.10.10:8888")
-      assert default_configuration() |> Map.put(:http_proxy, "http://10.10.10.10:8888") == init_config()
+      assert with_config(%{http_proxy: "http://10.10.10.10:8888"}, &init_config/0)
+        == default_configuration() |> Map.put(:http_proxy, "http://10.10.10.10:8888")
     end
 
     test "ignore_actions" do
       actions = ~w(
-        ExampleApplication.PageController#ignored
-        ExampleApplication.PageController#also_ignored
+          ExampleApplication.PageController#ignored
+          ExampleApplication.PageController#also_ignored
       )
-      add_to_application_env(:ignore_actions, actions)
-      assert default_configuration() |> Map.put(:ignore_actions, actions) == init_config()
+
+      assert with_config(%{ignore_actions: actions}, &init_config/0)
+        == default_configuration() |> Map.put(:ignore_actions, actions)
     end
 
     test "ignore_errors" do
       errors = ~w(VerySpecificError AnotherError)
-      add_to_application_env(:ignore_errors, errors)
-      assert default_configuration() |> Map.put(:ignore_errors, errors) == init_config()
+
+      assert with_config(%{ignore_errors: errors}, &init_config/0)
+        == default_configuration() |> Map.put(:ignore_errors, errors)
     end
 
     test "log" do
-      add_to_application_env(:log, "stdout")
-      assert default_configuration() |> Map.put(:log, "stdout") == init_config()
+      assert with_config(%{log: "stdout"}, &init_config/0)
+        == default_configuration() |> Map.put(:log, "stdout")
     end
 
     test "log_path" do
-      add_to_application_env(:log_path, "log/appsignal.log")
-      assert default_configuration() |> Map.put(:log_path, "log/appsignal.log") == init_config()
+      assert with_config(%{log_path: "log/appsignal.log"}, &init_config/0)
+        == default_configuration() |> Map.put(:log_path, "log/appsignal.log")
     end
 
     test "name" do
-      add_to_application_env(:name, "my application")
-      assert default_configuration() |> Map.put(:name, "my application") == init_config()
+      assert with_config(%{name: "my_application"}, &init_config/0)
+        == default_configuration() |> Map.put(:name, "my_application")
     end
 
     test "push_api_key" do
-      add_to_application_env(:push_api_key, "00000000-0000-0000-0000-000000000000")
-      assert valid_configuration() |> Map.put(:active, false) == init_config()
+      assert with_config(%{push_api_key: "00000000-0000-0000-0000-000000000000"}, &init_config/0)
+        == valid_configuration() |> Map.put(:active, false)
     end
 
     test "running_in_container" do
-      add_to_application_env(:running_in_container, true)
-      assert default_configuration() |> Map.put(:running_in_container, true) == init_config()
+      assert with_config(%{running_in_container: true}, &init_config/0)
+        == default_configuration() |> Map.put(:running_in_container, true)
     end
 
     test "send_params" do
-      add_to_application_env(:send_params, true)
-      assert default_configuration() |> Map.put(:send_params, true) == init_config()
+      assert with_config(%{send_params: true}, &init_config/0)
+        == default_configuration() |> Map.put(:send_params, true)
     end
 
     test "skip_session_data" do
-      add_to_application_env(:skip_session_data, true)
-      assert default_configuration() |> Map.put(:skip_session_data, true) == init_config()
+      assert with_config(%{skip_session_data: true}, &init_config/0)
+        == default_configuration() |> Map.put(:skip_session_data, true)
     end
 
     test "working_dir_path" do
-      add_to_application_env(:working_dir_path, "/tmp/appsignal")
-      assert default_configuration() |> Map.put(:working_dir_path, "/tmp/appsignal") == init_config()
+      assert with_config(%{working_dir_path: "/tmp/appsignal"}, &init_config/0)
+        == default_configuration() |> Map.put(:working_dir_path, "/tmp/appsignal")
     end
   end
 
   describe "using the system environment" do
     test "active" do
-      System.put_env("APPSIGNAL_ACTIVE", "true")
-      assert default_configuration() |> Map.put(:active, true) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_ACTIVE" => "true"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:active, true)
     end
 
     test "ca_file_path" do
-      System.put_env("APPSIGNAL_CA_FILE_PATH", "/foo/bar/baz.ca")
-      assert default_configuration() |> Map.put(:ca_file_path, "/foo/bar/baz.ca") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_CA_FILE_PATH" => "/foo/bar/baz.ca"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:ca_file_path, "/foo/bar/baz.ca")
     end
 
     test "debug" do
-      System.put_env("APPSIGNAL_DEBUG", "true")
-      assert default_configuration() |> Map.put(:debug, true) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_DEBUG" => "true"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:debug, true)
     end
 
     test "enable_host_metrics" do
-      System.put_env("APPSIGNAL_ENABLE_HOST_METRICS", "false")
-      assert default_configuration() |> Map.put(:enable_host_metrics, false) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_ENABLE_HOST_METRICS" => "false"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:enable_host_metrics, false)
     end
 
     test "endpoint" do
-      System.put_env("APPSIGNAL_PUSH_API_ENDPOINT", "https://push.staging.lol")
-      assert default_configuration() |> Map.put(:endpoint, "https://push.staging.lol") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_PUSH_API_ENDPOINT" => "https://push.staging.lol"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:endpoint, "https://push.staging.lol")
     end
 
     test "env" do
-      System.put_env("APPSIGNAL_APP_ENV", "prod")
-      assert default_configuration() |> Map.put(:env, :prod) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_APP_ENV" => "prod"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:env, :prod)
     end
 
     test "filter_parameters" do
-      System.put_env("APPSIGNAL_FILTER_PARAMETERS", "password,secret")
-      assert default_configuration() |> Map.put(:filter_parameters, ~w(password secret)) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_FILTER_PARAMETERS" => "password,secret"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:filter_parameters, ~w(password secret))
     end
 
     test "frontend_error_catching_path" do
-      System.put_env("APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH", "/appsignal_error_catcher")
-      assert default_configuration() |> Map.put(:frontend_error_catching_path, "/appsignal_error_catcher") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH" => "/appsignal_error_catcher"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:frontend_error_catching_path, "/appsignal_error_catcher")
     end
 
     test "hostname" do
-      System.put_env("APPSIGNAL_HOSTNAME", "Bobs-MBP.example.com")
-      assert default_configuration() |> Map.put(:hostname, "Bobs-MBP.example.com") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_HOSTNAME" => "Bobs-MBP.example.com"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:hostname, "Bobs-MBP.example.com")
     end
 
     test "http_proxy" do
-      System.put_env("APPSIGNAL_HTTP_PROXY", "http://10.10.10.10:8888")
-      assert default_configuration() |> Map.put(:http_proxy, "http://10.10.10.10:8888") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_HTTP_PROXY" => "http://10.10.10.10:8888"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:http_proxy, "http://10.10.10.10:8888")
     end
 
     test "ignore_actions" do
-      System.put_env("APPSIGNAL_IGNORE_ACTIONS", "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored")
-      actions = ~w(
+      assert with_env(
+        %{"APPSIGNAL_IGNORE_ACTIONS" => "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:ignore_actions, ~w(
           ExampleApplication.PageController#ignored
           ExampleApplication.PageController#also_ignored
-      )
-      assert default_configuration() |> Map.put(:ignore_actions, actions) == init_config()
+      ))
     end
 
     test "ignore_errors" do
-      System.put_env("APPSIGNAL_IGNORE_ERRORS", "VerySpecificError,AnotherError")
-      errors = ~w(VerySpecificError AnotherError)
-      assert default_configuration() |> Map.put(:ignore_errors, errors) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_IGNORE_ERRORS" => "VerySpecificError,AnotherError"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:ignore_errors, ~w(VerySpecificError AnotherError))
     end
 
     test "log" do
-      System.put_env("APPSIGNAL_LOG", "stdout")
-      assert default_configuration() |> Map.put(:log, "stdout") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_LOG" => "stdout"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:log, "stdout")
     end
 
     test "log_path" do
-      System.put_env("APPSIGNAL_LOG_PATH", "log/appsignal.log")
-      assert default_configuration() |> Map.put(:log_path, "log/appsignal.log") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_LOG_PATH" => "log/appsignal.log"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:log_path, "log/appsignal.log")
     end
 
     test "name" do
-      System.put_env("APPSIGNAL_APP_NAME", "my_application")
-      assert default_configuration() |> Map.put(:name, "my_application") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_APP_NAME" => "my_application"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:name, "my_application")
     end
 
     test "push_api_key" do
-      System.put_env("APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000")
-      assert valid_configuration() == init_config()
-      assert init_config()[:active] == true
+      assert with_env(
+        %{"APPSIGNAL_PUSH_API_KEY" => "00000000-0000-0000-0000-000000000000"},
+        &init_config/0
+      ) == valid_configuration()
     end
 
     test "running_in_container" do
-      System.put_env("APPSIGNAL_RUNNING_IN_CONTAINER", "true")
-      assert default_configuration() |> Map.put(:running_in_container, true) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_RUNNING_IN_CONTAINER" => "true"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:running_in_container, true)
     end
 
     test "send_params" do
-      System.put_env("APPSIGNAL_SEND_PARAMS", "true")
-      assert default_configuration() |> Map.put(:send_params, true) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_SEND_PARAMS" => "true"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:send_params, true)
     end
 
     test "skip_session_data" do
-      System.put_env("APPSIGNAL_SKIP_SESSION_DATA", "true")
-      assert default_configuration() |> Map.put(:skip_session_data, true) == init_config()
+      assert with_env(
+        %{"APPSIGNAL_SKIP_SESSION_DATA" => "true"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:skip_session_data, true)
     end
 
     test "working_dir_path" do
-      System.put_env("APPSIGNAL_WORKING_DIR_PATH", "/tmp/appsignal")
-      assert default_configuration() |> Map.put(:working_dir_path, "/tmp/appsignal") == init_config()
+      assert with_env(
+        %{"APPSIGNAL_WORKING_DIR_PATH" => "/tmp/appsignal"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:working_dir_path, "/tmp/appsignal")
     end
   end
 
   test "system environment overwrites application environment configuration" do
-    System.put_env("APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000")
-    assert valid_configuration() |> Map.put(:active, true) == init_config()
+    assert with_env(
+      %{"APPSIGNAL_PUSH_API_KEY" => "00000000-0000-0000-0000-000000000000"},
+      &init_config/0
+    ) == valid_configuration() |> Map.put(:active, true)
 
-    clear_env()
-
-    Application.put_env(:appsignal, :config, active: false)
-    System.put_env("APPSIGNAL_PUSH_API_KEY", "00000000-0000-0000-0000-000000000000")
-    assert valid_configuration() |> Map.put(:active, false) == init_config()
+    assert with_config(%{active: false}, fn() ->
+      with_env(
+        %{"APPSIGNAL_PUSH_API_KEY" => "00000000-0000-0000-0000-000000000000"},
+        &init_config/0
+      )
+    end) == valid_configuration() |> Map.put(:active, false)
   end
 
   describe "when on Heroku" do
     setup do
-      System.put_env("DYNO", "web.1")
+      setup_with_env(%{"DYNO" => "web.1"})
     end
 
     test ":running_in_container and :log" do
@@ -291,35 +338,33 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "application environment overwrites :running_in_container config on Heroku" do
-      Application.put_env :appsignal, :config, running_in_container: false
-      config = default_configuration()
-      |> Map.put(:running_in_container, false)
-      |> Map.put(:log, "stdout")
-      assert config == init_config()
+      assert with_config(%{running_in_container: false}, &init_config/0) ==
+        default_configuration()
+        |> Map.put(:running_in_container, false)
+        |> Map.put(:log, "stdout")
     end
 
     test "application environment overwrites :log config on Heroku" do
-      Application.put_env :appsignal, :config, log: "file"
-      config = default_configuration()
-      |> Map.put(:running_in_container, true)
-      |> Map.put(:log, "file")
-      assert config == init_config()
+      assert with_config(%{log: "file"}, &init_config/0) ==
+        default_configuration()
+        |> Map.put(:running_in_container, true)
+        |> Map.put(:log, "file")
     end
   end
 
   describe "reset_environment_config!" do
     test "deletes existing configuration in environment" do
-      System.put_env("_APPSIGNAL_APP_NAME", "foo")
-      Appsignal.Config.reset_environment_config!
-      assert System.get_env("_APPSIGNAL_APP_NAME") == nil
+      assert with_env(
+        %{"_APPSIGNAL_APP_NAME" => "foo"},
+        fn() ->
+          Appsignal.Config.reset_environment_config!
+          System.get_env("_APPSIGNAL_APP_NAME")
+        end
+      ) == nil
     end
   end
 
   describe "write_to_environment" do
-    setup do
-      Application.put_env(:appsignal, :config, [])
-    end
-
     defp write_to_environment do
       init_config()
       Appsignal.Config.write_to_environment
@@ -339,71 +384,80 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "deletes existing configuration in environment" do
-      # Name is present in the configuration
-      System.put_env("_APPSIGNAL_APP_NAME", "foo")
-      # The new config doesn't have a name
-      add_to_application_env(:name, "")
-      write_to_environment()
-      # So it doesn't get written to the new agent environment configuration
-      assert System.get_env("_APPSIGNAL_APP_NAME") == nil
+      with_env(
+        # Name is present in the configuration
+        %{"_APPSIGNAL_APP_NAME" => "foo"},
+        fn() ->
+          # The new config doesn't have a name
+          with_config(%{name: ""}, fn() ->
+            write_to_environment()
+            # So it doesn't get written to the new agent environment configuration
+            assert System.get_env("_APPSIGNAL_APP_NAME")  == nil
+          end)
+      end)
     end
 
     test "writes valid AppSignal config options to the env" do
-      add_to_application_env(:active, true)
-      add_to_application_env(:ca_file_path, "/foo/bar/zab.ca")
-      add_to_application_env(:debug, true)
-      add_to_application_env(:enable_host_metrics, false)
-      add_to_application_env(:endpoint, "https://push.staging.lol")
-      add_to_application_env(:env, :prod)
-      add_to_application_env(:filter_parameters, ~w(password secret))
-      add_to_application_env(:push_api_key, "00000000-0000-0000-0000-000000000000")
-      add_to_application_env(:hostname, "My hostname")
-      add_to_application_env(:http_proxy, "http://10.10.10.10:8888")
-      add_to_application_env :ignore_actions, ~w(
-        ExampleApplication.PageController#ignored
-        ExampleApplication.PageController#also_ignored
-      )
-      add_to_application_env(:ignore_errors, ~w(VerySpecificError AnotherError))
-      add_to_application_env(:log, "stdout")
-      add_to_application_env(:log_path, "log/appsignal.log")
-      add_to_application_env(:name, "My awesome app")
-      add_to_application_env(:running_in_container, false)
-      add_to_application_env(:working_dir_path, "/tmp/appsignal")
-      write_to_environment()
+      with_config(%{
+        active: true,
+        ca_file_path: "/foo/bar/zab.ca",
+        debug: true,
+        enable_host_metrics: false,
+        endpoint: "https://push.staging.lol",
+        env: :prod,
+        filter_parameters: ~w(password secret),
+        push_api_key: "00000000-0000-0000-0000-000000000000",
+        hostname: "My hostname",
+        http_proxy: "http://10.10.10.10:8888",
+        ignore_actions: ~w(
+          ExampleApplication.PageController#ignored
+          ExampleApplication.PageController#also_ignored
+        ),
+        ignore_errors: ~w(VerySpecificError AnotherError),
+        log: "stdout",
+        log_path: "log/appsignal.log",
+        name: "My awesome app",
+        running_in_container: false,
+        working_dir_path: "/tmp/appsignal"
+      }, fn() ->
+        write_to_environment()
 
-      assert System.get_env("_APPSIGNAL_ACTIVE") == "true"
-      assert System.get_env("_APPSIGNAL_AGENT_PATH") == List.to_string(:code.priv_dir(:appsignal))
-      assert System.get_env("_APPSIGNAL_AGENT_VERSION") == Appsignal.Agent.version
-      assert System.get_env("_APPSIGNAL_APP_NAME") == "My awesome app"
-      assert System.get_env("_APPSIGNAL_CA_FILE_PATH") == "/foo/bar/zab.ca"
-      assert System.get_env("_APPSIGNAL_DEBUG_LOGGING") == "true"
-      assert System.get_env("_APPSIGNAL_ENABLE_HOST_METRICS") == "false"
-      assert System.get_env("_APPSIGNAL_ENVIRONMENT") == "prod"
-      assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == "password,secret"
-      assert System.get_env("_APPSIGNAL_HOSTNAME") == "My hostname"
-      assert System.get_env("_APPSIGNAL_HTTP_PROXY") == "http://10.10.10.10:8888"
-      assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"
-      assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == "VerySpecificError,AnotherError"
-      assert System.get_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION") == "elixir-" <> Mix.Project.config[:version]
-      assert System.get_env("_APPSIGNAL_LOG") == "stdout"
-      assert System.get_env("_APPSIGNAL_LOG_FILE_PATH") == "log/appsignal.log"
-      assert System.get_env("_APPSIGNAL_PUSH_API_ENDPOINT") == "https://push.staging.lol"
-      assert System.get_env("_APPSIGNAL_PUSH_API_KEY") == "00000000-0000-0000-0000-000000000000"
-      assert System.get_env("_APPSIGNAL_RUNNING_IN_CONTAINER") == "false"
-      assert System.get_env("_APPSIGNAL_SEND_PARAMS") == "true"
-      assert System.get_env("_APPSIGNAL_WORKING_DIR_PATH") == "/tmp/appsignal"
+        assert System.get_env("_APPSIGNAL_ACTIVE") == "true"
+        assert System.get_env("_APPSIGNAL_AGENT_PATH") == List.to_string(:code.priv_dir(:appsignal))
+        assert System.get_env("_APPSIGNAL_AGENT_VERSION") == Appsignal.Agent.version
+        assert System.get_env("_APPSIGNAL_APP_NAME") == "My awesome app"
+        assert System.get_env("_APPSIGNAL_CA_FILE_PATH") == "/foo/bar/zab.ca"
+        assert System.get_env("_APPSIGNAL_DEBUG_LOGGING") == "true"
+        assert System.get_env("_APPSIGNAL_ENABLE_HOST_METRICS") == "false"
+        assert System.get_env("_APPSIGNAL_ENVIRONMENT") == "prod"
+        assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == "password,secret"
+        assert System.get_env("_APPSIGNAL_HOSTNAME") == "My hostname"
+        assert System.get_env("_APPSIGNAL_HTTP_PROXY") == "http://10.10.10.10:8888"
+        assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"
+        assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == "VerySpecificError,AnotherError"
+        assert System.get_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION") == "elixir-" <> Mix.Project.config[:version]
+        assert System.get_env("_APPSIGNAL_LOG") == "stdout"
+        assert System.get_env("_APPSIGNAL_LOG_FILE_PATH") == "log/appsignal.log"
+        assert System.get_env("_APPSIGNAL_PUSH_API_ENDPOINT") == "https://push.staging.lol"
+        assert System.get_env("_APPSIGNAL_PUSH_API_KEY") == "00000000-0000-0000-0000-000000000000"
+        assert System.get_env("_APPSIGNAL_RUNNING_IN_CONTAINER") == "false"
+        assert System.get_env("_APPSIGNAL_SEND_PARAMS") == "true"
+        assert System.get_env("_APPSIGNAL_WORKING_DIR_PATH") == "/tmp/appsignal"
+      end)
     end
 
     test "name as atom" do
-      add_to_application_env(:name, :my_application)
-      write_to_environment()
-      assert System.get_env("_APPSIGNAL_APP_NAME") == "my_application"
+      with_config(%{name: :my_application}, fn() ->
+        write_to_environment()
+        assert System.get_env("_APPSIGNAL_APP_NAME") == "my_application"
+      end)
     end
 
     test "name as string" do
-      add_to_application_env(:name, "My awesome application")
-      write_to_environment()
-      assert System.get_env("_APPSIGNAL_APP_NAME") == "My awesome application"
+      with_config(%{name: "My awesome application"}, fn() ->
+        write_to_environment()
+        assert System.get_env("_APPSIGNAL_APP_NAME") == "My awesome application"
+      end)
     end
   end
 
@@ -430,12 +484,6 @@ defmodule Appsignal.ConfigTest do
     |> Map.put(:active, true)
     |> Map.put(:valid, true)
     |> Map.put(:push_api_key, "00000000-0000-0000-0000-000000000000")
-  end
-
-  defp add_to_application_env(key, value) do
-    Application.put_env(:appsignal, :config,
-      Application.get_env(:appsignal, :config) ++ [{key, value}]
-    )
   end
 
   defp init_config() do

--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -1,34 +1,38 @@
 defmodule Appsignal.ReleaseUpgradeTest do
   use ExUnit.Case
-
   use Appsignal.Config
+
+  import AppsignalTest.Utils
 
   test "config_change/3" do
     assert System.get_env("_APPSIGNAL_APP_NAME") == nil
-    Application.put_env(:appsignal, :config, valid_configuration())
-    # First start
-    # Basically the contents of `Appsignal.initialize`
-    Appsignal.initialize
 
-    # Sets config to Application environment
-    assert config()[:name] == "My app v1"
-    # Sets config to system environment variables
-    assert System.get_env("_APPSIGNAL_APP_NAME") == "My app v1"
+    with_config(valid_configuration(), fn() ->
+      # First start
+      # Basically the contents of `Appsignal.initialize`
+      Appsignal.initialize
 
-    # The system reloads the application config (set in Mix) during the upgrade.
-    new_config = valid_configuration()
-    |> Map.put(:name, "My app v2")
-    Application.put_env(:appsignal, :config, new_config)
+      # Sets config to Application environment
+      assert config()[:name] == "My app v1"
+      # Sets config to system environment variables
+      assert System.get_env("_APPSIGNAL_APP_NAME") == "My app v1"
 
-    # Hot reload / upgrade
-    config_reload_pid = Appsignal.config_change([], [], [])
-    # The config is reloaded in a separate process so we wait for it here
-    assert Process.alive?(config_reload_pid)
-    :timer.sleep 3500
-    refute Process.alive?(config_reload_pid)
+      # The system reloads the application config (set in Mix) during the upgrade.
+      new_config = valid_configuration()
+      |> Map.put(:name, "My app v2")
 
-    assert config()[:name] == "My app v2"
-    assert System.get_env("_APPSIGNAL_APP_NAME") == "My app v2"
+      with_config(new_config, fn() ->
+        # Hot reload / upgrade
+        config_reload_pid = Appsignal.config_change([], [], [])
+        # The config is reloaded in a separate process so we wait for it here
+        assert Process.alive?(config_reload_pid)
+        :timer.sleep 3500
+        refute Process.alive?(config_reload_pid)
+
+        assert config()[:name] == "My app v2"
+        assert System.get_env("_APPSIGNAL_APP_NAME") == "My app v2"
+      end)
+    end)
   end
 
   def valid_configuration do

--- a/test/appsignal/system_test.exs
+++ b/test/appsignal/system_test.exs
@@ -2,6 +2,7 @@ defmodule Appsignal.SystemTest do
   use ExUnit.Case, async: false
 
   import Mock
+  import AppsignalTest.Utils
 
   test "hostname_with_domain" do
     with_mocks([
@@ -22,26 +23,17 @@ defmodule Appsignal.SystemTest do
     end
   end
 
-  describe "when on Heroku" do
-    setup do
-      System.put_env "DYNO", "1"
-      on_exit fn ->
-        System.delete_env "DYNO"
-      end
-    end
-
-    test "returns true" do
-      assert Appsignal.System.heroku?
+  describe "when not on Heroku" do
+    test "returns false" do
+      refute Appsignal.System.heroku?
     end
   end
 
-  describe "when not on Heroku" do
-    setup do
-      System.delete_env "DYNO"
-    end
+  describe "when on Heroku" do
+    setup do: setup_with_env(%{"DYNO" => "1"})
 
-    test "returns false" do
-      refute Appsignal.System.heroku?
+    test "returns true" do
+      assert Appsignal.System.heroku?
     end
   end
 end

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -1,27 +1,28 @@
 defmodule Appsignal.Transaction.FilterTest do
   use ExUnit.Case
   alias Appsignal.Config
-
   alias Appsignal.Utils.ParamsFilter
+
+  import AppsignalTest.Utils
 
   describe "parameter filtering" do
     test "uses parameter filters from the appsignal config" do
-      with_app_config(:appsignal, :config, [filter_parameters: ["password"]], fn() ->
+      with_config(%{filter_parameters: ["password"]}, fn() ->
         Config.initialize()
         assert ParamsFilter.get_filter_parameters() == ["password"]
       end)
     end
 
     test "uses parameter filters from the phoenix config" do
-      with_app_config(:phoenix, :filter_parameters, ["secret1"], fn() ->
+      with_config(%{filter_parameters: ["secret1"]}, fn() ->
         Config.initialize()
         assert ParamsFilter.get_filter_parameters() == ["secret1"]
       end)
     end
 
     test "appsignal's paramter filters override Phoenix' parameter filters" do
-      with_app_config(:phoenix, :config, [filter_parameters: ["secret1"]], fn() ->
-        with_app_config(:appsignal, :config, [filter_parameters: ["secret2"]], fn() ->
+      with_config_for(:phoenix, %{filter_parameters: ["secret1"]}, fn() ->
+        with_config(%{filter_parameters: ["secret2"]}, fn() ->
           Config.initialize()
           assert ParamsFilter.get_filter_parameters() == ["secret2"]
         end)
@@ -29,11 +30,10 @@ defmodule Appsignal.Transaction.FilterTest do
     end
 
     test "uses filter parameters from the OS environment" do
-      System.put_env("APPSIGNAL_FILTER_PARAMETERS", "foo,bar")
-      Config.initialize()
-      assert ParamsFilter.get_filter_parameters() == ["foo", "bar"]
-      System.delete_env("APPSIGNAL_FILTER_PARAMETERS")
-      Application.delete_env(:appsignal, :config)
+      with_env(%{"APPSIGNAL_FILTER_PARAMETERS" => "foo,bar"}, fn() ->
+        Config.initialize()
+        assert ParamsFilter.get_filter_parameters() == ["foo", "bar"]
+      end)
     end
 
     test "filter_values" do
@@ -68,13 +68,4 @@ defmodule Appsignal.Transaction.FilterTest do
         %{:foo => "bar", "password" => "[FILTERED]"}
     end
   end
-
-
-  defp with_app_config(app, key, value, function) do
-    Application.put_env(app, key, value)
-    function.()
-    Application.delete_env(app, key)
-    System.delete_env("APPSIGNAL_FILTER_PARAMETERS")
-  end
-
 end

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -21,7 +21,7 @@ defmodule Appsignal.Transaction.FilterTest do
     end
 
     test "appsignal's paramter filters override Phoenix' parameter filters" do
-      with_config_for(:phoenix, %{filter_parameters: ["secret1"]}, fn() ->
+      with_config(:phoenix, %{filter_parameters: ["secret1"]}, fn() ->
         with_config(%{filter_parameters: ["secret2"]}, fn() ->
           Config.initialize()
           assert ParamsFilter.get_filter_parameters() == ["secret2"]

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -114,12 +114,10 @@ defmodule AppsignalTransactionTest do
 
     @tag :skip_env_test_no_nif
     @tag :skip_env_test
-    test_with_mock "send session data", context, Appsignal.Transaction, [:passthrough], [] do
-      transaction = with_config(%{skip_session_data: false}, fn() ->
-        "test5"
-        |> Transaction.start(:http_request)
-        |> Transaction.set_request_metadata(context[:conn])
-      end)
+    test_with_mock "sends session data", context, Appsignal.Transaction, [:passthrough], [] do
+      transaction = "test5"
+      |> Transaction.start(:http_request)
+      |> Transaction.set_request_metadata(context[:conn])
 
       assert called Transaction.set_sample_data(
         transaction, "session_data", context[:conn].private.plug_session
@@ -128,7 +126,21 @@ defmodule AppsignalTransactionTest do
 
     @tag :skip_env_test_no_nif
     @tag :skip_env_test
-    test_with_mock "does not send session data", context, Appsignal.Transaction, [:passthrough], [] do
+    test_with_mock "sends session data when skip_session_data is false", context, Appsignal.Transaction, [:passthrough], [] do
+      transaction = with_config(%{skip_session_data: false}, fn() ->
+        "test5"
+        |> Transaction.start(:http_request)
+        |> Transaction.set_request_metadata(context[:conn])
+      end)
+
+      assert called Appsignal.Transaction.set_sample_data(
+        transaction, "session_data", context[:conn].private.plug_session
+      )
+    end
+
+    @tag :skip_env_test_no_nif
+    @tag :skip_env_test
+    test_with_mock "does not send session data when skip_session_data is true", context, Appsignal.Transaction, [:passthrough], [] do
       transaction = with_config(%{skip_session_data: true}, fn() ->
         "test5"
         |> Transaction.start(:http_request)

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -17,8 +17,6 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     # By default use the same as the actual state of the Nif
     @nif.set(:loaded?, Appsignal.Nif.loaded?)
 
-    clear_env()
-
     # By default, Push API key is valid
     bypass = Bypass.open
     setup_with_config(%{

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -21,7 +21,10 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
     # By default, Push API key is valid
     bypass = Bypass.open
-    merge_appsignal_config %{endpoint: "http://localhost:#{bypass.port}"}
+    setup_with_config(%{
+      endpoint: "http://localhost:#{bypass.port}"
+    })
+
     Bypass.expect bypass, fn conn ->
       assert "/1/auth" == conn.request_path
       assert "GET" == conn.method
@@ -138,8 +141,8 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   describe "when config is not active" do
     test "runs agent in diagnose mode, but doesn't change the active state" do
       @nif.set(:run_diagnose, true)
-      merge_appsignal_config %{active: false}
-      output = run()
+
+      output = with_config(%{active: false}, &run/0)
       assert String.contains? output, "active: false"
       assert String.contains? output, "Agent diagnostics"
       assert String.contains? output, "  Extension config: valid"
@@ -260,7 +263,8 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
   describe "with invalid Push API key" do
     setup %{bypass: bypass} do
-      merge_appsignal_config %{push_api_key: ""}
+      setup_with_config(%{push_api_key: ""})
+
       Bypass.expect bypass, fn conn ->
         assert "/1/auth" == conn.request_path
         assert "GET" == conn.method
@@ -277,8 +281,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
   describe "without config" do
     test "it outputs tmp dir for log_dir_path" do
-      merge_appsignal_config %{log_path: nil}
-      output = run()
+      output = with_config(%{log_path: nil}, &run/0)
       assert String.contains? output, "Paths"
       assert String.contains? output, "log_dir_path: /tmp"
       assert String.contains? output, "log_file_path: /tmp/appsignal.log"
@@ -311,8 +314,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
   describe "when log_dir_path does not exist" do
     test "outputs exists: false" do
-      merge_appsignal_config %{log_path: "/foo/bar/baz.log"}
-      output = run()
+      output = with_config(%{log_path: "/foo/bar/baz.log"}, &run/0)
 
       assert String.contains? output, "log_dir_path: /foo/bar\n    - Exists?: no"
       assert String.contains? output, "log_file_path: /foo/bar/baz.log\n    - Exists?: no"
@@ -331,7 +333,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       File.mkdir_p!(log_dir_path)
       File.touch!(log_file_path)
       File.chmod!(log_dir_path, 0o400)
-      merge_appsignal_config %{log_path: log_file_path}
+      setup_with_config(%{log_path: log_file_path})
 
       {:ok, %{log_dir_path: log_dir_path, log_file_path: log_file_path}}
     end
@@ -374,14 +376,6 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       end
   end
 
-  defp appsignal_config do
-    Application.get_env(:appsignal, :config, %{})
-  end
-
-  defp merge_appsignal_config(config) do
-    Application.put_env(:appsignal, :config, Map.merge(appsignal_config(), config))
-  end
-
   defp prepare_tmp_dir(path) do
     log_dir_path = Path.expand("tmp/#{path}", File.cwd!)
     log_file_path = Path.expand("appsignal.log", log_dir_path)
@@ -390,7 +384,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     end
 
     File.mkdir_p!(log_dir_path)
-    merge_appsignal_config %{log_path: log_file_path}
+    setup_with_config(%{log_path: log_file_path})
 
     %{log_dir_path: log_dir_path, log_file_path: log_file_path}
   end

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -1,19 +1,17 @@
 defmodule Mix.Tasks.Appsignal.InstallTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
+  import AppsignalTest.Utils
 
   @demo Application.get_env(:appsignal, :appsignal_demo, Appsignal.Demo)
 
   setup do
     @demo.start_link
-    original_config = Application.get_env(:appsignal, :config, %{})
 
     bypass = Bypass.open
-    System.put_env("APPSIGNAL_PUSH_API_ENDPOINT", "http://localhost:#{bypass.port}")
-
-    on_exit :reset_config, fn ->
-      Application.put_env(:appsignal, :config, original_config)
-    end
+    setup_with_env(%{
+      "APPSIGNAL_PUSH_API_ENDPOINT" => "http://localhost:#{bypass.port}"
+    })
 
     {:ok, %{bypass: bypass}}
   end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -1,67 +1,71 @@
 defmodule AppsignalTest.Utils do
-  def clear_env do
-    Application.delete_env(:appsignal, :config)
-
-    System.get_env
-    |> Enum.filter(
-      fn({"APPSIGNAL_" <> _, _}) -> true;
-      ({"_APPSIGNAL_" <> _, _}) -> true;
-      ({"APP_REVISION", _}) -> true;
-      ({"DYNO", _}) -> true;
-      (_) -> false end
-    ) |> Enum.each(fn({key, _}) ->
-      System.delete_env(key)
-    end)
-  end
-
-  def with_config_for(app, config, function) do
-    before = put_merged_config_for(app, config)
+  def with_frozen_environment(function) do
+    environment = freeze_environment()
     result = function.()
-    Application.put_env(app, :config, before)
+    unfreeze_environment(environment)
     result
   end
 
+  def freeze_environment do
+    {
+      Application.get_env(:appsignal, :config, %{}),
+      System.get_env
+    }
+  end
+
+  def unfreeze_environment({config, env}) do
+    Application.put_env(:appsignal, :config, config)
+    reset_env(env)
+  end
+
   def with_config(config, function) do
-    with_config_for(:appsignal, config, function)
+    with_config(:appsignal, config, function)
+  end
+
+  def with_config(app, config, function) do
+    with_frozen_environment(fn() ->
+      put_merged_config_for(app, config)
+      function.()
+    end)
   end
 
   defp put_merged_config_for(app, config) do
-    before = Application.get_env(app, :config, %{})
-    Application.put_env(app, :config, Map.merge(before, config))
-    before
+    config = app
+    |> Application.get_env(:config, %{})
+    |> Map.merge(config)
+
+    Application.put_env(app, :config, config)
   end
 
   def setup_with_config(config) do
-    before = put_merged_config_for(:appsignal, config)
+    environment = freeze_environment()
+    put_merged_config_for(:appsignal, config)
 
     ExUnit.Callbacks.on_exit fn() ->
-      Application.put_env(:appsignal, :config, before)
+      unfreeze_environment(environment)
     end
   end
 
   def with_env(env, function) do
-    before = put_merged_env(env)
-    result = function.()
-    reset_env(before)
-    result
+    with_frozen_environment(fn() ->
+      put_merged_env(env)
+      function.()
+    end)
   end
 
   def setup_with_env(env) do
-    before = put_merged_env(env)
+    environment = freeze_environment()
+    put_merged_env(env)
 
     ExUnit.Callbacks.on_exit fn() ->
-      reset_env(before)
+      unfreeze_environment(environment)
     end
   end
 
   defp put_merged_env(env) do
-    before = System.get_env
-
-    before
+    System.get_env
     |> Map.merge(env)
     |> System.put_env
-
-    before
   end
 
   defp reset_env(before) do

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -13,4 +13,16 @@ defmodule AppsignalTest.Utils do
       System.delete_env(key)
     end)
   end
+
+  def setup_with_env(env) do
+    before = System.get_env
+
+    before
+    |> Map.merge(env)
+    |> System.put_env
+
+    ExUnit.Callbacks.on_exit fn() ->
+      System.put_env(before)
+    end
+  end
 end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -14,15 +14,28 @@ defmodule AppsignalTest.Utils do
     end)
   end
 
+  def with_env(env, function) do
+    before = put_merged_env(env)
+    result = function.()
+    System.put_env(before)
+    result
+  end
+
   def setup_with_env(env) do
+    before = put_merged_env(env)
+
+    ExUnit.Callbacks.on_exit fn() ->
+      System.put_env(before)
+    end
+  end
+
+  defp put_merged_env(env) do
     before = System.get_env
 
     before
     |> Map.merge(env)
     |> System.put_env
 
-    ExUnit.Callbacks.on_exit fn() ->
-      System.put_env(before)
-    end
+    before
   end
 end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -15,8 +15,7 @@ defmodule AppsignalTest.Utils do
   end
 
   def with_config_for(app, config, function) do
-    before = Application.get_env(app, :config, %{})
-    Application.put_env(app, :config, Map.merge(before, config))
+    before = put_merged_config_for(app, config)
     result = function.()
     Application.put_env(app, :config, before)
     result
@@ -24,6 +23,20 @@ defmodule AppsignalTest.Utils do
 
   def with_config(config, function) do
     with_config_for(:appsignal, config, function)
+  end
+
+  defp put_merged_config_for(app, config) do
+    before = Application.get_env(app, :config, %{})
+    Application.put_env(app, :config, Map.merge(before, config))
+    before
+  end
+
+  def setup_with_config(config) do
+    before = put_merged_config_for(:appsignal, config)
+
+    ExUnit.Callbacks.on_exit fn() ->
+      Application.put_env(:appsignal, :config, before)
+    end
   end
 
   def with_env(env, function) do


### PR DESCRIPTION
Instead of calling `System.put_env` and `Application.put_env` all over the test suite, there are now a couple of helpers that update the system environment or application configuration, run a function, and put them back. This removes all occurrences of `System.put_env` and `Application.put_env` from the test suite, outside of the newly added helpers.