### PR TITLE
Drop GenEvent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,3 @@ script:
   - MIX_ENV=test mix compile --warnings-as-errors && MIX_ENV=test mix test
   - MIX_ENV=test_phoenix mix compile --warnings-as-errors && MIX_ENV=test_phoenix mix test
   - MIX_ENV=test_no_nif mix compile --warnings-as-errors && MIX_ENV=test_no_nif mix test
-
-matrix:
-  allow_failures:
-    - elixir: 1.5.1

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -10,8 +10,6 @@ defmodule Appsignal.ErrorHandler do
 
   """
 
-  use GenEvent
-
   require Logger
 
   alias Appsignal.{Transaction, Backtrace}
@@ -21,7 +19,7 @@ defmodule Appsignal.ErrorHandler do
   """
   @spec get_last_transaction :: Transaction.t | nil
   def get_last_transaction do
-    GenEvent.call(:error_logger, Appsignal.ErrorHandler, :get_last_transaction)
+    :gen_event.call(:error_logger, Appsignal.ErrorHandler, :get_last_transaction)
   end
 
   def init(_) do

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -30,8 +30,6 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
   end
 
   defmodule CustomErrorHandler do
-    use GenEvent
-
     def init(_) do
       {:ok, nil}
     end
@@ -49,7 +47,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
   defp get_last_crash do
     :timer.sleep(20)
-    GenEvent.call(:error_logger, @error_handler, :get_matched_crash)
+    :gen_event.call(:error_logger, @error_handler, :get_matched_crash)
   end
 
   defp assert_crash_caught({:ok, pid}) when is_pid(pid) do


### PR DESCRIPTION
Use :gen_event instead of GenEvent, which is deprecated, and is [breaking the build](https://travis-ci.org/appsignal/appsignal-elixir/jobs/266830270) on 1.5.