### PR TITLE
Only set `active` in appsignal.exs if no environment based configuration files exist

### DIFF
--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -179,7 +179,7 @@ defmodule Mix.Tasks.Appsignal.Install do
     if File.exists? env_file do
       IO.write "Activating #{env} environment: "
 
-      active_content = "\nconfig :appsignal, :config, active: true, env: :#{env}\n"
+      active_content = "\nconfig :appsignal, :config, active: true\n"
       case file_contains?(env_file, active_content) do
         :ok -> IO.puts "Success! (Already active?)"
         {:error, :not_found} ->

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -154,12 +154,17 @@ defmodule Mix.Tasks.Appsignal.Install do
 
   # Contents for the config/appsignal.exs file.
   defp appsignal_config_file_contents(config) do
+    options = [
+      ~s(  active: true),
+      ~s(  name: "#{config[:name]}"),
+      ~s(  push_api_key: "#{config[:push_api_key]}"),
+      ~s(  env: Mix.env)
+    ]
+
     "use Mix.Config\n\n" <>
       "config :appsignal, :config,\n" <>
-      ~s(  active: true,\n) <>
-      ~s(  name: "#{config[:name]}",\n) <>
-      ~s(  push_api_key: "#{config[:push_api_key]}",\n) <>
-      ~s(  env: Mix.env\n)
+      Enum.join(options, ",\n") <>
+      "\n"
   end
 
   # Append a line to Mix configuration environment files which activate

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -235,7 +235,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       |> IO.binwrite(~s(use Mix.Config\n# config\nimport_config "appsignal.exs"))
       |> File.close
       File.open!(Path.join(@test_config_directory, "dev.exs"), [:append])
-      |> IO.binwrite(~s(\nconfig :appsignal, :config, active: true, env: :dev\n))
+      |> IO.binwrite(~s(\nconfig :appsignal, :config, active: true\n))
       |> File.close
 
       output = run_with_file_config()
@@ -293,7 +293,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
     case File.read(Path.join(@test_config_directory, "#{env}.exs")) do
       {:ok, env_config} ->
         String.contains?(env_config, ~s(use Mix.Config\n# #{env}\n)) &&
-          String.contains?(env_config, ~s(\nconfig :appsignal, :config, active: true, env: :#{env}))
+          String.contains?(env_config, ~s(\nconfig :appsignal, :config, active: true))
       {:error, _} -> false
     end
   end

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -83,7 +83,9 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       if context[:file_config] do
         File.mkdir_p!(@test_config_directory)
         create_config_file()
-        create_config_file_for_env("test")
+        create_config_file_for_env("dev")
+        create_config_file_for_env("stag")
+        create_config_file_for_env("prod")
 
         on_exit :cleanup_tmp_dir, fn ->
           File.rm_rf!(@test_directory)
@@ -175,18 +177,26 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       app_config = File.read!(Path.join(@test_config_directory, "config.exs"))
       assert String.contains? app_config, ~s(\nimport_config "appsignal.exs")
 
-      # Deactivates Appsignal for the test environment
-      assert String.contains? output, "Deactivating AppSignal in the test environment: Success!"
-      assert config_deactivated_for_test_env?()
+      # Activates AppSignal in the production, staging and development environments
+      assert String.contains? output, "Activating dev environment: Success!"
+      assert String.contains? output, "Activating stag environment: Success!"
+      assert String.contains? output, "Activating prod environment: Success!"
+      assert config_active_for_env?("dev")
+      assert config_active_for_env?("stag")
+      assert config_active_for_env?("prod")
     end
 
     @tag :file_config
     test "file based config option doesn't crash if a config file doesn't exist" do
-      File.rm(Path.join(@test_config_directory, "test.exs"))
+      File.rm(Path.join(@test_config_directory, "stag.exs"))
       output = run_with_file_config()
 
-      refute String.contains? output, "Deactivating AppSignal"
-      refute config_deactivated_for_test_env?()
+      assert String.contains? output, "Activating dev environment: Success!"
+      refute String.contains? output, "Activating stag environment:"
+      assert String.contains? output, "Activating prod environment: Success!"
+      assert config_active_for_env?("dev")
+      refute config_active_for_env?("stag")
+      assert config_active_for_env?("prod")
     end
 
     @tag :file_config
@@ -194,13 +204,13 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       File.open!(Path.join(@test_config_directory, "config.exs"), [:write])
       |> IO.binwrite(~s(use Mix.Config\n# config\nimport_config "appsignal.exs"))
       |> File.close
-      File.open!(Path.join(@test_config_directory, "test.exs"), [:append])
-      |> IO.binwrite(~s(\nconfig :appsignal, :config, active: false\n))
+      File.open!(Path.join(@test_config_directory, "dev.exs"), [:append])
+      |> IO.binwrite(~s(\nconfig :appsignal, :config, active: true, env: :dev\n))
       |> File.close
 
       output = run_with_file_config()
       assert String.contains? output, "Linking config to config/config.exs: Success! (Already linked?)"
-      assert String.contains? output, "Deactivating AppSignal in the test environment: Success! (Already deactivated)"
+      assert String.contains? output, "Activating dev environment: Success! (Already active?)"
     end
 
     test "outputs 'installed!' message" do
@@ -240,11 +250,11 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
 
   # Checks if the original file content is present and if the env has AppSignal
   # activation config.
-  defp config_deactivated_for_test_env? do
-    case File.read(Path.join(@test_config_directory, "test.exs")) do
+  defp config_active_for_env?(env) do
+    case File.read(Path.join(@test_config_directory, "#{env}.exs")) do
       {:ok, env_config} ->
-        String.contains?(env_config, ~s(use Mix.Config\n# test\n)) &&
-          String.contains?(env_config, ~s(\nconfig :appsignal, :config, active: false))
+        String.contains?(env_config, ~s(use Mix.Config\n# #{env}\n)) &&
+          String.contains?(env_config, ~s(\nconfig :appsignal, :config, active: true, env: :#{env}))
       {:error, _} -> false
     end
   end


### PR DESCRIPTION
dace2aa0df7d63a09a4000e6617b2b11201132f6 introduced a regression where the main config (`config/appsignal.exs`) overwrote the `active` option in the environment based configuration, because the main config is loaded after the environment config. 

Instead of setting `active` to `true` in the main configuration and disabling it in the test environment, we're now only setting the `active` configuration in the main config if no env-based configuration files exist. 

Thanks for reporting this issue, @bittersweet! 🥇 