### PR TITLE
Add DNS servers configuration option

### DIFF
--- a/agent.ex
+++ b/agent.ex
@@ -1,27 +1,27 @@
 defmodule Appsignal.Agent do
-  def version, do: "da14f3b"
+  def version, do: "f16607c"
 
   def triples do
     %{
       "x86_64-linux" => %{
-        checksum: "690ae21a087fc9bc8089f492bd2f751c77d9e9573441aa5b2b9427ab8b1e5433",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "0479e8b0aeba95360e9fd8cfd7e7f7f4c1a8dfc555f6149c0c35d27593a05193",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-linux-all-static.tar.gz"
        },
       "i686-linux" => %{
-        checksum: "18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "3c3c63f26bec0304649cad4fb69410dd6b13313a178f3db7cdeba72b24834715",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86-linux" => %{
-        checksum: "18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "3c3c63f26bec0304649cad4fb69410dd6b13313a178f3db7cdeba72b24834715",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86_64-darwin" => %{
-        checksum: "33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "853398d93cda5f16edd2a931346f97fedea4c16f729bb987564cfbc29e73ef33",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-darwin-all-static.tar.gz"
        },
       "universal-darwin" => %{
-        checksum: "33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "853398d93cda5f16edd2a931346f97fedea4c16f729bb987564cfbc29e73ef33",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-darwin-all-static.tar.gz"
        },
     }
   end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -4,6 +4,7 @@ defmodule Appsignal.Config do
   @default_config %{
     active: false,
     debug: false,
+    dns_servers: [],
     enable_host_metrics: true,
     endpoint: "https://push.appsignal.com",
     diagnose_endpoint: "https://appsignal.com/diag",
@@ -66,6 +67,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_HOSTNAME" => :hostname,
     "APPSIGNAL_FILTER_PARAMETERS" => :filter_parameters,
     "APPSIGNAL_DEBUG" => :debug,
+    "APPSIGNAL_DNS_SERVERS" => :dns_servers,
     "APPSIGNAL_LOG" => :log,
     "APPSIGNAL_LOG_PATH" => :log_path,
     "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
@@ -80,7 +82,7 @@ defmodule Appsignal.Config do
   @string_keys ~w(APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_CA_FILE_PATH)
   @bool_keys ~w(APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING APPSIGNAL_ENABLE_ALLOCATION_TRACKING APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA)
   @atom_keys ~w(APPSIGNAL_APP_ENV)
-  @string_list_keys ~w(APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS)
+  @string_list_keys ~w(APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS APPSIGNAL_DNS_SERVERS)
 
   defp load_environment(config, list, converter) do
     list |> Enum.reduce(
@@ -129,6 +131,7 @@ defmodule Appsignal.Config do
 
   defp empty?(nil), do: true
   defp empty?(""), do: true
+  defp empty?([]), do: true
   defp empty?(_), do: false
 
   defp true?("true"), do: true
@@ -174,6 +177,9 @@ defmodule Appsignal.Config do
       System.put_env("_APPSIGNAL_CA_FILE_PATH", config[:ca_file_path])
     end
     System.put_env("_APPSIGNAL_DEBUG_LOGGING", Atom.to_string(config[:debug]))
+    unless empty?(config[:dns_servers]) do
+      System.put_env("_APPSIGNAL_DNS_SERVERS", config[:dns_servers] |> Enum.join(","))
+    end
 
     System.put_env("_APPSIGNAL_ENABLE_HOST_METRICS", Atom.to_string(config[:enable_host_metrics]))
     System.put_env("_APPSIGNAL_ENVIRONMENT", Atom.to_string(config[:env]))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -77,6 +77,11 @@ defmodule Appsignal.ConfigTest do
         == default_configuration() |> Map.put(:debug, true)
     end
 
+    test "dns_servers" do
+      assert with_config(%{dns_servers: ["8.8.8.8", "8.8.4.4"]}, &init_config/0)
+        == default_configuration() |> Map.put(:dns_servers, ["8.8.8.8", "8.8.4.4"])
+    end
+
     test "enable_host_metrics" do
       assert with_config(%{enable_host_metrics: false}, &init_config/0)
         == default_configuration() |> Map.put(:enable_host_metrics, false)
@@ -190,6 +195,13 @@ defmodule Appsignal.ConfigTest do
         %{"APPSIGNAL_DEBUG" => "true"},
         &init_config/0
       ) == default_configuration() |> Map.put(:debug, true)
+    end
+
+    test "dns_servers" do
+      assert with_env(
+        %{"APPSIGNAL_DNS_SERVERS" => "8.8.8.8,8.8.4.4"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:dns_servers, ["8.8.8.8", "8.8.4.4"])
     end
 
     test "enable_host_metrics" do
@@ -406,6 +418,7 @@ defmodule Appsignal.ConfigTest do
         active: true,
         ca_file_path: "/foo/bar/zab.ca",
         debug: true,
+        dns_servers: ["8.8.8.8", "8.8.4.4"],
         enable_host_metrics: false,
         endpoint: "https://push.staging.lol",
         env: :prod,
@@ -432,6 +445,7 @@ defmodule Appsignal.ConfigTest do
         assert System.get_env("_APPSIGNAL_APP_NAME") == "AppSignal test suite app"
         assert System.get_env("_APPSIGNAL_CA_FILE_PATH") == "/foo/bar/zab.ca"
         assert System.get_env("_APPSIGNAL_DEBUG_LOGGING") == "true"
+        assert System.get_env("_APPSIGNAL_DNS_SERVERS") == "8.8.8.8,8.8.4.4"
         assert System.get_env("_APPSIGNAL_ENABLE_HOST_METRICS") == "false"
         assert System.get_env("_APPSIGNAL_ENVIRONMENT") == "prod"
         assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == "password,secret"
@@ -450,7 +464,7 @@ defmodule Appsignal.ConfigTest do
       end)
     end
 
-    test "ame as atom" do
+    test "name as atom" do
       with_config(%{name: :appsignal_test_suite_app}, fn() ->
         write_to_environment()
         assert System.get_env("_APPSIGNAL_APP_NAME") == "appsignal_test_suite_app"
@@ -463,12 +477,20 @@ defmodule Appsignal.ConfigTest do
         assert System.get_env("_APPSIGNAL_APP_NAME") == "AppSignal test suite app"
       end)
     end
+
+    test "does not write dns_servers to env if empty" do
+      with_config(%{dns_servers: []}, fn() ->
+        write_to_environment()
+        assert System.get_env("_APPSIGNAL_DNS_SERVERS") == nil
+      end)
+    end
   end
 
   defp default_configuration() do
     %{
       active: false,
       debug: false,
+      dns_servers: [],
       enable_host_metrics: true,
       endpoint: "https://push.appsignal.com",
       diagnose_endpoint: "https://appsignal.com/diag",


### PR DESCRIPTION
Agent bumped to support `_APPSIGNAL_DNS_SERVERS` configuration option.

Tracking issue: https://github.com/appsignal/appsignal-agent/issues/246