### PR TITLE
Better backtraces for linked processes

### DIFF
--- a/agent.ex
+++ b/agent.ex
@@ -1,27 +1,27 @@
 defmodule Appsignal.Agent do
-  def version, do: "7ade8ff"
+  def version, do: "da14f3b"
 
   def triples do
     %{
       "x86_64-linux" => %{
-        checksum: "4c9a40b6215aa5598f546050817448e698479a2e6594feb8f7d46b755ae959e9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "690ae21a087fc9bc8089f492bd2f751c77d9e9573441aa5b2b9427ab8b1e5433",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-linux-all-static.tar.gz"
        },
       "i686-linux" => %{
-        checksum: "0caf5d0ef96f663b03b36d4c37741856ded851d205e0c1403550d6c04266eb6b",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86-linux" => %{
-        checksum: "0caf5d0ef96f663b03b36d4c37741856ded851d205e0c1403550d6c04266eb6b",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz"
        },
       "x86_64-darwin" => %{
-        checksum: "bc72d9f7485b66802f9642e1d2fee4d2fe2f1b5b363f1378c46469d112b9442e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz"
        },
       "universal-darwin" => %{
-        checksum: "bc72d9f7485b66802f9642e1d2fee4d2fe2f1b5b363f1378c46469d112b9442e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz"
        },
     }
   end

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -41,6 +41,10 @@ static appsignal_string_t make_appsignal_string(ErlNifBinary binary)
     return retval;
 }
 
+static ERL_NIF_TERM make_elixir_string(ErlNifEnv* env, appsignal_string_t binary) {
+  return enif_make_string_len(env, binary.buf, binary.len, ERL_NIF_LATIN1);
+}
+
 static ERL_NIF_TERM _start(ErlNifEnv* env, int UNUSED(arc), const ERL_NIF_TERM UNUSED(argv[]))
 {
     appsignal_start();
@@ -51,6 +55,10 @@ static ERL_NIF_TERM _stop(ErlNifEnv* env, int UNUSED(arc), const ERL_NIF_TERM UN
 {
     appsignal_stop();
     return enif_make_atom(env, "ok");
+}
+
+static ERL_NIF_TERM _diagnose(ErlNifEnv* env, int UNUSED(arc), const ERL_NIF_TERM UNUSED(argv[])) {
+  return make_elixir_string(env, appsignal_diagnose());
 }
 
 static ERL_NIF_TERM _start_transaction(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -771,6 +779,7 @@ static ErlNifFunc nif_funcs[] =
 {
     {"_start", 0, _start, 0},
     {"_stop", 0, _stop, 0},
+    {"_diagnose", 0, _diagnose, 0},
     {"_start_transaction", 2, _start_transaction, 0},
     {"_start_event", 1, _start_event, 0},
     {"_finish_event", 5, _finish_event, 0},

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,4 +10,5 @@ if Mix.env in [:test, :test_phoenix, :test_no_nif] do
   config :appsignal, appsignal_nif: Appsignal.FakeNif
   config :appsignal, appsignal_demo: Appsignal.FakeDemo
   config :appsignal, appsignal_transaction: Appsignal.FakeTransaction
+  config :appsignal, appsignal_diagnose_report: Appsignal.Diagnose.FakeReport
 end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -6,6 +6,7 @@ defmodule Appsignal.Config do
     debug: false,
     enable_host_metrics: true,
     endpoint: "https://push.appsignal.com",
+    diagnose_endpoint: "https://appsignal.com/diag",
     env: :dev,
     filter_parameters: nil,
     ignore_actions: [],

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -1,0 +1,94 @@
+defmodule Appsignal.Diagnose.Agent do
+  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+  def report do
+    if @nif.loaded? do
+      System.put_env("_APPSIGNAL_DIAGNOSE", "true")
+      report_string = @nif.diagnose
+      report = case Poison.decode(report_string) do
+        {:ok, report} -> {:ok, report}
+        {:error, _} -> {:error, report_string}
+      end
+      System.delete_env("_APPSIGNAL_DIAGNOSE")
+      report
+    else
+      {:error, :nif_not_loaded}
+    end
+  end
+
+  # Start AppSignal as usual, in diagnose mode, so that it exits early, but
+  # does go through the whole process of setting the config to the
+  # environment.
+  def print(report) do
+    IO.puts "Agent diagnostics"
+    if report["error"] do
+      IO.puts "  Error: #{report["error"]}"
+    else
+      Enum.each(report_definition(), fn({component, categories}) ->
+        print_component(report[component] || %{}, categories)
+      end)
+    end
+    IO.puts ""
+  end
+
+  defp print_component(report, categories) do
+    Enum.each(categories, fn({category, tests}) ->
+      print_category(report[category] || %{}, tests)
+    end)
+  end
+
+  defp print_category(report, tests) do
+    Enum.each(tests, fn({test, definition}) ->
+      print_test(report[test] || %{}, definition)
+    end)
+  end
+
+  defp print_test(report, definition) do
+    IO.write "  #{definition[:label]}: "
+    case Map.fetch(definition[:values], report["result"]) do
+      {:ok, value} -> IO.puts value
+      :error -> IO.puts "-"
+    end
+    if report["error"], do: IO.puts "    Error: #{report["error"]}"
+    if report["output"], do: IO.puts "    Output: #{report["output"]}"
+  end
+
+  defp report_definition do
+    %{
+      "extension" => %{
+        "config" => %{
+          "valid" => %{
+            :label => "Extension config",
+            :values => %{ true => "valid", false => "invalid" }
+          }
+        }
+      },
+      "agent" => %{
+        "boot" => %{
+          "started" => %{
+            :label => "Agent started",
+            :values => %{ true => "started", false => "not started" }
+          }
+        },
+        "config" => %{
+          "valid" => %{
+            :label => "Agent config",
+            :values => %{ true => "valid", false => "invalid" }
+          }
+        },
+        "logger" => %{
+          "started" => %{
+            :label => "Agent logger",
+            :values => %{ true => "started", false => "not started" }
+          }
+        },
+        "lock_path" => %{
+          "created" => %{
+            :label => "Agent lock path",
+            :values => %{ true => "writable", false => "not writable" }
+          }
+        }
+      }
+    }
+  end
+end

--- a/lib/appsignal/diagnose/host.ex
+++ b/lib/appsignal/diagnose/host.ex
@@ -1,0 +1,15 @@
+defmodule Appsignal.Diagnose.Host do
+  @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
+  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+  def info do
+    %{
+      architecture: to_string(:erlang.system_info(:system_architecture)),
+      language_version: System.version,
+      otp_version: System.otp_release,
+      heroku: @system.heroku?,
+      root: @system.root?,
+      running_in_container: @nif.running_in_container?
+    }
+  end
+end

--- a/lib/appsignal/diagnose/library.ex
+++ b/lib/appsignal/diagnose/library.ex
@@ -1,0 +1,14 @@
+defmodule Appsignal.Diagnose.Library do
+  @appsignal_version Mix.Project.config[:version]
+  @agent_version Mix.Project.config[:agent_version]
+  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+  def info do
+    %{
+      language: "elixir",
+      agent_version: @agent_version,
+      package_version: @appsignal_version,
+      extension_loaded: @nif.loaded?
+    }
+  end
+end

--- a/lib/appsignal/diagnose/paths.ex
+++ b/lib/appsignal/diagnose/paths.ex
@@ -1,0 +1,37 @@
+defmodule Appsignal.Diagnose.Paths do
+  def info(config) do
+    log_file_path = config[:log_path] || "/tmp/appsignal.log"
+    log_dir_path = Path.dirname(log_file_path)
+    %{
+      log_dir_path: path_report(log_dir_path),
+      log_file_path: path_report(log_file_path)
+    }
+  end
+
+  defp path_report(path) do
+    report = %{
+      path: path,
+      configured: true,
+      exists: false,
+      writable: false
+    }
+
+    path_details =
+      if File.exists? path do
+        case File.stat(path) do
+          {:ok, %{access: access, uid: uid}} ->
+            case access do
+              p when p in [:write, :read_write] ->
+                %{writable: true}
+              _ -> %{}
+            end
+            |> Map.merge(%{ownership: %{uid: uid}})
+          {:error, reason} -> %{error: reason}
+        end
+        |> Map.merge(%{exists: true})
+      else
+        %{}
+      end
+    Map.merge(report, path_details)
+  end
+end

--- a/lib/appsignal/diagnose/report.ex
+++ b/lib/appsignal/diagnose/report.ex
@@ -1,0 +1,31 @@
+defmodule Appsignal.Diagnose.ReportBehaviour do
+  @callback send(Appsignal.Config.t, %{}) :: {:ok, String.t}
+end
+
+defmodule Appsignal.Diagnose.Report do
+  @behaviour Appsignal.Diagnose.ReportBehaviour
+
+  def send(config, report) do
+    HTTPoison.start
+    params = URI.encode_query(%{
+      api_key: config[:push_api_key],
+      name: config[:name],
+      environment: config[:environment],
+      hostname: config[:hostname]
+    })
+    url = "#{config[:diagnose_endpoint]}?#{params}"
+    body = Poison.encode!(%{diagnose: report})
+    headers = [{"Content-Type", "application/json; charset=UTF-8"}]
+    case HTTPoison.post url, body, headers do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        case Poison.decode(body) do
+          {:ok, response} -> {:ok, response["token"]}
+          {:error, _} -> {:error, %{status_code: 200, body: body}}
+        end
+      {_, %HTTPoison.Response{status_code: status_code, body: body}} ->
+        {:error, %{status_code: status_code, body: body}}
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, %{reason: reason}}
+    end
+  end
+end

--- a/lib/appsignal/diagnose/validation.ex
+++ b/lib/appsignal/diagnose/validation.ex
@@ -1,0 +1,14 @@
+defmodule Appsignal.Diagnose.Validation do
+  alias Appsignal.Utils.PushApiKeyValidator
+
+  def validate(config) do
+    case PushApiKeyValidator.validate(config) do
+      :ok ->
+        %{push_api_key: "valid"}
+      {:error, :invalid} ->
+        %{push_api_key: "invalid"}
+      {:error, reason} ->
+        %{push_api_key: "error: #{reason}"}
+    end
+  end
+end

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -78,11 +78,16 @@ defmodule Appsignal.ErrorHandler do
                                     {:pid, pid},
                                     {:registered_name, name},
                                     {:error_info, {_kind, exception, stack}} | _], _linked]) do
-
     msg = "Process #{crash_name(pid, name)} terminating"
+    stacktrace = extract_stacktrace(exception) || stack
     {reason, message} = extract_reason_and_message(exception, msg)
-    {origin, reason, message, Backtrace.from_stacktrace(stack), nil}
+    {origin, reason, message, Backtrace.from_stacktrace(stacktrace), nil}
   end
+
+  defp extract_stacktrace({_, stacktrace}) when is_list(stacktrace) do
+    stacktrace
+  end
+  defp extract_stacktrace(_), do: nil
 
   @doc false
   def format_stack(stacktrace) do

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -84,10 +84,21 @@ defmodule Appsignal.ErrorHandler do
     {origin, reason, message, Backtrace.from_stacktrace(stacktrace), nil}
   end
 
-  defp extract_stacktrace({_, stacktrace}) when is_list(stacktrace) do
-    stacktrace
+  defp extract_stacktrace({_, stacktrace}) do
+    case stacktrace?(stacktrace) do
+      true -> stacktrace
+      false -> nil
+    end
   end
   defp extract_stacktrace(_), do: nil
+
+  defp stacktrace?(stacktrace) when is_list(stacktrace) do
+    Enum.all?(stacktrace, &stacktrace_line?/1)
+  end
+  defp stacktrace?(_), do: false
+
+  defp stacktrace_line?({_,_,_,[file: _, line: _]}), do: true
+  defp stacktrace_line?(_), do: false
 
   @doc false
   def format_stack(stacktrace) do

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -56,6 +56,10 @@ defmodule Appsignal.Nif do
     _stop()
   end
 
+  def diagnose do
+    _diagnose()
+  end
+
   def start_transaction(transaction_id, namespace) do
     _start_transaction(transaction_id, namespace)
   end
@@ -192,6 +196,10 @@ defmodule Appsignal.Nif do
 
   def _stop do
     :ok
+  end
+
+  def _diagnose do
+    :error
   end
 
   def _start_transaction(_id, _namespace) do

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -51,7 +51,7 @@ if Appsignal.phoenix? do
     def channel_action(module, name, %Phoenix.Socket{} = socket, function) do
       alias Appsignal.Transaction
 
-      transaction = Transaction.start(Transaction.generate_id(), :background_job)
+      transaction = Transaction.start(Transaction.generate_id(), :channel)
 
       action_str = "#{module}##{name}"
       <<"Elixir.", action :: binary>> = action_str

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -1,7 +1,5 @@
 defmodule Appsignal.TransactionBehaviour do
-  @type namespace :: :http_request | :background_job
-
-  @callback start(String.t, namespace) :: Appsignal.Transaction.t
+  @callback start(String.t, String.t) :: Appsignal.Transaction.t
   @callback start_event() :: Appsignal.Transaction.t
   @callback finish_event(Appsignal.Transaction.t | nil, String.t, String.t, any, integer) :: Appsignal.Transaction.t
   @callback finish() :: :sample | :no_sample
@@ -45,22 +43,14 @@ defmodule Appsignal.Transaction do
   """
   @type t :: %Transaction{}
 
-  @typedoc """
-  The transaction's namespace
-  """
-  @type namespace :: :http_request | :background_job
-
-  @valid_namespaces [:http_request, :background_job]
-
-
   @doc """
   Start a transaction
 
   Call this when a transaction such as a http request or background job starts.
 
   Parameters:
-  - `transaction_id` The unique identifier of this transaction
-  - `namespace` The namespace of this transaction. Must be one of `:http_request`, `:background_job`.
+  - `transaction_id` The unique identifier of this transaction.
+  - `namespace` The namespace of this transaction. Defaults to :background_job.
 
   The function returns a `%Transaction{}` struct for use with the
   other transaction functions in this module.
@@ -71,8 +61,8 @@ defmodule Appsignal.Transaction do
   `Appsignal.TransactionRegistry`.
 
   """
-  @spec start(String.t, namespace) :: Transaction.t
-  def start(transaction_id, namespace) when is_binary(transaction_id) and namespace in @valid_namespaces do
+  @spec start(String.t, String.t) :: Transaction.t
+  def start(transaction_id, namespace) when is_binary(transaction_id) do
     {:ok, resource} = Nif.start_transaction(transaction_id, Atom.to_string(namespace))
     transaction = %Appsignal.Transaction{resource: resource, id: transaction_id}
     TransactionRegistry.register(transaction)

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -10,6 +10,102 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
 
   @shortdoc "Starts and tests AppSignal while validating the configuration."
 
+  defmodule AgentReport do
+    @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+    # Start AppSignal as usual, in diagnose mode, so that it exits early, but
+    # does go through the whole process of setting the config to the
+    # environment.
+    def run do
+      IO.puts "Agent diagnostics"
+      if @nif.loaded? do
+        System.put_env("_APPSIGNAL_DIAGNOSE", "true")
+        report_string = @nif.diagnose
+        case Poison.decode(report_string) do
+          {:ok, report} -> print_report report
+          {:error, _} ->
+            IO.puts "  Error: Could not parse the agent report:"
+            IO.puts "    Output: #{report_string}"
+        end
+        System.delete_env("_APPSIGNAL_DIAGNOSE")
+      else
+        IO.puts "  Error: Nif not loaded, aborting."
+      end
+      IO.puts ""
+    end
+
+    defp print_report(report) do
+      if report["error"] do
+        IO.puts "  Error: #{report["error"]}"
+      else
+        Enum.each(report_definition(), fn({component, categories}) ->
+          print_component(report[component] || %{}, categories)
+        end)
+      end
+    end
+
+    defp print_component(report, categories) do
+      Enum.each(categories, fn({category, tests}) ->
+        print_category(report[category] || %{}, tests)
+      end)
+    end
+
+    defp print_category(report, tests) do
+      Enum.each(tests, fn({test, definition}) ->
+        print_test(report[test] || %{}, definition)
+      end)
+    end
+
+    defp print_test(report, definition) do
+      IO.write "  #{definition[:label]}: "
+      case Map.fetch(definition[:values], report["result"]) do
+        {:ok, value} -> IO.puts value
+        :error -> IO.puts "-"
+      end
+      if report["error"], do: IO.puts "    Error: #{report["error"]}"
+      if report["output"], do: IO.puts "    Output: #{report["output"]}"
+    end
+
+    defp report_definition do
+      %{
+        "extension" => %{
+          "config" => %{
+            "valid" => %{
+              :label => "Extension config",
+              :values => %{ true => "valid", false => "invalid" }
+            }
+          }
+        },
+        "agent" => %{
+          "boot" => %{
+            "started" => %{
+              :label => "Agent started",
+              :values => %{ true => "started", false => "not started" }
+            }
+          },
+          "config" => %{
+            "valid" => %{
+              :label => "Agent config",
+              :values => %{ true => "valid", false => "invalid" }
+            }
+          },
+          "logger" => %{
+            "started" => %{
+              :label => "Agent logger",
+              :values => %{ true => "started", false => "not started" }
+            }
+          },
+          "lock_path" => %{
+            "created" => %{
+              :label => "Agent lock path",
+              :values => %{ true => "writable", false => "not writable" }
+            }
+          }
+        }
+      }
+    end
+  end
+
   def run(_args) do
     header()
     empty_line()
@@ -20,9 +116,8 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     host_information()
     empty_line()
 
-    if @nif.loaded? do
-      start_appsignal_in_diagnose_mode()
-    end
+    configure_appsignal()
+    run_agent_diagnose_mode()
 
     configuration()
     empty_line()
@@ -65,22 +160,13 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts "  Container: #{yes_or_no(@nif.running_in_container?)}"
   end
 
-  # Start AppSignal as usual, in diagnose mode, so that it exits early, but
-  # does go through the whole process of setting the config to the
-  # environment.
-  defp start_appsignal_in_diagnose_mode do
+  defp configure_appsignal do
     Config.initialize
     Config.write_to_environment
+  end
 
-    agent_path = Path.join(List.to_string(:code.priv_dir(:appsignal)), "appsignal-agent")
-    env = [{"_APPSIGNAL_DIAGNOSE", "true"}]
-    case System.cmd(agent_path, [], env: env) do
-      {output, 0} -> IO.puts output
-      {output, exit_code} ->
-        IO.puts "Agent diagnostic failure!"
-        IO.puts "  Exit code: #{exit_code}"
-        IO.puts "  Error message: #{output}"
-    end
+  defp run_agent_diagnose_mode do
+    AgentReport.run
   end
 
   defp configuration do

--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,7 @@ defmodule Appsignal.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.11"},
+      {:poison, ">= 1.3.0"},
       {:decorator, "~> 1.0"},
       {:phoenix, ">= 1.2.0", optional: true, only: [:prod, :test_phoenix, :dev]},
       {:mock, "~> 0.2.1", only: [:test, :test_phoenix, :test_no_nif]},

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -471,6 +471,7 @@ defmodule Appsignal.ConfigTest do
       debug: false,
       enable_host_metrics: true,
       endpoint: "https://push.appsignal.com",
+      diagnose_endpoint: "https://appsignal.com/diag",
       env: :dev,
       filter_parameters: nil,
       ignore_actions: [],

--- a/test/appsignal/diagnose/report_test.exs
+++ b/test/appsignal/diagnose/report_test.exs
@@ -1,0 +1,80 @@
+defmodule Mix.Tasks.Appsignal.Diagnose.ReportTest do
+  use ExUnit.Case
+  import AppsignalTest.Utils
+
+  defp send() do
+    Appsignal.Diagnose.Report.send(
+      Application.get_env(:appsignal, :config, %{}),
+      %{}
+    )
+  end
+
+  setup do
+    diagnose_bypass = Bypass.open
+    setup_with_config(%{
+      api_key: "foo",
+      name: "AppSignal test suite app",
+      environment: "production",
+      hostname: "foo",
+      diagnose_endpoint: "http://localhost:#{diagnose_bypass.port}/diag"
+    })
+
+    {:ok, diagnose_bypass: diagnose_bypass}
+  end
+
+  describe "with valid response" do
+    setup %{diagnose_bypass: diagnose_bypass} do
+      Bypass.expect diagnose_bypass, fn conn ->
+        assert "/diag" == conn.request_path
+        assert "POST" == conn.method
+        Plug.Conn.resp(conn, 200, ~s({"token": "support token"}))
+      end
+      :ok
+    end
+
+    test "sends the diagnostics report to AppSignal and returns support token" do
+      assert send() == {:ok, "support token"}
+    end
+  end
+
+  describe "with invalid response" do
+    setup %{diagnose_bypass: diagnose_bypass} do
+      Bypass.expect diagnose_bypass, fn conn ->
+        assert "/diag" == conn.request_path
+        assert "POST" == conn.method
+        Plug.Conn.resp(conn, 200, ~s({"foo": bar}))
+      end
+      :ok
+    end
+
+    test "sends the diagnostics report to AppSignal and returns an error" do
+      assert send() == {:error, %{body: ~s({"foo": bar}), status_code: 200}}
+    end
+  end
+
+  describe "with error response" do
+    setup %{diagnose_bypass: diagnose_bypass} do
+      Bypass.expect diagnose_bypass, fn conn ->
+        assert "/diag" == conn.request_path
+        assert "POST" == conn.method
+        Plug.Conn.resp(conn, 500, ~s(woops))
+      end
+      :ok
+    end
+
+    test "sends the diagnostics report to AppSignal and returns an error" do
+      assert send() == {:error, %{body: "woops", status_code: 500}}
+    end
+  end
+
+  describe "with no server response" do
+    setup %{diagnose_bypass: diagnose_bypass} do
+      Bypass.down(diagnose_bypass)
+      :ok
+    end
+
+    test "sends the diagnostics report to AppSignal and returns an error" do
+      assert send() == {:error, %{reason: :econnrefused}}
+    end
+  end
+end

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -84,8 +84,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason("{:exit, :crash_proc_lib_spawn}")
     |> message(~r(Process #PID<[\d.]+> terminating$))
     |> stacktrace([
-      "test/appsignal/error_handler/error_matcher_test.exs:81: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test proc_lib.spawn + exit/1",
-      "(stdlib) proc_lib.erl:232: :proc_lib.init_p/3"
+      ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test proc_lib.spawn \+ exit/1},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -97,8 +97,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason("{:error, :crash_proc_lib_error}")
     |> message(~r(Process #PID<[\d.]+> terminating$))
     |> stacktrace([
-      "test/appsignal/error_handler/error_matcher_test.exs:94: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test proc_lib.spawn + erlang.error/1",
-      "(stdlib) proc_lib.erl:232: :proc_lib.init_p/3"
+      ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test proc_lib.spawn \+ erlang.error/1},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -110,8 +110,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason("{:error, :function_clause}")
     |> message(~r(Process #PID<[\d.]+> terminating$))
     |> stacktrace([
-      "(elixir) unicode/unicode.ex:190: String.Unicode.length/1",
-      "(stdlib) proc_lib.erl:232: :proc_lib.init_p/3"
+      ~r{\(elixir\) unicode/unicode.ex:\d+: String.Unicode.length/1},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -121,8 +121,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason("{:error, {:badmatch, [1, 2, 3]}}")
     |> message(~r(Process #PID<[\d.]+> terminating: {:badmatch, \[1, 2, 3\]}))
     |> stacktrace([
-      "test/appsignal/error_handler/error_matcher_test.exs:119: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test proc_lib.spawn + badmatch error/1",
-      "(stdlib) proc_lib.erl:232: :proc_lib.init_p/3"
+      ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test proc_lib.spawn \+ badmatch error/1},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -133,8 +133,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason("{:exit, {:bad_return_value, :crashed_gen_server_throw}}")
     |> message(~r(Process #PID<[\d.]+> terminating: {:bad_return_valu...))
     |> stacktrace([
-      "(stdlib) gen_server.erl:812: :gen_server.terminate/7",
-      "(stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3"
+      ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.terminate/7},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
     ])
   end
 
@@ -144,8 +144,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason("{:exit, :crashed_gen_server_exit}")
     |> message(~r(Process #PID<[\d.]+> terminating$))
     |> stacktrace([
-      "(stdlib) gen_server.erl:812: :gen_server.terminate/7",
-      "(stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3"
+      ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.terminate/7},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
     ])
   end
 
@@ -155,11 +155,11 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason(":function_clause")
     |> message(~r(Process #PID<[\d.]+> terminating: {:function_clause...))
     |> stacktrace([
-      "(elixir) unicode/unicode.ex:190: String.Unicode.length/1",
-      "test/appsignal/error_handler/error_matcher_test.exs:27: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2",
-      "(stdlib) gen_server.erl:601: :gen_server.try_dispatch/4",
-      "(stdlib) gen_server.erl:667: :gen_server.handle_msg/5",
-      "(stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3"
+      ~r{\(elixir\) unicode/unicode.ex:\d+: String.Unicode.length/1},
+      ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2},
+      ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
+      ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.handle_msg/5},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
     ])
   end
 
@@ -173,9 +173,9 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       ~r(Process #PID<[\d.]+> terminating: {:function_clause, \[{String.Uni...)
     )
     |> stacktrace([
-      "(elixir) unicode/unicode.ex:190: String.Unicode.length/1",
-      "(elixir) lib/task/supervised.ex:85: Task.Supervised.do_apply/2",
-      "(stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3"
+      ~r{\(elixir\) unicode/unicode.ex:\d+: String.Unicode.length/1},
+      ~r{\(elixir\) lib/task/supervised.ex:\d+: Task.Supervised.do_apply/2},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
     ])
   end
 
@@ -192,8 +192,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       ~r(Process #PID<[\d.]+> terminating: {:timeout, {Task, :await, \[%Tas...)
     )
     |> stacktrace([
-      "(elixir) lib/task.ex:416: Task.await/2",
-      "(stdlib) proc_lib.erl:232: :proc_lib.init_p/3"
+      ~r{\(elixir\) lib/task.ex:\d+: Task.await/2},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -208,7 +208,14 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
   end
 
   defp stacktrace({_reason, _message, stacktrace} = data, expected) do
-    assert stacktrace == expected
+    assert_stacktrace(stacktrace, expected)
     data
   end
+
+  defp assert_stacktrace([line|tail], [expected|expected_tail]) do
+    assert line =~ expected
+    assert_stacktrace(tail, expected_tail)
+  end
+  defp assert_stacktrace([line], [expected]), do: assert line =~ expected
+  defp assert_stacktrace([], []), do: true
 end

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -116,10 +116,10 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
   end
 
   test "proc_lib.spawn + badmatch error" do
-    :proc_lib.spawn(fn() -> throw({:badmatch, 2}) end)
+    :proc_lib.spawn(fn() -> throw({:badmatch, [1, 2, 3]}) end)
     |> assert_crash_caught
-    |> reason("{:error, {:badmatch, 2}}")
-    |> message(~r(Process #PID<[\d.]+> terminating: {:badmatch, 2}))
+    |> reason("{:error, {:badmatch, [1, 2, 3]}}")
+    |> message(~r(Process #PID<[\d.]+> terminating: {:badmatch, \[1, 2, 3\]}))
     |> stacktrace([
       "test/appsignal/error_handler/error_matcher_test.exs:119: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest.test proc_lib.spawn + badmatch error/1",
       "(stdlib) proc_lib.erl:232: :proc_lib.init_p/3"

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -155,7 +155,10 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     |> reason(":function_clause")
     |> message(~r(Process #PID<[\d.]+> terminating: {:function_clause...))
     |> stacktrace([
-      "(stdlib) gen_server.erl:812: :gen_server.terminate/7",
+      "(elixir) unicode/unicode.ex:190: String.Unicode.length/1",
+      "test/appsignal/error_handler/error_matcher_test.exs:27: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2",
+      "(stdlib) gen_server.erl:601: :gen_server.try_dispatch/4",
+      "(stdlib) gen_server.erl:667: :gen_server.handle_msg/5",
       "(stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3"
     ])
   end
@@ -170,7 +173,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       ~r(Process #PID<[\d.]+> terminating: {:function_clause, \[{String.Uni...)
     )
     |> stacktrace([
-      "(elixir) lib/task/supervised.ex:116: Task.Supervised.exit/4",
+      "(elixir) unicode/unicode.ex:190: String.Unicode.length/1",
+      "(elixir) lib/task/supervised.ex:85: Task.Supervised.do_apply/2",
       "(stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3"
     ])
   end

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -125,13 +125,14 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
   @tag :skip_env_test_no_nif
   test "runs agent in diagnose mode" do
+    @nif.set(:run_diagnose, true)
     output = run()
     assert String.contains? output, "Agent diagnostics"
-    assert String.contains? output, "Running agent in diagnose mode"
-    assert String.contains? output, "Valid config present"
-    assert String.contains? output, "Logger initialized successfully"
-    assert String.contains? output, "Lock path is writable"
-    assert String.contains? output, "Agent diagnose finished"
+    assert String.contains? output, "  Extension config: valid"
+    assert String.contains? output, "  Agent started: started"
+    assert String.contains? output, "  Agent config: valid"
+    assert String.contains? output, "  Agent lock path: writable"
+    assert String.contains? output, "  Agent logger: started"
   end
 
   @tag :skip_env_test_no_nif
@@ -142,11 +143,102 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       output = with_config(%{active: false}, &run/0)
       assert String.contains? output, "active: false"
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "Running agent in diagnose mode"
-      assert String.contains? output, "Valid config present"
-      assert String.contains? output, "Logger initialized successfully"
-      assert String.contains? output, "Lock path is writable"
-      assert String.contains? output, "Agent diagnose finished"
+      assert String.contains? output, "  Extension config: valid"
+      assert String.contains? output, "  Agent started: started"
+      assert String.contains? output, "  Agent config: valid"
+      assert String.contains? output, "  Agent lock path: writable"
+      assert String.contains? output, "  Agent logger: started"
+    end
+  end
+
+  describe "when extension is not loaded" do
+    setup do: @nif.set(:loaded?, false)
+
+    test "agent diagnostics is not run" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Error: Nif not loaded, aborting."
+    end
+  end
+
+  describe "when extension output is invalid JSON" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, "agent_report_string")
+    end
+
+    test "agent diagnostics report prints an error" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Error: Could not parse the agent report:"
+      assert String.contains? output, "    Output: agent_report_string"
+    end
+  end
+
+  describe "when extension output is missing a test" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, ~s(
+        {
+          "extension": { "config": { "valid": { "result": true } } }
+        }
+      ))
+    end
+
+    test "agent diagnostics report prints the tests, but shows a dash `-` for missed results" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Extension config: valid"
+      assert String.contains? output, "  Agent started: -"
+      assert String.contains? output, "  Agent config: -"
+      assert String.contains? output, "  Agent lock path: -"
+      assert String.contains? output, "  Agent logger: -"
+    end
+  end
+
+  describe "when the agent diagnose report contains an error" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, ~s({ "error": "fatal error" }))
+    end
+
+    test "prints the error" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics\n  Error: fatal error"
+    end
+  end
+
+  describe "when an agent diagnose report test contains an error" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, ~s(
+        {
+          "agent": { "boot": { "started": { "result": false, "error": "my error" } } }
+        }
+      ))
+    end
+
+    test "prints the error" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Agent started: not started\n    Error: my error"
+    end
+  end
+
+  describe "when an agent diagnose report test contains command output" do
+    setup do
+      @nif.set(:loaded?, true)
+      @nif.set(:diagnose, ~s(
+        {
+          "agent": { "boot": { "started": { "result": false, "output": "my output" } } }
+        }
+      ))
+    end
+
+    test "prints the output" do
+      output = run()
+      assert String.contains? output, "Agent diagnostics"
+      assert String.contains? output, "  Agent started: not started\n    Output: my output"
     end
   end
 
@@ -211,6 +303,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
     @tag :skip_env_test_no_nif
     test "outputs writable and creates log file", %{log_dir_path: log_dir_path, log_file_path: log_file_path} do
+      @nif.set(:run_diagnose, true)
       output = run()
       assert String.contains? output, "log_dir_path: #{log_dir_path}\n    - Writable?: yes"
       assert String.contains? output, "log_file_path: #{log_file_path}\n    - Writable?: yes"

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -27,7 +27,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
   test_with_mock "channel_action function decorator", Appsignal.Transaction, [:passthrough], [] do
     SomeApp.MyChannel.handle_in("ping", :payload, %Socket{})
     t = Appsignal.TransactionRegistry.lookup(self())
-    assert called Transaction.start(t.id, :background_job)
+    assert called Transaction.start(t.id, :channel)
     assert called Transaction.set_action(t, "Appsignal.Phoenix.ChannelTest.SomeApp.MyChannel#ping")
     assert called Transaction.finish(t)
     assert called Transaction.complete(t)
@@ -36,7 +36,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
   test_with_mock "direct calling of channel_action function", Appsignal.Transaction, [:passthrough], [] do
     SomeApp.MyChannel.handle_in("pong", :payload, %Socket{})
     t = Appsignal.TransactionRegistry.lookup(self())
-    assert called Transaction.start(t.id, :background_job)
+    assert called Transaction.start(t.id, :channel)
     assert called Transaction.set_action(t, "Appsignal.Phoenix.ChannelTest.SomeApp.MyChannel#pong")
     assert called Transaction.finish(t)
     assert called Transaction.complete(t)

--- a/test/support/fake_diagnose_report.ex
+++ b/test/support/fake_diagnose_report.ex
@@ -1,0 +1,21 @@
+defmodule Appsignal.Diagnose.FakeReport do
+  @behaviour Appsignal.Diagnose.ReportBehaviour
+
+  def start_link do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  def get(key) do
+    Agent.get(__MODULE__, &Map.get(&1, key))
+  end
+
+  def set(key, value) do
+    Agent.update(__MODULE__, &Map.put(&1, key, value))
+  end
+
+  def send(_, report) do
+    Agent.update(__MODULE__, &Map.put(&1, :report_sent?, true))
+    Agent.update(__MODULE__, &Map.put(&1, :sent_report, report))
+    get(:response) || {:error, %{reason: "response not set"}}
+  end
+end

--- a/test/support/fake_nif.ex
+++ b/test/support/fake_nif.ex
@@ -16,4 +16,12 @@ defmodule Appsignal.FakeNif do
   def running_in_container? do
     Agent.get(__MODULE__, &Map.get(&1, :running_in_container?, true))
   end
+
+  def diagnose do
+    if Agent.get(__MODULE__, &Map.get(&1, :run_diagnose, false)) do
+      Appsignal.Nif.diagnose
+    else
+      Agent.get(__MODULE__, &Map.get(&1, :diagnose, "{}"))
+    end
+  end
 end


### PR DESCRIPTION
Adds `ErrorHandler.extract_stacktrace/1`, which tries to extract the stacktrace from the exception, as that stack trace will include the line the error happened on as opposed to the stack trace from the error report's `:error_info`, which does not.

In short (and as shown in 2a5bf34c20aa6b4051b055fda0d6bab2ab562c06):

```
(stdlib) gen_server.erl:812: :gen_server.terminate/7
(stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```

... becomes:

```
(elixir) unicode/unicode.ex:190: String.Unicode.length/1
test/appsignal/error_handler/error_matcher_test.exs:27: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2
(stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
(stdlib) gen_server.erl:667: :gen_server.handle_msg/5
(stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```