### PR TITLE
Set `env: Mix.env` in generated config.exs

### DIFF
--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -156,7 +156,8 @@ defmodule Mix.Tasks.Appsignal.Install do
       "config :appsignal, :config,\n" <>
       ~s(  active: true,\n) <>
       ~s(  name: "#{config[:name]}",\n) <>
-      ~s(  push_api_key: "#{config[:push_api_key]}"\n)
+      ~s(  push_api_key: "#{config[:push_api_key]}",\n) <>
+      ~s(  env: Mix.env\n)
   end
 
   # Append a line to Mix configuration environment files which deactivates

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -170,7 +170,8 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(config :appsignal, :config,\n) <>
         ~s(  active: true,\n) <>
         ~s(  name: "My app's name",\n) <>
-        ~s(  push_api_key: "my_push_api_key"\n)
+        ~s(  push_api_key: "my_push_api_key",\n) <>
+        ~s(  env: Mix.env\n)
 
       # Imports AppSignal config in config.exs file
       app_config = File.read!(Path.join(@test_config_directory, "config.exs"))


### PR DESCRIPTION
While setting up AS, I ran `mix appsignal.install your-push-api-key` and was a bit confused why my app was running in `dev` while deployed, but that's the default env.

Looking at the docs, `env: Mix.env` is listed in the [example config](http://docs.appsignal.com/elixir/installation.html#configuration), so after adding that to my `config.exs`, everything was smooth sailing. So I made this pull because I'm guessing a lot of people will use the mix task and probably think 'that's it'. 

I'm not sure if this was done intentionally, because [http://docs.appsignal.com/elixir/configuration/](http://docs.appsignal.com/elixir/configuration/) does mention `env` in in the minimal required config, and in the example to set up `prod.exs` manually:

```
# config/prod.exs
config :appsignal, :config,
  active: true,
  env: :prod
```

But anyway, this was easy to add, so let me know :-) 