### PR TITLE
Trick Dialyzer into not warning

### DIFF
--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -243,7 +243,9 @@ defmodule Appsignal.Nif do
   end
 
   def _finish(_transaction_resource) do
-    :no_sample
+    # Using `String.to_atom("no_sample") instead of `:no_sample` to trick
+    # Dialyzer into thinking this value isn't hardcoded.
+    String.to_atom("no_sample")
   end
 
   def _complete(_transaction_resource) do


### PR DESCRIPTION
As reported in #165, Dialyzer produced a warning in Phoenix and Plug
applications:

    lib/hue_labs_backend/endpoint.ex:51: The pattern 'true' can never match the type 'false'
    lib/hue_labs_backend/endpoint.ex:51: The test 'nil' | 'no_sample' == 'sample' can never evaluate to 'true'

Normally, the agent will decide which of the samples sent to it require request
metadata, by returning either `:sample` or `:no_sample` from
`Appsignal.Nif._finish/1`. By default (and when the NIF can't be
loaded), `_finish/1` will return `:no_sample`, which is hardcoded in the
function in the `Appsignal.Nif` module. The function in the NIF itself
will overwrite the function in the Elixir code when the NIF is loaded.

Dialyzer can't seem to handle extending code like this, and will assume
that `_finish/1` will always return `:no_sample` based on the code in
`Appsignal.Nif`. In `Appsignal.Plug.finish_with_conn/2`, the result of
`finish/1` is compared to `:sample`, which trips Dialyzer up, because
`:no_sample` can never be equal to `:sample`.

By using `String.to_atom("no_sample")` instead of `:no_sample` in
`_finish/1`, this commit tricks Dialyzer into thinking the value isn't
hardcoded, removing the warning. This isn't a really nice solution, so
ideas on how to improve this are welcome.

Closes #165.