### PR TITLE
Add ignore_namespaces option

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -12,6 +12,7 @@ defmodule Appsignal.Config do
     filter_parameters: nil,
     ignore_actions: [],
     ignore_errors: [],
+    ignore_namespaces: [],
     send_params: true,
     skip_session_data: false,
     log: "file"
@@ -70,8 +71,9 @@ defmodule Appsignal.Config do
     "APPSIGNAL_DNS_SERVERS" => :dns_servers,
     "APPSIGNAL_LOG" => :log,
     "APPSIGNAL_LOG_PATH" => :log_path,
-    "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
     "APPSIGNAL_IGNORE_ACTIONS" => :ignore_actions,
+    "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
+    "APPSIGNAL_IGNORE_NAMESPACES" => :ignore_namespaces,
     "APPSIGNAL_HTTP_PROXY" => :http_proxy,
     "APPSIGNAL_RUNNING_IN_CONTAINER" => :running_in_container,
     "APPSIGNAL_WORKING_DIR_PATH" => :working_dir_path,
@@ -82,7 +84,7 @@ defmodule Appsignal.Config do
   @string_keys ~w(APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_CA_FILE_PATH)
   @bool_keys ~w(APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING APPSIGNAL_ENABLE_ALLOCATION_TRACKING APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA)
   @atom_keys ~w(APPSIGNAL_APP_ENV)
-  @string_list_keys ~w(APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS APPSIGNAL_DNS_SERVERS)
+  @string_list_keys ~w(APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS APPSIGNAL_IGNORE_NAMESPACES APPSIGNAL_DNS_SERVERS)
 
   defp load_environment(config, list, converter) do
     list |> Enum.reduce(
@@ -192,6 +194,7 @@ defmodule Appsignal.Config do
     end
     System.put_env("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
     System.put_env("_APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))
+    System.put_env("_APPSIGNAL_IGNORE_NAMESPACES", config[:ignore_namespaces] |> Enum.join(","))
     System.put_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION", "elixir-" <> @language_integration_version)
     System.put_env("_APPSIGNAL_LOG", config[:log])
     unless empty?(config[:log_path]) do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -134,6 +134,13 @@ defmodule Appsignal.ConfigTest do
         == default_configuration() |> Map.put(:ignore_errors, errors)
     end
 
+    test "ignore_namespaces" do
+      namespaces = ~w(admin private_namespace)
+
+      assert with_config(%{ignore_namespaces: namespaces}, &init_config/0)
+        == default_configuration() |> Map.put(:ignore_namespaces, namespaces)
+    end
+
     test "log" do
       assert with_config(%{log: "stdout"}, &init_config/0)
         == default_configuration() |> Map.put(:log, "stdout")
@@ -270,6 +277,13 @@ defmodule Appsignal.ConfigTest do
       ) == default_configuration() |> Map.put(:ignore_errors, ~w(VerySpecificError AnotherError))
     end
 
+    test "ignore_namespaces" do
+      assert with_env(
+        %{"APPSIGNAL_IGNORE_NAMESPACES" => "admin,private_namespace"},
+        &init_config/0
+      ) == default_configuration() |> Map.put(:ignore_namespaces, ~w(admin private_namespace))
+    end
+
     test "log" do
       assert with_env(
         %{"APPSIGNAL_LOG" => "stdout"},
@@ -392,8 +406,9 @@ defmodule Appsignal.ConfigTest do
       assert System.get_env("_APPSIGNAL_CA_FILE_PATH") == nil
       assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == nil
       assert System.get_env("_APPSIGNAL_HTTP_PROXY") == nil
-      assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == ""
       assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == ""
+      assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == ""
+      assert System.get_env("_APPSIGNAL_IGNORE_NAMESPACES") == ""
       assert System.get_env("_APPSIGNAL_LOG_FILE_PATH") == nil
       assert System.get_env("_APPSIGNAL_WORKING_DIR_PATH") == nil
       assert System.get_env("_APPSIGNAL_RUNNING_IN_CONTAINER") == nil
@@ -431,6 +446,7 @@ defmodule Appsignal.ConfigTest do
           ExampleApplication.PageController#also_ignored
         ),
         ignore_errors: ~w(VerySpecificError AnotherError),
+        ignore_namespaces: ~w(admin private_namespace),
         log: "stdout",
         log_path: "log/appsignal.log",
         name: "AppSignal test suite app",
@@ -453,6 +469,7 @@ defmodule Appsignal.ConfigTest do
         assert System.get_env("_APPSIGNAL_HTTP_PROXY") == "http://10.10.10.10:8888"
         assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"
         assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == "VerySpecificError,AnotherError"
+        assert System.get_env("_APPSIGNAL_IGNORE_NAMESPACES") == "admin,private_namespace"
         assert System.get_env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION") == "elixir-" <> Mix.Project.config[:version]
         assert System.get_env("_APPSIGNAL_LOG") == "stdout"
         assert System.get_env("_APPSIGNAL_LOG_FILE_PATH") == "log/appsignal.log"
@@ -498,6 +515,7 @@ defmodule Appsignal.ConfigTest do
       filter_parameters: nil,
       ignore_actions: [],
       ignore_errors: [],
+      ignore_namespaces: [],
       send_params: true,
       skip_session_data: false,
       valid: false,


### PR DESCRIPTION
Related PR https://github.com/appsignal/appsignal-ruby/pull/312.

This feature was added to the AppSignal extension in PR
https://github.com/appsignal/appsignal-agent/pull/255, this PR adds the
config option to the Elixir package.

Configure `ignore_namespaces` to ignore transactions (requests and jobs)
from certain namespaces configured as described in our docs:
http://docs.appsignal.com/application/namespaces.html

This allows users to ignore entire namespaces, such as administration
panels, without having to ignore all the controllers in that namespace
with `ignore_actions`.