### PR TITLE
Check if curl is installed before calling it

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -69,14 +69,23 @@ defmodule Mix.Appsignal.Helper do
         filename
       false ->
         Logger.info "Downloading agent release from #{url}"
-        case System.cmd("curl", ["-s", "-S", "--retry", Integer.to_string(@max_retries), "-f", "-o", filename, url], stderr_to_stdout: true) do
-          {_, 0} ->
-            filename
-          {result, exitcode} ->
-            IO.binwrite(result)
+        case System.find_executable("curl") do
+          nil ->
             raise Mix.Error, message: """
-            Download failed with code #{exitcode}
+            Could not find the curl executable. Please make sure curl is
+            installed on this system as it is needed to download the AppSignal
+            extension and agent.
             """
+          _ ->
+            case System.cmd("curl", ["-s", "-S", "--retry", Integer.to_string(@max_retries), "-f", "-o", filename, url], stderr_to_stdout: true) do
+              {_, 0} ->
+                filename
+              {result, exitcode} ->
+                IO.binwrite(result)
+                raise Mix.Error, message: """
+                Download failed with code #{exitcode}
+                """
+            end
         end
     end
   end


### PR DESCRIPTION
Closes #223

It can happen that curl is not installed on the system. If this is the
case, print an error that the agent could not be installed.

This to improve the normal error message which doesn't help the user
figure out what's going wrong.

```
** (ErlangError) erlang error: :enoent
    (elixir) lib/system.ex:552: System.cmd("curl", {options...})
    mix_helpers.exs:80: Mix.Appsignal.Helper.download_file/2
    {stacktrace...}
```