### PR TITLE
ErrorHandler handles errors in tuples

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -121,6 +121,9 @@ defmodule Appsignal.ErrorHandler do
     msg = Exception.message(r)
     {"#{inspect r.__struct__}", prefixed(message, msg)}
   end
+  def extract_reason_and_message({r = %{}, _}, message) do
+    extract_reason_and_message(r, message)
+  end
   def extract_reason_and_message({kind, _} = reason, message) do
     {inspect(kind), prefixed(message, inspect(reason))}
   end

--- a/test/appsignal/error_handler/error_extracter_test.exs
+++ b/test/appsignal/error_handler/error_extracter_test.exs
@@ -54,4 +54,19 @@ defmodule Appsignal.ErrorHandler.ErrorExtracterTest do
     assert "Foo error: protocol Enumerable not implemented for {:error, :foo}" == m
   end
 
+  @tuple_with_error_and_exception {
+    %RuntimeError{message: "Exception!"},
+    [
+      {AppsignalPhoenixExample.PageController, :"-exception/2-fun-0-", 0, [file: 'web/controllers/page_controller.ex', line: 18]},
+      {Task.Supervised, :do_apply, 2, [file: 'lib/task/supervised.ex', line: 85]},
+      {Task.Supervised, :reply, 5, [file: 'lib/task/supervised.ex', line: 36]},
+      {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}
+    ]
+  }
+
+  test "tuple with error struct and exception" do
+    {r, m} = ErrorHandler.extract_reason_and_message(@tuple_with_error_and_exception, "Foo error")
+    assert "RuntimeError" == r
+    assert "Foo error: Exception!" == m
+  end
 end


### PR DESCRIPTION
When an error is triggered from a Task, or another linked process:

    Task.async(fn ->
      raise("Exception")
    end)

The error looks like this:

    {
      %RuntimeError{message: "Exception!"},
      [
        {AppsignalPhoenixExample.PageController, :"-exception/2-fun-0-", 0, [file: 'web/controllers/page_controller.ex', line: 18]},
        {Task.Supervised, :do_apply, 2, [file: 'lib/task/supervised.ex', line: 85]},
        {Task.Supervised, :reply, 5, [file: 'lib/task/supervised.ex', line: 36]},
        {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}
      ]
    }

Appsignal.ErrorHandler.extract_reason_and_message/2 currectly returns
"%RuntimeError{message: "Exception!"}" as the name, and includes the
whole stacktrace in the description.

This patch changes the name to "RuntimeError", and the description to
"Process #PID<0.574.0> terminating: Exception!".