### PR TITLE
Download agent in priv path

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -63,7 +63,7 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp download_file(url, version) do
-    filename = "/tmp/appsignal-agent-#{version}.tar.gz"
+    filename = priv_path("appsignal-agent-#{version}.tar.gz")
     case File.exists?(filename) do
       true ->
         filename


### PR DESCRIPTION
This to prevent potential permission issues as described in #213.
I don't see a reason why we can't download it in the private directory
instead of the system /tmp dir. We roughly do the same for the Ruby gem
as well.

Closes #213