### PR TITLE
Improve registry lookup performance

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -34,10 +34,6 @@ defmodule Appsignal do
     Supervisor.start_link(children, [strategy: :one_for_one, name: Appsignal.Supervisor])
   end
 
-  def started? do
-    Application.get_application(Appsignal) != nil
-  end
-
   def phoenix? do
     Code.ensure_loaded?(Phoenix)
   end

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -34,13 +34,12 @@ defmodule Appsignal.TransactionRegistry do
   @spec register(Transaction.t) :: :ok
   def register(transaction) do
     pid = self()
-    case registry_alive?() do
-      true ->
-        true = :ets.insert(@table, {pid, transaction})
-        GenServer.cast(__MODULE__, {:monitor, pid})
-      false ->
-        Logger.debug("Appsignal was not started, skipping transaction registration.")
-        nil
+    if registry_alive?() do
+      true = :ets.insert(@table, {pid, transaction})
+      GenServer.cast(__MODULE__, {:monitor, pid})
+    else
+      Logger.debug("Appsignal was not started, skipping transaction registration.")
+      nil
     end
   end
 

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -43,11 +43,6 @@ defmodule Appsignal.TransactionRegistry do
     end
   end
 
-  defp registry_alive? do
-    pid = Process.whereis(__MODULE__)
-    !is_nil(pid) && Process.alive?(pid)
-  end
-
   @doc """
   Given a process ID, return its associated transaction.
   """
@@ -124,5 +119,8 @@ defmodule Appsignal.TransactionRegistry do
     {:noreply, state}
   end
 
-
+  defp registry_alive? do
+    pid = Process.whereis(__MODULE__)
+    !is_nil(pid) && Process.alive?(pid)
+  end
 end

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -34,7 +34,7 @@ defmodule Appsignal.TransactionRegistry do
   @spec register(Transaction.t) :: :ok
   def register(transaction) do
     pid = self()
-    case Appsignal.started? do
+    case registry_alive?() do
       true ->
         true = :ets.insert(@table, {pid, transaction})
         GenServer.cast(__MODULE__, {:monitor, pid})
@@ -44,12 +44,17 @@ defmodule Appsignal.TransactionRegistry do
     end
   end
 
+  defp registry_alive? do
+    pid = Process.whereis(__MODULE__)
+    !is_nil(pid) && Process.alive?(pid)
+  end
+
   @doc """
   Given a process ID, return its associated transaction.
   """
   @spec lookup(pid, boolean) :: Transaction.t | nil
   def lookup(pid, return_removed \\ false) do
-    case Appsignal.started? && :ets.lookup(@table, pid) do
+    case registry_alive?() && :ets.lookup(@table, pid) do
       [{^pid, :removed}] ->
         case return_removed do
           false -> nil

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -18,10 +18,6 @@ defmodule AppsignalTest do
     Appsignal.add_distribution_value("dist_key", 10)
   end
 
-  test "started?" do
-    assert Appsignal.started?
-  end
-
   test "Agent environment variables" do
     with_env(%{"APPSIGNAL_APP_ENV" => "test"}, fn() ->
       Appsignal.Config.initialize()

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -9,7 +9,7 @@ defmodule Appsignal.Transaction.RegistryTest do
 
     TransactionRegistry.register(transaction)
 
-    assert ^transaction = TransactionRegistry.lookup(self())
+    assert transaction == TransactionRegistry.lookup(self())
   end
 
 
@@ -18,13 +18,13 @@ defmodule Appsignal.Transaction.RegistryTest do
 
     pid = spawn(fn() ->
       TransactionRegistry.register(transaction)
-      assert ^transaction = TransactionRegistry.lookup(self())
+      assert transaction == TransactionRegistry.lookup(self())
       :timer.sleep(50)
     end)
 
     :timer.sleep(10)
 
-    assert ^transaction = TransactionRegistry.lookup(pid)
+    assert transaction == TransactionRegistry.lookup(pid)
 
     :timer.sleep(100)
     # by now the process is gone

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -12,7 +12,7 @@ defmodule Appsignal.Transaction.RegistryTest do
   end
 
 
-  test "lookup returns nil after process has ended" do
+  test "lookup/1 returns nil after process has ended" do
     transaction = %Transaction{id: Transaction.generate_id()}
 
     pid = spawn(fn() ->


### PR DESCRIPTION
Hi,

I'll start with a short background story so you can have a context of why this change is important.
We use quite a few partials in our project to render relatively big collections (100-500 items). Template rendering was taking up to 50% of time on such pages according to performance reports. 

We started adding more instrumentation to views in a mission to narrow down the bottleneck. This resulted in a noticeable increase of render time. We also saw performance reports pointing that the issue was in rather view helpers doing simple operations on small lists.

We used Benchfella to verify the issue with these view helpers and quickly discovered that it was caused by Appsignal decorated functions being invoked in a loop. Benchmarking further only Appsignal instrumentation we pinned the root cause to `Appsignal.started?` function that uses relatively slow `Application.get_applicatin/1`.

`Appsignal.stated?` was added as a fix to issue #53, where uninitialized ets table was accessed because appsignal was not started. This PR proposes to check if `Appsignal.TransactionRegistry` process is running instead. After all that's what we're really interested in, as ets table is coupled to this process. Checking for ets table presense could be another option, but checking for process presence seems to be more decoupled approach.

Anyway, here's the benchmark code

```
{:ok, _} = Application.ensure_all_started(:appsignal)

defmodule Appsignal.InstrumentationBench do
  use Benchfella
  import Appsignal.Instrumentation.Helpers, only: [instrument: 3]

  bench "instrumenting no-op function" do
    instrument("no-op", "no-op", fn() -> :ok end)
  end
end
```


Appsignal 1.2.0
```
benchmark name                iterations   average time
instrumenting no-op function     1000000   19.94 µs/op
```

PR branch
```
benchmark name                iterations   average time
instrumenting no-op function   100000000   0.31 µs/op
```

And a couple screenshots from performance reports after we switched to this fork with no other changes:

1. Template that uses ~ 30 partials (including nested) and view helpers.
![image](https://cloud.githubusercontent.com/assets/1159573/25380307/17b72ddc-29b0-11e7-86b4-9a95231a3638.png)

2. View helper that used instrumented function in a loop
![image](https://cloud.githubusercontent.com/assets/1159573/25380378/5df2edd6-29b0-11e7-952e-5a0337b1fcdf.png)

3. Controller using above template
![image](https://cloud.githubusercontent.com/assets/1159573/25380531/d7fa84ea-29b0-11e7-8391-05d62b298c8a.png)

