### PR TITLE
Plug support without Phoenix

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -34,6 +34,10 @@ defmodule Appsignal do
     Supervisor.start_link(children, [strategy: :one_for_one, name: Appsignal.Supervisor])
   end
 
+  def plug? do
+    Code.ensure_loaded?(Plug)
+  end
+
   def phoenix? do
     Code.ensure_loaded?(Phoenix)
   end

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -52,7 +52,7 @@ defmodule Appsignal.ErrorHandler do
     Logger.debug("Submitting #{inspect transaction}: #{message}")
     transaction
   end
-  if Appsignal.phoenix? do
+  if Appsignal.plug? do
     def submit_transaction(transaction, reason, message, stack, metadata, conn) do
       if conn do
         Transaction.set_request_metadata(transaction, conn)

--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -23,28 +23,6 @@ if Appsignal.phoenix? do
     @doc false
     defmacro __using__(_) do
       quote do
-        def call(conn, opts) do
-          try do
-            super(conn, opts)
-          catch
-            kind, reason ->
-              Plug.ErrorHandler.__catch__(conn, kind, reason, fn(conn, _exception) ->
-                stacktrace = System.stacktrace
-                import Appsignal.Phoenix
-                case {
-                  Appsignal.TransactionRegistry.lookup(self()),
-                  Appsignal.Plug.extract_error_metadata(reason, conn, stacktrace)
-                } do
-                  {nil, _} -> :skip
-                  {_, nil} -> :skip
-                  {transaction, {reason, message, stack, conn}} ->
-                    submit_http_error(reason, message, stack, transaction, conn)
-                end
-              end)
-          end
-        end
-
-        defoverridable [call: 2]
         use Appsignal.Plug
       end
     end
@@ -57,6 +35,8 @@ if Appsignal.phoenix? do
 
     @doc false
     def submit_http_error(reason, message, stack, transaction, conn) do
+      IO.warn "Appsignal.Phoenix.submit_http_error/5 is deprecated."
+
       @transaction.set_error(transaction, reason, message, stack)
       if @transaction.finish(transaction) == :sample do
         @transaction.set_request_metadata(transaction, conn)

--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -51,7 +51,7 @@ if Appsignal.phoenix? do
 
     @doc false
     def extract_error_metadata(reason, conn, stack) do
-      IO.warn "Appsignal.Phoenix.extract_error_metadata/3 is deprecated. Use Appsignal.Plug.extract_error_metadata/3 instead."
+      IO.warn "Appsignal.Phoenix.extract_error_metadata/3 is deprecated. Use Appsignal.Plug.extract_error_metadata/1 instead."
       Appsignal.Plug.extract_error_metadata(reason, conn, stack)
     end
 

--- a/lib/appsignal/phoenix.ex
+++ b/lib/appsignal/phoenix.ex
@@ -33,7 +33,7 @@ if Appsignal.phoenix? do
                 import Appsignal.Phoenix
                 case {
                   Appsignal.TransactionRegistry.lookup(self()),
-                  Appsignal.Phoenix.Plug.extract_error_metadata(reason, conn, stacktrace)
+                  Appsignal.Plug.extract_error_metadata(reason, conn, stacktrace)
                 } do
                   {nil, _} -> :skip
                   {_, nil} -> :skip
@@ -45,14 +45,14 @@ if Appsignal.phoenix? do
         end
 
         defoverridable [call: 2]
-        use Appsignal.Phoenix.Plug
+        use Appsignal.Plug
       end
     end
 
     @doc false
     def extract_error_metadata(reason, conn, stack) do
-      IO.warn "Appsignal.Phoenix.extract_error_metadata/3 is deprecated. Use Appsignal.Phoenix.Plug.extract_error_metadata/3 instead."
-      Appsignal.Phoenix.Plug.extract_error_metadata(reason, conn, stack)
+      IO.warn "Appsignal.Phoenix.extract_error_metadata/3 is deprecated. Use Appsignal.Plug.extract_error_metadata/3 instead."
+      Appsignal.Plug.extract_error_metadata(reason, conn, stack)
     end
 
     @doc false

--- a/lib/appsignal/phoenix/instrumenter.ex
+++ b/lib/appsignal/phoenix/instrumenter.ex
@@ -25,8 +25,8 @@ if Appsignal.phoenix? do
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 
     @doc false
-    def phoenix_controller_call(:start, _, args) do
-      @transaction.try_set_action(args[:conn])
+    def phoenix_controller_call(:start, _, %{conn: conn} = args) do
+      @transaction.set_action(Appsignal.Plug.extract_action(conn))
       {@transaction.start_event, args}
     end
 

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -1,47 +1,16 @@
 if Appsignal.plug? do
   defmodule Appsignal.Phoenix.Plug do
-    @moduledoc """
-    Plug handler for Phoenix requests
-    """
 
     defmacro __using__(_) do
+      IO.warn "Appsignal.Phoenix.Plug is deprecated. Use Appsignal.Plug instead."
       quote do
-        @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
-
-        def call(conn, opts) do
-          id = Logger.metadata()[:request_id] || @transaction.generate_id()
-          transaction = @transaction.start(id, :http_request)
-
-          conn = super(conn, opts)
-
-          @transaction.try_set_action(transaction, conn)
-          if @transaction.finish(transaction) == :sample do
-            @transaction.set_request_metadata(transaction, conn)
-          end
-
-          :ok = @transaction.complete(transaction)
-          conn
-        end
+        use Appsignal.Plug
       end
     end
 
-    @phoenix_message "HTTP request error"
-
-    @doc """
-    Returns a tuple with the exception's reason, message, stacktrace and the
-    conn when passing the exception, a conn, and a stacktrace.
-    """
-    def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason = %{}, conn: conn}, _conn, stack) do
-      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
-      {reason, message, stack, conn}
-    end
-    def extract_error_metadata(%{plug_status: s}, _conn, _stack) when s < 500 do
-      # Do not submit regular HTTP errors which have a status code
-      nil
-    end
     def extract_error_metadata(reason, conn, stack) do
-      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
-      {reason, message, stack, conn}
+      IO.warn "Appsignal.Phoenix.Plug.extract_error_metadata/3 is deprecated. Use Appsignal.Plug.extract_error_metadata/3 instead."
+      Appsignal.Plug.extract_error_metadata(reason, conn, stack)
     end
   end
 end

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -1,4 +1,4 @@
-if Appsignal.phoenix? do
+if Appsignal.plug? do
   defmodule Appsignal.Phoenix.Plug do
     @moduledoc """
     Plug handler for Phoenix requests

--- a/lib/appsignal/phoenix/plug.ex
+++ b/lib/appsignal/phoenix/plug.ex
@@ -9,7 +9,7 @@ if Appsignal.plug? do
     end
 
     def extract_error_metadata(reason, conn, stack) do
-      IO.warn "Appsignal.Phoenix.Plug.extract_error_metadata/3 is deprecated. Use Appsignal.Plug.extract_error_metadata/3 instead."
+      IO.warn "Appsignal.Phoenix.Plug.extract_error_metadata/3 is deprecated. Use Appsignal.Plug.extract_error_metadata/1 instead."
       Appsignal.Plug.extract_error_metadata(reason, conn, stack)
     end
   end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -66,6 +66,7 @@ if Appsignal.plug? do
     def extract_action(%Plug.Conn{private: %{phoenix_action: action, phoenix_controller: controller}}) do
       merge_action_and_controller(action, controller)
     end
+    def extract_action(%Plug.Conn{private: %{phoenix_endpoint: _}}), do: nil
     def extract_action(%Plug.Conn{method: method, request_path: path}) do
       "#{method} #{path}"
     end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -43,5 +43,9 @@ if Appsignal.plug? do
       {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
       {reason, message, stack, conn}
     end
+
+    def extract_action(%Plug.Conn{method: method, request_path: path}) do
+      "#{method} #{path}"
+    end
   end
 end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -15,12 +15,10 @@ if Appsignal.plug? do
           conn = try do
             super(conn, opts)
           catch
-            _kind, %RuntimeError{message: message} = error ->
+            _kind, error ->
+              {reason, message} = Appsignal.Plug.extract_error_metadata(error)
               @transaction.set_error(
-                transaction,
-                "RuntimeError",
-                "HTTP request error: #{message}",
-                System.stacktrace
+                transaction, reason, message, System.stacktrace
               )
 
               raise error

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -31,13 +31,20 @@ if Appsignal.plug? do
         end
 
         defp finish_with_conn(transaction, conn) do
-          @transaction.set_action(transaction, Appsignal.Plug.extract_action(conn))
+          try_set_action(transaction, conn)
           if @transaction.finish(transaction) == :sample do
             @transaction.set_request_metadata(transaction, conn)
           end
 
           :ok = @transaction.complete(transaction)
           conn
+        end
+
+        defp try_set_action(transaction, conn) do
+          case Appsignal.Plug.extract_action(conn) do
+            nil -> nil
+            action -> @transaction.set_action(transaction, action)
+          end
         end
       end
     end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -19,9 +19,13 @@ if Appsignal.plug? do
               Plug.ErrorHandler.__catch__(conn, kind, error, fn(conn, _exception) ->
                 case Appsignal.Plug.extract_error_metadata(error) do
                   {reason, message} ->
+                    @transaction.set_action(transaction, Appsignal.Plug.extract_action(conn))
                     @transaction.set_error(
                       transaction, reason, message, System.stacktrace
                     )
+                    @transaction.finish(transaction)
+                    @transaction.set_request_metadata(transaction, conn)
+                    :ok = @transaction.complete(transaction)
                   nil -> :ok
                 end
               end)

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -44,8 +44,21 @@ if Appsignal.plug? do
       {reason, message, stack, conn}
     end
 
+    def extract_action(%Plug.Conn{private: %{phoenix_action: action, phoenix_controller: controller}}) do
+      merge_action_and_controller(action, controller)
+    end
     def extract_action(%Plug.Conn{method: method, request_path: path}) do
       "#{method} #{path}"
+    end
+
+    defp merge_action_and_controller(action, controller) when is_atom(controller) do
+      merge_action_and_controller(
+        action,
+        controller |> Atom.to_string |> String.trim_leading("Elixir.")
+      )
+    end
+    defp merge_action_and_controller(action, controller) do
+      "#{controller}##{action}"
     end
   end
 end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -15,13 +15,13 @@ if Appsignal.plug? do
           conn = try do
             super(conn, opts)
           catch
-            _kind, error ->
-              {reason, message} = Appsignal.Plug.extract_error_metadata(error)
-              @transaction.set_error(
-                transaction, reason, message, System.stacktrace
-              )
-
-              raise error
+            kind, error->
+              Plug.ErrorHandler.__catch__(conn, kind, error, fn(conn, _exception) ->
+                {reason, message} = Appsignal.Plug.extract_error_metadata(error)
+                @transaction.set_error(
+                  transaction, reason, message, System.stacktrace
+                )
+              end)
           end
 
           @transaction.set_action(transaction, Appsignal.Plug.extract_action(conn))

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -14,7 +14,7 @@ if Appsignal.plug? do
 
           conn = super(conn, opts)
 
-          @transaction.try_set_action(transaction, conn)
+          @transaction.set_action(transaction, Appsignal.Plug.extract_action(conn))
           if @transaction.finish(transaction) == :sample do
             @transaction.set_request_metadata(transaction, conn)
           end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -15,12 +15,15 @@ if Appsignal.plug? do
           conn = try do
             super(conn, opts)
           catch
-            kind, error->
+            kind, error ->
               Plug.ErrorHandler.__catch__(conn, kind, error, fn(conn, _exception) ->
-                {reason, message} = Appsignal.Plug.extract_error_metadata(error)
-                @transaction.set_error(
-                  transaction, reason, message, System.stacktrace
-                )
+                case Appsignal.Plug.extract_error_metadata(error) do
+                  {reason, message} ->
+                    @transaction.set_error(
+                      transaction, reason, message, System.stacktrace
+                    )
+                  nil -> :ok
+                end
               end)
           end
 

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -1,0 +1,47 @@
+if Appsignal.plug? do
+  defmodule Appsignal.Plug do
+    @moduledoc """
+    Plug handler for Phoenix requests
+    """
+
+    defmacro __using__(_) do
+      quote do
+        @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
+
+        def call(conn, opts) do
+          id = Logger.metadata()[:request_id] || @transaction.generate_id()
+          transaction = @transaction.start(id, :http_request)
+
+          conn = super(conn, opts)
+
+          @transaction.try_set_action(transaction, conn)
+          if @transaction.finish(transaction) == :sample do
+            @transaction.set_request_metadata(transaction, conn)
+          end
+
+          :ok = @transaction.complete(transaction)
+          conn
+        end
+      end
+    end
+
+    @phoenix_message "HTTP request error"
+
+    @doc """
+    Returns a tuple with the exception's reason, message, stacktrace and the
+    conn when passing the exception, a conn, and a stacktrace.
+    """
+    def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason = %{}, conn: conn}, _conn, stack) do
+      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
+      {reason, message, stack, conn}
+    end
+    def extract_error_metadata(%{plug_status: s}, _conn, _stack) when s < 500 do
+      # Do not submit regular HTTP errors which have a status code
+      nil
+    end
+    def extract_error_metadata(reason, conn, stack) do
+      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, @phoenix_message)
+      {reason, message, stack, conn}
+    end
+  end
+end

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -7,9 +7,13 @@ defmodule Appsignal.TransactionBehaviour do
   @callback complete() :: :ok
   @callback complete(Transaction.t | nil) :: :ok
   @callback set_error(Transaction.t | nil, String.t, String.t, any) :: Transaction.t
+
   if Appsignal.phoenix? do
     @callback try_set_action(Plug.Conn.t) :: :ok
     @callback try_set_action(Appsignal.Transaction.t, Plug.Conn.t) :: :ok
+  end
+
+  if Appsignal.plug? do
     @callback set_request_metadata(Transaction.t | nil, Plug.Conn.t) :: Transaction.t
   end
 end
@@ -365,7 +369,7 @@ defmodule Appsignal.Transaction do
     end
   end
 
-  if Appsignal.phoenix? do
+  if Appsignal.plug? do
     @doc """
     Set the request metadata, given a Plug.Conn.t.
     """
@@ -413,7 +417,9 @@ defmodule Appsignal.Transaction do
     defp peer(%Plug.Conn{peer: {host, port}}) do
       "#{:inet_parse.ntoa host}:#{port}"
     end
+  end
 
+  if Appsignal.phoenix? do
     @doc """
     Given the transaction and a %Plug.Conn{}, try to set the Phoenix controller module / action in the transaction.
     """
@@ -453,5 +459,4 @@ defmodule Appsignal.Transaction do
         t
     end
   end
-
 end

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -7,11 +7,8 @@ defmodule Appsignal.TransactionBehaviour do
   @callback complete() :: :ok
   @callback complete(Transaction.t | nil) :: :ok
   @callback set_error(Transaction.t | nil, String.t, String.t, any) :: Transaction.t
-
-  if Appsignal.phoenix? do
-    @callback try_set_action(Plug.Conn.t) :: :ok
-    @callback try_set_action(Appsignal.Transaction.t, Plug.Conn.t) :: :ok
-  end
+  @callback set_action(String.t) :: Transaction.t
+  @callback set_action(Transaction.t | nil, String.t) :: Transaction.t
 
   if Appsignal.plug? do
     @callback set_request_metadata(Transaction.t | nil, Plug.Conn.t) :: Transaction.t

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -423,15 +423,13 @@ defmodule Appsignal.Transaction do
     @doc """
     Given the transaction and a %Plug.Conn{}, try to set the Phoenix controller module / action in the transaction.
     """
-    def try_set_action(conn), do: try_set_action(lookup(), conn)
+    def try_set_action(conn) do
+      IO.warn "Appsignal.Transaction.try_set_action/1 is deprecated. Use Appsignal.Plug.extract_action/1 and Appsignal.Transaction.set_action/1 instead."
+      Transaction.set_action(lookup(), Appsignal.Plug.extract_action(conn))
+    end
     def try_set_action(transaction, conn) do
-      try do
-        action_str = "#{Phoenix.Controller.controller_module(conn)}##{Phoenix.Controller.action_name(conn)}"
-        <<"Elixir.", action :: binary>> = action_str
-        Transaction.set_action(transaction, action)
-      catch
-        _, _ -> :ok
-      end
+      IO.warn "Appsignal.Transaction.try_set_action/2 is deprecated. Use Appsignal.Plug.extract_action/1 and Appsignal.Transaction.set_action/2 instead."
+      Transaction.set_action(transaction, Appsignal.Plug.extract_action(conn))
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -85,6 +85,7 @@ defmodule Appsignal.Mixfile do
       {:httpoison, "~> 0.11"},
       {:poison, ">= 1.3.0"},
       {:decorator, "~> 1.0"},
+      {:plug, ">= 1.1.0", optional: true},
       {:phoenix, ">= 1.2.0", optional: true, only: [:prod, :test_phoenix, :dev]},
       {:mock, "~> 0.2.1", only: [:test, :test_phoenix, :test_no_nif]},
       {:bypass, "~> 0.5", only: [:test, :test_phoenix, :test_no_nif]},

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -18,6 +18,19 @@ defmodule AppsignalTest do
     Appsignal.add_distribution_value("dist_key", 10)
   end
 
+  describe "phoenix?/0" do
+    @tag :skip_env_test
+    @tag :skip_env_test_no_nif
+    test "is true when Phoenix is loaded" do
+      assert Appsignal.phoenix? == true
+    end
+
+    @tag :skip_env_test_phoenix
+    test "is false when Phoenix is not loaded" do
+      assert Appsignal.phoenix? == false
+    end
+  end
+
   test "Agent environment variables" do
     with_env(%{"APPSIGNAL_APP_ENV" => "test"}, fn() ->
       Appsignal.Config.initialize()

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -18,6 +18,12 @@ defmodule AppsignalTest do
     Appsignal.add_distribution_value("dist_key", 10)
   end
 
+  describe "plug?/0" do
+    test "is true when Plug is loaded" do
+      assert Appsignal.plug? == true
+    end
+  end
+
   describe "phoenix?/0" do
     @tag :skip_env_test
     @tag :skip_env_test_no_nif

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -105,4 +105,12 @@ defmodule Appsignal.PlugTest do
         == nil
     end
   end
+
+  describe "extracting action names" do
+    test "from a Plug conn" do
+      assert Appsignal.Plug.extract_action(
+        %Plug.Conn{method: "GET", request_path: "/foo"}
+      ) == "GET /foo"
+    end
+  end
 end

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -5,10 +5,10 @@ defmodule UsingAppsignalPlug do
 
   defoverridable [call: 2]
 
-  use Appsignal.Phoenix.Plug
+  use Appsignal.Plug
 end
 
-defmodule Appsignal.Phoenix.PlugTest do
+defmodule Appsignal.PlugTest do
   use ExUnit.Case
   alias Appsignal.FakeTransaction
 
@@ -77,14 +77,14 @@ defmodule Appsignal.Phoenix.PlugTest do
     test "with a reason and a conn", %{conn: conn, stack: stack} do
       error = %RuntimeError{}
 
-      assert Appsignal.Phoenix.Plug.extract_error_metadata(error, conn, stack)
+      assert Appsignal.Plug.extract_error_metadata(error, conn, stack)
         == {"RuntimeError", "HTTP request error: runtime error", stack, conn}
     end
 
     test "with a Plug.Conn.WrapperError", %{conn: conn, stack: stack} do
       error = %Plug.Conn.WrapperError{reason: %RuntimeError{}, conn: conn}
 
-      assert Appsignal.Phoenix.Plug.extract_error_metadata(error, conn, stack)
+      assert Appsignal.Plug.extract_error_metadata(error, conn, stack)
         == {"RuntimeError", "HTTP request error: runtime error", stack, conn}
     end
 
@@ -94,14 +94,14 @@ defmodule Appsignal.Phoenix.PlugTest do
         [%Task{owner: self(), pid: self(), ref: make_ref()},
          1]}}
 
-      assert Appsignal.Phoenix.Plug.extract_error_metadata(error, conn, stack)
+      assert Appsignal.Plug.extract_error_metadata(error, conn, stack)
         == {":timeout", "HTTP request error: #{inspect(error)}", stack, conn}
     end
 
     test "ignores errors with a plug_status < 500", %{conn: conn, stack: stack} do
       error = %Plug.BadRequestError{}
 
-      assert Appsignal.Phoenix.Plug.extract_error_metadata(error, conn, stack)
+      assert Appsignal.Plug.extract_error_metadata(error, conn, stack)
         == nil
     end
   end

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -20,11 +20,11 @@ defmodule Appsignal.PlugTest do
   describe "for a :sample transaction" do
     setup do
       conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, "foo")
-      |> Plug.Conn.put_private(:phoenix_action, "bar")
+      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+      |> Plug.Conn.put_private(:phoenix_action, :index)
       |> UsingAppsignalPlug.call(%{})
 
-      {:ok, conn: conn}
+      [conn: conn]
     end
 
     test "starts a transaction" do
@@ -36,7 +36,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "sets the transaction's action name" do
-      assert "foo#bar" == FakeTransaction.action
+      assert "AppsignalPhoenixExample.PageController#index" == FakeTransaction.action
     end
 
     test "finishes the transaction" do
@@ -57,11 +57,11 @@ defmodule Appsignal.PlugTest do
       FakeTransaction.set_finish(:no_sample)
 
       conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, "foo")
-      |> Plug.Conn.put_private(:phoenix_action, "bar")
+      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+      |> Plug.Conn.put_private(:phoenix_action, :index)
       |> UsingAppsignalPlug.call(%{})
 
-      {:ok, conn: conn}
+      [conn: conn]
     end
 
     test "does not set the transaction's request metadata" do

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -203,6 +203,12 @@ defmodule Appsignal.PlugTest do
       ) == "GET /foo"
     end
 
+    test "from a Plug conn with a Phoenix endpoint, but no controller or action" do
+      assert %Plug.Conn{}
+      |> Plug.Conn.put_private(:phoenix_endpoint, MyEndpoint)
+      |> Appsignal.Plug.extract_action == nil
+    end
+
     test "from a Plug conn with a Phoenix controller and action" do
       assert %Plug.Conn{}
       |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -112,5 +112,12 @@ defmodule Appsignal.PlugTest do
         %Plug.Conn{method: "GET", request_path: "/foo"}
       ) == "GET /foo"
     end
+
+    test "from a Plug conn with a Phoenix controller and action" do
+      assert %Plug.Conn{}
+      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+      |> Plug.Conn.put_private(:phoenix_action, :index)
+      |> Appsignal.Plug.extract_action == "AppsignalPhoenixExample.PageController#index"
+    end
   end
 end

--- a/test/phoenix/instrumenter_test.exs
+++ b/test/phoenix/instrumenter_test.exs
@@ -6,22 +6,21 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
     FakeTransaction.start_link
 
     transaction = Transaction.start("test", :http_request)
-
-    [transaction: transaction]
-  end
-
-  test "starts an event in phoenix_controller_call", context do
-    arguments = %{foo: "bar"}
-    assert {context[:transaction], arguments} ==
-      Instrumenter.phoenix_controller_call(:start, nil, arguments)
-  end
-
-  test "sets the action name in phoenix_controller_call" do
     conn = %Plug.Conn{}
     |> Plug.Conn.put_private(:phoenix_controller, "foo")
     |> Plug.Conn.put_private(:phoenix_action, "bar")
 
-    arguments = %{foo: "bar", conn: conn}
+    [transaction: transaction, conn: conn]
+  end
+
+  test "starts an event in phoenix_controller_call", %{transaction: transaction, conn: conn} do
+    arguments = %{conn: conn}
+
+    assert {transaction, arguments} ==
+      Instrumenter.phoenix_controller_call(:start, nil, arguments)
+  end
+
+  test "sets the action name in phoenix_controller_call", arguments do
     Instrumenter.phoenix_controller_call(:start, nil, arguments)
     assert "foo#bar" == FakeTransaction.action
   end

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -34,14 +34,9 @@ defmodule Appsignal.FakeTransaction do
     Agent.get(__MODULE__, &Map.get(&1, :finished_events, []))
   end
 
-  def try_set_action(_transaction, conn), do: try_set_action(conn)
-  def try_set_action(conn) do
-    try do
-      value = "#{conn.private.phoenix_controller}##{conn.private.phoenix_action}"
-      Agent.update(__MODULE__, &Map.put(&1, :action, value))
-    catch
-      _, _ -> :ok
-    end
+  def set_action(_transaction, conn), do: set_action(conn)
+  def set_action(action) do
+    Agent.update(__MODULE__, &Map.put(&1, :action, action))
   end
 
   def action do

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -134,6 +134,7 @@ defmodule Appsignal.FakeTransaction do
 
       new_state
     end)
+    transaction
   end
 
   def errors do


### PR DESCRIPTION
Closes #153.

Adds `Appsignal.Plug`, which handles instrumentation and error handling for Plug apps (including Phoenix). Deprecates most of `Appsignal.Phoenix` and `Appsignal.Phoenix.Plug`.