### PR TITLE
Add arch mapping for 32bit linux

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -111,6 +111,7 @@ defmodule Mix.Appsignal.Helper do
   defp make_args(_), do: []
 
   if Mix.env != :test_no_nif do
+    defp map_arch('i686-pc-linux-gnu' ++ _), do: "i686-linux"
     defp map_arch('x86_64-redhat-linux-gnu' ++ _), do: "x86_64-linux"
     defp map_arch('x86_64-pc-linux-gnu' ++ _), do: "x86_64-linux"
     defp map_arch('x86_64-alpine-linux' ++ _), do: "x86_64-linux"

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -111,10 +111,13 @@ defmodule Mix.Appsignal.Helper do
   defp make_args(_), do: []
 
   if Mix.env != :test_no_nif do
+    defp map_arch('i686-alpine-linux' ++ _), do: "i686-linux"
     defp map_arch('i686-pc-linux-gnu' ++ _), do: "i686-linux"
-    defp map_arch('x86_64-redhat-linux-gnu' ++ _), do: "x86_64-linux"
-    defp map_arch('x86_64-pc-linux-gnu' ++ _), do: "x86_64-linux"
+    defp map_arch('i686-redhat-linux-gnu' ++ _), do: "i686-linux"
+    defp map_arch('i686-unknown-linux' ++ _), do: "i686-linux"
     defp map_arch('x86_64-alpine-linux' ++ _), do: "x86_64-linux"
+    defp map_arch('x86_64-pc-linux-gnu' ++ _), do: "x86_64-linux"
+    defp map_arch('x86_64-redhat-linux-gnu' ++ _), do: "x86_64-linux"
     defp map_arch('x86_64-unknown-linux' ++ _), do: "x86_64-linux"
     defp map_arch('x86_64-apple-darwin' ++ _), do: "x86_64-darwin"
   end


### PR DESCRIPTION
Could you do a sanity check @jeffkreeftmeijer ?

And should I added mapping for the other linux archs too?

```
x86_64-redhat-linux-gnu
x86_64-alpine-linux
x86_64-unknown-linux
```

As reported in https://app.intercom.io/a/apps/yzor8gyw/respond/inbox/540709/conversations/10344463255

**Note**: This is a PR aimed at master so we can do a patch release 