### PR TITLE
Add IGNORE_COOKIES option

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -187,7 +187,6 @@ defmodule Appsignal.Config do
       System.put_env("_APPSIGNAL_HTTP_PROXY", config[:http_proxy])
     end
     System.put_env("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
-    System.put_env("_APPSIGNAL_IGNORE_COOKIES", config[:ignore_cookies] |> Enum.join(","))
     System.put_env("_APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))
     System.put_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION", "elixir-" <> @language_integration_version)
     System.put_env("_APPSIGNAL_LOG", config[:log])

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -10,6 +10,7 @@ defmodule Appsignal.Config do
     env: :dev,
     filter_parameters: nil,
     ignore_actions: [],
+    ignore_cookies: [],
     ignore_errors: [],
     send_params: true,
     skip_session_data: false,
@@ -69,6 +70,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_LOG" => :log,
     "APPSIGNAL_LOG_PATH" => :log_path,
     "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
+    "APPSIGNAL_IGNORE_COOKIES" => :ignore_cookies,
     "APPSIGNAL_IGNORE_ACTIONS" => :ignore_actions,
     "APPSIGNAL_HTTP_PROXY" => :http_proxy,
     "APPSIGNAL_RUNNING_IN_CONTAINER" => :running_in_container,
@@ -80,7 +82,7 @@ defmodule Appsignal.Config do
   @string_keys ~w(APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_CA_FILE_PATH)
   @bool_keys ~w(APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING APPSIGNAL_ENABLE_ALLOCATION_TRACKING APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA)
   @atom_keys ~w(APPSIGNAL_APP_ENV)
-  @string_list_keys ~w(APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS)
+  @string_list_keys ~w(APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_COOKIES APPSIGNAL_IGNORE_ERRORS)
 
   defp load_environment(config, list, converter) do
     list |> Enum.reduce(
@@ -185,6 +187,7 @@ defmodule Appsignal.Config do
       System.put_env("_APPSIGNAL_HTTP_PROXY", config[:http_proxy])
     end
     System.put_env("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
+    System.put_env("_APPSIGNAL_IGNORE_COOKIES", config[:ignore_cookies] |> Enum.join(","))
     System.put_env("_APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))
     System.put_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION", "elixir-" <> @language_integration_version)
     System.put_env("_APPSIGNAL_LOG", config[:log])

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -122,6 +122,13 @@ defmodule Appsignal.ConfigTest do
         == default_configuration() |> Map.put(:ignore_actions, actions)
     end
 
+    test "ignore_cookies" do
+      cookies = ~w(session_cookie secret_cookie)
+
+      assert with_config(%{ignore_cookies: cookies}, &init_config/0)
+      == default_configuration() |> Map.put(:ignore_cookies, cookies)
+    end
+
     test "ignore_errors" do
       errors = ~w(VerySpecificError AnotherError)
 
@@ -249,6 +256,13 @@ defmodule Appsignal.ConfigTest do
           ExampleApplication.PageController#ignored
           ExampleApplication.PageController#also_ignored
       ))
+    end
+
+    test "ignore_cookies" do
+      assert with_env(
+        %{"APPSIGNAL_IGNORE_COOKIES" => "session_cookie,secret_cookie"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:ignore_cookies, ~w(session_cookie secret_cookie))
     end
 
     test "ignore_errors" do
@@ -381,6 +395,7 @@ defmodule Appsignal.ConfigTest do
       assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == nil
       assert System.get_env("_APPSIGNAL_HTTP_PROXY") == nil
       assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == ""
+      assert System.get_env("_APPSIGNAL_IGNORE_COOKIES") == ""
       assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == ""
       assert System.get_env("_APPSIGNAL_LOG_FILE_PATH") == nil
       assert System.get_env("_APPSIGNAL_WORKING_DIR_PATH") == nil
@@ -417,6 +432,7 @@ defmodule Appsignal.ConfigTest do
           ExampleApplication.PageController#ignored
           ExampleApplication.PageController#also_ignored
         ),
+        ignore_cookies: ~w(session_cookie secret_cookie),
         ignore_errors: ~w(VerySpecificError AnotherError),
         log: "stdout",
         log_path: "log/appsignal.log",
@@ -438,6 +454,7 @@ defmodule Appsignal.ConfigTest do
         assert System.get_env("_APPSIGNAL_HOSTNAME") == "My hostname"
         assert System.get_env("_APPSIGNAL_HTTP_PROXY") == "http://10.10.10.10:8888"
         assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"
+        assert System.get_env("_APPSIGNAL_IGNORE_COOKIES") == "session_cookie,secret_cookie"
         assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == "VerySpecificError,AnotherError"
         assert System.get_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION") == "elixir-" <> Mix.Project.config[:version]
         assert System.get_env("_APPSIGNAL_LOG") == "stdout"
@@ -475,6 +492,7 @@ defmodule Appsignal.ConfigTest do
       env: :dev,
       filter_parameters: nil,
       ignore_actions: [],
+      ignore_cookies: [],
       ignore_errors: [],
       send_params: true,
       skip_session_data: false,

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -395,7 +395,6 @@ defmodule Appsignal.ConfigTest do
       assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == nil
       assert System.get_env("_APPSIGNAL_HTTP_PROXY") == nil
       assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == ""
-      assert System.get_env("_APPSIGNAL_IGNORE_COOKIES") == ""
       assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == ""
       assert System.get_env("_APPSIGNAL_LOG_FILE_PATH") == nil
       assert System.get_env("_APPSIGNAL_WORKING_DIR_PATH") == nil
@@ -454,7 +453,6 @@ defmodule Appsignal.ConfigTest do
         assert System.get_env("_APPSIGNAL_HOSTNAME") == "My hostname"
         assert System.get_env("_APPSIGNAL_HTTP_PROXY") == "http://10.10.10.10:8888"
         assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"
-        assert System.get_env("_APPSIGNAL_IGNORE_COOKIES") == "session_cookie,secret_cookie"
         assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == "VerySpecificError,AnotherError"
         assert System.get_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION") == "elixir-" <> Mix.Project.config[:version]
         assert System.get_env("_APPSIGNAL_LOG") == "stdout"
@@ -464,6 +462,8 @@ defmodule Appsignal.ConfigTest do
         assert System.get_env("_APPSIGNAL_RUNNING_IN_CONTAINER") == "false"
         assert System.get_env("_APPSIGNAL_SEND_PARAMS") == "true"
         assert System.get_env("_APPSIGNAL_WORKING_DIR_PATH") == "/tmp/appsignal"
+
+        refute System.get_env("_APPSIGNAL_IGNORE_COOKIES")
       end)
     end
 


### PR DESCRIPTION
When using AppSignal, we'd like to skip sending session cookies to it, as they can be used to impersonate a user in the app.

This PR adds an option to remove certain cookie keys from what is sent to AppSignal in the environment's `req_header.cookie` key.