### PR TITLE
Use more explicit app name in test suite

### DIFF
--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -140,8 +140,8 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "name" do
-      assert with_config(%{name: "my_application"}, &init_config/0)
-        == default_configuration() |> Map.put(:name, "my_application")
+      assert with_config(%{name: "AppSignal test suite app"}, &init_config/0)
+        == default_configuration() |> Map.put(:name, "AppSignal test suite app")
     end
 
     test "push_api_key" do
@@ -274,9 +274,9 @@ defmodule Appsignal.ConfigTest do
 
     test "name" do
       assert with_env(
-        %{"APPSIGNAL_APP_NAME" => "my_application"},
+        %{"APPSIGNAL_APP_NAME" => "AppSignal test suite app"},
         &init_config/0
-      ) == default_configuration() |> Map.put(:name, "my_application")
+      ) == default_configuration() |> Map.put(:name, "AppSignal test suite app")
     end
 
     test "push_api_key" do
@@ -359,7 +359,7 @@ defmodule Appsignal.ConfigTest do
   describe "reset_environment_config!" do
     test "deletes existing configuration in environment" do
       assert with_env(
-        %{"_APPSIGNAL_APP_NAME" => "foo"},
+        %{"_APPSIGNAL_APP_NAME" => "AppSignal test suite app"},
         fn() ->
           Appsignal.Config.reset_environment_config!
           System.get_env("_APPSIGNAL_APP_NAME")
@@ -390,7 +390,7 @@ defmodule Appsignal.ConfigTest do
     test "deletes existing configuration in environment" do
       with_env(
         # Name is present in the configuration
-        %{"_APPSIGNAL_APP_NAME" => "foo"},
+        %{"_APPSIGNAL_APP_NAME" => "AppSignal test suite app"},
         fn() ->
           # The new config doesn't have a name
           with_config(%{name: ""}, fn() ->
@@ -420,7 +420,7 @@ defmodule Appsignal.ConfigTest do
         ignore_errors: ~w(VerySpecificError AnotherError),
         log: "stdout",
         log_path: "log/appsignal.log",
-        name: "My awesome app",
+        name: "AppSignal test suite app",
         running_in_container: false,
         working_dir_path: "/tmp/appsignal"
       }, fn() ->
@@ -429,7 +429,7 @@ defmodule Appsignal.ConfigTest do
         assert System.get_env("_APPSIGNAL_ACTIVE") == "true"
         assert System.get_env("_APPSIGNAL_AGENT_PATH") == List.to_string(:code.priv_dir(:appsignal))
         assert System.get_env("_APPSIGNAL_AGENT_VERSION") == Appsignal.Agent.version
-        assert System.get_env("_APPSIGNAL_APP_NAME") == "My awesome app"
+        assert System.get_env("_APPSIGNAL_APP_NAME") == "AppSignal test suite app"
         assert System.get_env("_APPSIGNAL_CA_FILE_PATH") == "/foo/bar/zab.ca"
         assert System.get_env("_APPSIGNAL_DEBUG_LOGGING") == "true"
         assert System.get_env("_APPSIGNAL_ENABLE_HOST_METRICS") == "false"
@@ -450,17 +450,17 @@ defmodule Appsignal.ConfigTest do
       end)
     end
 
-    test "name as atom" do
-      with_config(%{name: :my_application}, fn() ->
+    test "ame as atom" do
+      with_config(%{name: :appsignal_test_suite_app}, fn() ->
         write_to_environment()
-        assert System.get_env("_APPSIGNAL_APP_NAME") == "my_application"
+        assert System.get_env("_APPSIGNAL_APP_NAME") == "appsignal_test_suite_app"
       end)
     end
 
     test "name as string" do
-      with_config(%{name: "My awesome application"}, fn() ->
+      with_config(%{name: "AppSignal test suite app"}, fn() ->
         write_to_environment()
-        assert System.get_env("_APPSIGNAL_APP_NAME") == "My awesome application"
+        assert System.get_env("_APPSIGNAL_APP_NAME") == "AppSignal test suite app"
       end)
     end
   end

--- a/test/appsignal/diagnose/report_test.exs
+++ b/test/appsignal/diagnose/report_test.exs
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose.ReportTest do
     diagnose_bypass = Bypass.open
     setup_with_config(%{
       api_key: "foo",
-      name: "My app",
+      name: "AppSignal test suite app",
       environment: "production",
       hostname: "foo",
       diagnose_endpoint: "http://localhost:#{diagnose_bypass.port}/diag"

--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -13,13 +13,13 @@ defmodule Appsignal.ReleaseUpgradeTest do
       Appsignal.initialize
 
       # Sets config to Application environment
-      assert config()[:name] == "My app v1"
+      assert config()[:name] == "AppSignal test suite app v1"
       # Sets config to system environment variables
-      assert System.get_env("_APPSIGNAL_APP_NAME") == "My app v1"
+      assert System.get_env("_APPSIGNAL_APP_NAME") == "AppSignal test suite app v1"
 
       # The system reloads the application config (set in Mix) during the upgrade.
       new_config = valid_configuration()
-      |> Map.put(:name, "My app v2")
+      |> Map.put(:name, "AppSignal test suite app v2")
 
       with_config(new_config, fn() ->
         # Hot reload / upgrade
@@ -29,8 +29,8 @@ defmodule Appsignal.ReleaseUpgradeTest do
         :timer.sleep 3500
         refute Process.alive?(config_reload_pid)
 
-        assert config()[:name] == "My app v2"
-        assert System.get_env("_APPSIGNAL_APP_NAME") == "My app v2"
+        assert config()[:name] == "AppSignal test suite app v2"
+        assert System.get_env("_APPSIGNAL_APP_NAME") == "AppSignal test suite app v2"
       end)
     end)
   end
@@ -47,7 +47,7 @@ defmodule Appsignal.ReleaseUpgradeTest do
       ignore_actions: [],
       ignore_errors: [],
       log: "file",
-      name: "My app v1",
+      name: "AppSignal test suite app v1",
       push_api_key: "00000000-0000-0000-0000-000000000000",
       send_params: true,
       skip_session_data: false,

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
     end
 
     defp run_with_file_config do
-      capture_io([input: "My app's name\n1"], fn ->
+      capture_io([input: "AppSignal test suite app\n1"], fn ->
         File.cd!(@test_directory, fn ->
           Mix.Tasks.Appsignal.Install.run(["my_push_api_key"])
         end)
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
     end
 
     defp run_with_environment_config do
-      capture_io([input: "My app's name\n2"], fn ->
+      capture_io([input: "AppSignal test suite app\n2"], fn ->
         Mix.Tasks.Appsignal.Install.run(["my_push_api_key"])
       end)
     end
@@ -123,7 +123,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
 
     test "requires an application name" do
       # First entry is empty and thus invalid, so it asks for the name again.
-      output = capture_io([input: "\nfoo\n2"], fn ->
+      output = capture_io([input: "\nAppSignal test suite app\n2"], fn ->
         Mix.Tasks.Appsignal.Install.run(["my_push_api_key"])
       end)
 
@@ -148,7 +148,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       output = run_with_environment_config()
       assert String.contains? output, "What is your preferred configuration method? (1/2): "
       assert String.contains? output, "Configuring with environment variables."
-      assert String.contains? output, ~s(APPSIGNAL_APP_NAME="My app's name")
+      assert String.contains? output, ~s(APPSIGNAL_APP_NAME="AppSignal test suite app")
       assert String.contains? output, ~s(APPSIGNAL_APP_ENV="production")
       assert String.contains? output, ~s(APPSIGNAL_PUSH_API_KEY="my_push_api_key")
     end
@@ -167,7 +167,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? appsignal_config, ~s(use Mix.Config\n\n) <>
         ~s(config :appsignal, :config,\n) <>
         ~s(  active: true,\n) <>
-        ~s(  name: "My app's name",\n) <>
+        ~s(  name: "AppSignal test suite app",\n) <>
         ~s(  push_api_key: "my_push_api_key",\n) <>
         ~s(  env: Mix.env\n)
 


### PR DESCRIPTION
To help prevent future debug sessions, such as the one for our nominee
for most obscure bug of the year, we are going to use more explicit app
names that can be easily traced back to the Elixir package test suite.