### PR TITLE
phoenix template: use path as title instead of name

### DIFF
--- a/lib/appsignal/phoenix/template_instrumenter.ex
+++ b/lib/appsignal/phoenix/template_instrumenter.ex
@@ -42,7 +42,7 @@ if Appsignal.phoenix? do
             Appsignal.Instrumentation.Helpers.instrument(
               self(),
               "render.phoenix_template",
-              unquote(name),
+              unquote(path),
               fn() -> unquote(expr) end
             )
           end


### PR DESCRIPTION
I've noticed that slow events report groups template render events from multiple controllers. That's not expected and I'd like to see event response time separately.