### PR TITLE
Channel params

### DIFF
--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -80,12 +80,13 @@ defmodule Appsignal.Instrumentation.Decorators do
   end
 
   @doc false
-  def channel_action(body, context = %{args: [action, _payload, socket]}) do
+  def channel_action(body, context = %{args: [action, payload, socket]}) do
     quote do
       Appsignal.Phoenix.Channel.channel_action(
         unquote(context.module),
         unquote(action),
         unquote(socket),
+        unquote(payload),
         fn -> unquote(body) end
       )
     end

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -76,6 +76,7 @@ if Appsignal.phoenix? do
     socket metadata to the transaction.
     """
     def set_metadata(transaction, socket) do
+      IO.warn "Appsignal.Channel.set_metadata/1 is deprecated. Set params and environment data directly with Appsignal.Transaction.set_sample_data/2 instead."
       transaction
       |> @transaction.set_sample_data("params", socket.assigns |> Appsignal.Utils.ParamsFilter.filter_values)
       |> @transaction.set_sample_data("environment", request_environment(socket))

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -63,8 +63,12 @@ if Appsignal.phoenix? do
       resp = @transaction.finish(transaction)
       if resp == :sample do
         transaction
-        |> @transaction.set_sample_data("params", params)
-        |> @transaction.set_sample_data("environment", request_environment(socket))
+        |> @transaction.set_sample_data(
+          "params", Appsignal.Utils.ParamsFilter.filter_values(params)
+        )
+        |> @transaction.set_sample_data(
+          "environment", request_environment(socket)
+        )
       end
       :ok = @transaction.complete(transaction)
 

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -47,10 +47,12 @@ if Appsignal.phoenix? do
     @doc """
     Record a channel action. Meant to be called from the 'channel_action' instrumentation decorator.
     """
+    @spec channel_action(atom, String.t, Phoenix.Socket.t, fun) :: any
     def channel_action(module, name, %Phoenix.Socket{} = socket, function) do
       channel_action(module, name, %Phoenix.Socket{} = socket, %{}, function)
     end
 
+    @spec channel_action(atom, String.t, Phoenix.Socket.t, map, fun) :: any
     def channel_action(module, name, %Phoenix.Socket{} = socket, params, function) do
       transaction = @transaction.start(@transaction.generate_id(), :channel)
 
@@ -79,6 +81,7 @@ if Appsignal.phoenix? do
     Given the `Appsignal.Transaction` and a `Phoenix.Socket`, add the
     socket metadata to the transaction.
     """
+    @spec set_metadata(Appsignal.Transaction.t, Phoenix.Socket.t) :: Appsignal.Transaction.t
     def set_metadata(transaction, socket) do
       IO.warn "Appsignal.Channel.set_metadata/1 is deprecated. Set params and environment data directly with Appsignal.Transaction.set_sample_data/2 instead."
       transaction
@@ -87,6 +90,7 @@ if Appsignal.phoenix? do
     end
 
     @socket_fields ~w(id channel endpoint handler ref topic transport)a
+    @spec request_environment(Phoenix.Socket.t) :: map
     defp request_environment(socket) do
       @socket_fields
       |> Enum.map(fn(k) -> {k, Map.get(socket, k)} end)

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -1,5 +1,7 @@
 if Appsignal.phoenix? do
   defmodule Appsignal.Phoenix.Channel do
+    @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
+
     @moduledoc """
     Instrumentation for channel events
 
@@ -40,34 +42,28 @@ if Appsignal.phoenix? do
             end)
           end
         end
-
     """
-
-    alias Appsignal.Transaction
 
     @doc """
     Record a channel action. Meant to be called from the 'channel_action' instrumentation decorator.
     """
     def channel_action(module, name, %Phoenix.Socket{} = socket, function) do
-      alias Appsignal.Transaction
-
-      transaction = Transaction.start(Transaction.generate_id(), :channel)
+      transaction = @transaction.start(@transaction.generate_id(), :channel)
 
       action_str = "#{module}##{name}"
       <<"Elixir.", action :: binary>> = action_str
-      Transaction.set_action(transaction, action)
+      @transaction.set_action(transaction, action)
 
       result = function.()
 
-      resp = Transaction.finish(transaction)
+      resp = @transaction.finish(transaction)
       if resp == :sample do
         Appsignal.Phoenix.Channel.set_metadata(transaction, socket)
       end
-      :ok = Transaction.complete(transaction)
+      :ok = @transaction.complete(transaction)
 
       result
     end
-
 
     @doc """
     Given the `Appsignal.Transaction` and a `Phoenix.Socket`, add the
@@ -75,8 +71,8 @@ if Appsignal.phoenix? do
     """
     def set_metadata(transaction, socket) do
       transaction
-      |> Transaction.set_sample_data("params", socket.assigns |> Appsignal.Utils.ParamsFilter.filter_values)
-      |> Transaction.set_sample_data("environment", request_environment(socket))
+      |> @transaction.set_sample_data("params", socket.assigns |> Appsignal.Utils.ParamsFilter.filter_values)
+      |> @transaction.set_sample_data("environment", request_environment(socket))
     end
 
     @socket_fields ~w(id channel endpoint handler ref topic transport)a

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -9,6 +9,7 @@ defmodule Appsignal.TransactionBehaviour do
   @callback set_error(Transaction.t | nil, String.t, String.t, any) :: Transaction.t
   @callback set_action(String.t) :: Transaction.t
   @callback set_action(Transaction.t | nil, String.t) :: Transaction.t
+  @callback set_sample_data(Transaction.t | nil, String.t, any) :: Transaction.t
 
   if Appsignal.plug? do
     @callback set_request_metadata(Transaction.t | nil, Plug.Conn.t) :: Transaction.t

--- a/test/appsignal/instrumentation/decorator_test.exs
+++ b/test/appsignal/instrumentation/decorator_test.exs
@@ -1,93 +1,92 @@
+defmodule UsingAppsignalDecorators do
+  use Appsignal.Instrumentation.Decorators
+
+  @decorate transaction()
+  def transaction do
+    bar(123)
+  end
+
+  @decorate transaction(:background_job)
+  def background_transaction do
+    bar(123)
+  end
+
+  @decorate transaction()
+  def transaction_with_return_value(x) do
+    2 * x
+  end
+
+  @decorate transaction_event()
+  def bar(arg) do
+    nested(arg, arg)
+  end
+
+  @doc "A moduledoc attribute"
+  @decorate transaction_event()
+  def nested(_arg1, _arg2) do
+  end
+end
+
+defmodule UsingAppsignalDecoratorsWithCustomNamespaces do
+  use Appsignal.Instrumentation.Decorators
+
+  @doc "A moduledoc attribute"
+  @decorate transaction_event :http
+  def bar(arg) do
+    nested(arg, arg)
+  end
+
+  @decorate transaction_event :db
+  def nested(_arg1, _arg2) do
+  end
+end
+
 defmodule Appsignal.Instrumentation.DecoratorsTest do
   use ExUnit.Case
   import Mock
 
   alias Appsignal.Transaction
 
-  defmodule Example do
-    use Appsignal.Instrumentation.Decorators
-
-    @decorate transaction()
-    def transaction do
-      bar(123)
-    end
-
-    @decorate transaction(:background_job)
-    def background_transaction do
-      bar(123)
-    end
-
-    @decorate transaction()
-    def transaction_with_return_value(x) do
-      2 * x
-    end
-
-    @decorate transaction_event()
-    def bar(arg) do
-      nested(arg, arg)
-    end
-
-    @doc "A moduledoc attribute"
-    @decorate transaction_event()
-    def nested(_arg1, _arg2) do
-    end
-
-  end
-
   test_with_mock "instrument module function", Appsignal.Transaction, [:passthrough], [] do
     t = Transaction.start("bar", :http_request)
-    Example.bar(123)
+    UsingAppsignalDecorators.bar(123)
     assert called Transaction.start_event(t)
-    assert called Transaction.finish_event(t, "bar", "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example.bar", "", 0)
-    assert called Transaction.finish_event(t, "nested", "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example.nested", "", 0)
+    assert called Transaction.finish_event(t, "bar", "Elixir.UsingAppsignalDecorators.bar", "", 0)
+    assert called Transaction.finish_event(t, "nested", "Elixir.UsingAppsignalDecorators.nested", "", 0)
   end
 
   test_with_mock "instrument transaction", Appsignal.Transaction, [:passthrough], [] do
-    Example.transaction
+    UsingAppsignalDecorators.transaction
     assert called Transaction.start(:_, :http_request)
-    assert called Appsignal.Transaction.set_action(:_, "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example#transaction")
+    assert called Appsignal.Transaction.set_action(:_, "Elixir.UsingAppsignalDecorators#transaction")
     assert called Appsignal.Transaction.finish(:_)
     assert called Appsignal.Transaction.complete(:_)
   end
 
   test_with_mock "instrument background transaction", Appsignal.Transaction, [:passthrough], [] do
-    Example.background_transaction
+    UsingAppsignalDecorators.background_transaction
     assert called Transaction.start(:_, :background_job)
-    assert called Appsignal.Transaction.set_action(:_, "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example#background_transaction")
+    assert called Appsignal.Transaction.set_action(:_, "Elixir.UsingAppsignalDecorators#background_transaction")
     assert called Appsignal.Transaction.finish(:_)
     assert called Appsignal.Transaction.complete(:_)
   end
 
   test_with_mock "instrument transaction with return value", Appsignal.Transaction, [:passthrough], [] do
-    result = Example.transaction_with_return_value(123)
+    result = UsingAppsignalDecorators.transaction_with_return_value(123)
     assert 246 == result
     assert called Transaction.start(:_, :http_request)
-    assert called Appsignal.Transaction.set_action(:_, "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example#transaction_with_return_value")
+    assert called Appsignal.Transaction.set_action(:_, "Elixir.UsingAppsignalDecorators#transaction_with_return_value")
     assert called Appsignal.Transaction.finish(:_)
     assert called Appsignal.Transaction.complete(:_)
   end
 
-  defmodule Example2 do
-    use Appsignal.Instrumentation.Decorators
-
-    @doc "A moduledoc attribute"
-    @decorate transaction_event :http
-    def bar(arg) do
-      nested(arg, arg)
-    end
-
-    @decorate transaction_event :db
-    def nested(_arg1, _arg2) do
-    end
-
-  end
 
   test_with_mock "instrument module function with category", Appsignal.Transaction, [:passthrough], [] do
     t = Transaction.start("bar", :http_request)
-    Example2.bar(123)
+    UsingAppsignalDecoratorsWithCustomNamespaces.bar(123)
     assert called Transaction.start_event(t)
-    assert called Transaction.finish_event(t, "bar.http", "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example2.bar", "", 0)
-    assert called Transaction.finish_event(t, "nested.db", "Elixir.Appsignal.Instrumentation.DecoratorsTest.Example2.nested", "", 0)
+    assert called Transaction.finish_event(t, "bar.http", "Elixir.UsingAppsignalDecoratorsWithCustomNamespaces.bar", "", 0)
+    assert called Transaction.finish_event(t, "nested.db", "Elixir.UsingAppsignalDecoratorsWithCustomNamespaces.nested", "", 0)
   end
 
 end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -35,7 +35,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
   end
 
   test "instruments a channel action with a decorator", %{socket: socket} do
-    UsingAppsignalPhoenixChannel.handle_in("decorated", %{body: "Hello, world!"}, socket)
+    UsingAppsignalPhoenixChannel.handle_in("decorated", %{"body" => "Hello, world!"}, socket)
 
     assert [{"123", :channel}] == FakeTransaction.started_transactions
     assert "UsingAppsignalPhoenixChannel#decorated" == FakeTransaction.action
@@ -49,14 +49,14 @@ defmodule Appsignal.Phoenix.ChannelTest do
         topic: "room:lobby",
         transport: Phoenix.Transports.WebSocket
       },
-      "params" => %{body: "Hello, world!"}
+      "params" => %{"body" => "Hello, world!"}
     } == FakeTransaction.sample_data
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions
   end
 
   test "instruments a channel action with an instrumentation helper", %{socket: socket} do
-    UsingAppsignalPhoenixChannel.handle_in("instrumented", %{body: "Hello, world!"}, socket)
+    UsingAppsignalPhoenixChannel.handle_in("instrumented", %{"body" => "Hello, world!"}, socket)
 
     assert [{"123", :channel}] == FakeTransaction.started_transactions
     assert "UsingAppsignalPhoenixChannel#instrumented" == FakeTransaction.action
@@ -70,7 +70,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
         topic: "room:lobby",
         transport: Phoenix.Transports.WebSocket
       },
-      "params" => %{body: "Hello, world!"}
+      "params" => %{"body" => "Hello, world!"}
     } == FakeTransaction.sample_data
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -35,7 +35,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
   end
 
   test "instruments a channel action with a decorator", %{socket: socket} do
-    UsingAppsignalPhoenixChannel.handle_in("decorated", %{}, socket)
+    UsingAppsignalPhoenixChannel.handle_in("decorated", %{body: "Hello, world!"}, socket)
 
     assert [{"123", :channel}] == FakeTransaction.started_transactions
     assert "UsingAppsignalPhoenixChannel#decorated" == FakeTransaction.action
@@ -49,7 +49,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
         topic: "room:lobby",
         transport: Phoenix.Transports.WebSocket
       },
-      "params" => %{}
+      "params" => %{body: "Hello, world!"}
     } == FakeTransaction.sample_data
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -1,45 +1,43 @@
+defmodule UsingAppsignalPhoenixChannel do
+  import Appsignal.Phoenix.Channel, only: [channel_action: 4]
+  use Appsignal.Instrumentation.Decorators
+
+  @decorate channel_action()
+  def handle_in("decorated", payload, socket) do
+    {:reply, {:ok, payload}, socket}
+  end
+
+  def handle_in("instrumented" = action, payload, socket) do
+    channel_action(__MODULE__, action, socket, fn ->
+      {:reply, {:ok, payload}, socket}
+    end)
+  end
+end
+
 defmodule Appsignal.Phoenix.ChannelTest do
   use ExUnit.Case
-  import Mock
+  alias Appsignal.FakeTransaction
 
-  alias Phoenix.Socket
-  alias Appsignal.Transaction
-
-  defmodule SomeApp.MyChannel do
-
-    use Appsignal.Instrumentation.Decorators
-
-    @decorate channel_action
-    def handle_in("ping", payload, socket) do
-      {:reply, {:ok, payload}, socket}
-    end
-
-    import Appsignal.Phoenix.Channel, only: [channel_action: 4]
-
-    def handle_in("pong" = action, payload, socket) do
-      channel_action(__MODULE__, action, socket, fn ->
-        {:reply, {:ok, payload}, socket}
-      end)
-    end
-
+  setup do
+    Appsignal.FakeTransaction.start_link
+    :ok
   end
 
-  test_with_mock "channel_action function decorator", Appsignal.Transaction, [:passthrough], [] do
-    SomeApp.MyChannel.handle_in("ping", :payload, %Socket{})
-    t = Appsignal.TransactionRegistry.lookup(self())
-    assert called Transaction.start(t.id, :channel)
-    assert called Transaction.set_action(t, "Appsignal.Phoenix.ChannelTest.SomeApp.MyChannel#ping")
-    assert called Transaction.finish(t)
-    assert called Transaction.complete(t)
+  test "instruments a channel action with a decorator" do
+    UsingAppsignalPhoenixChannel.handle_in("decorated", :payload, %Phoenix.Socket{})
+
+    assert [{"123", :channel}] == FakeTransaction.started_transactions
+    assert "UsingAppsignalPhoenixChannel#decorated" == FakeTransaction.action
+    assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
+    assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions
   end
 
-  test_with_mock "direct calling of channel_action function", Appsignal.Transaction, [:passthrough], [] do
-    SomeApp.MyChannel.handle_in("pong", :payload, %Socket{})
-    t = Appsignal.TransactionRegistry.lookup(self())
-    assert called Transaction.start(t.id, :channel)
-    assert called Transaction.set_action(t, "Appsignal.Phoenix.ChannelTest.SomeApp.MyChannel#pong")
-    assert called Transaction.finish(t)
-    assert called Transaction.complete(t)
-  end
+  test "instruments a channel action with an instrumentation helper" do
+    UsingAppsignalPhoenixChannel.handle_in("instrumented", :payload, %Phoenix.Socket{})
 
+    assert [{"123", :channel}] == FakeTransaction.started_transactions
+    assert "UsingAppsignalPhoenixChannel#instrumented" == FakeTransaction.action
+    assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
+    assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions
+  end
 end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -75,4 +75,11 @@ defmodule Appsignal.Phoenix.ChannelTest do
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions
   end
+
+  test "filters parameters", %{socket: socket} do
+    AppsignalTest.Utils.with_config(%{filter_parameters: ["password"]}, fn() ->
+      UsingAppsignalPhoenixChannel.handle_in("instrumented", %{"password" => "secret"}, socket)
+      assert "[FILTERED]" == FakeTransaction.sample_data["params"]["password"]
+    end)
+  end
 end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -1,5 +1,5 @@
 defmodule UsingAppsignalPhoenixChannel do
-  import Appsignal.Phoenix.Channel, only: [channel_action: 4]
+  import Appsignal.Phoenix.Channel, only: [channel_action: 5]
   use Appsignal.Instrumentation.Decorators
 
   @decorate channel_action()
@@ -8,7 +8,7 @@ defmodule UsingAppsignalPhoenixChannel do
   end
 
   def handle_in("instrumented" = action, payload, socket) do
-    channel_action(__MODULE__, action, socket, fn ->
+    channel_action(__MODULE__, action, socket, payload, fn ->
       {:reply, {:ok, payload}, socket}
     end)
   end
@@ -56,7 +56,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
   end
 
   test "instruments a channel action with an instrumentation helper", %{socket: socket} do
-    UsingAppsignalPhoenixChannel.handle_in("instrumented", %{}, socket)
+    UsingAppsignalPhoenixChannel.handle_in("instrumented", %{body: "Hello, world!"}, socket)
 
     assert [{"123", :channel}] == FakeTransaction.started_transactions
     assert "UsingAppsignalPhoenixChannel#instrumented" == FakeTransaction.action
@@ -70,7 +70,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
         topic: "room:lobby",
         transport: Phoenix.Transports.WebSocket
       },
-      "params" => %{}
+      "params" => %{body: "Hello, world!"}
     } == FakeTransaction.sample_data
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -20,23 +20,58 @@ defmodule Appsignal.Phoenix.ChannelTest do
 
   setup do
     Appsignal.FakeTransaction.start_link
-    :ok
+
+    [
+      socket: %Phoenix.Socket{
+        channel: Elixir.PhoenixChatExampleWeb.RoomChannel,
+        endpoint: Elixir.PhoenixChatExampleWeb.Endpoint,
+        handler: Elixir.PhoenixChatExampleWeb.UserSocket,
+        ref: 2,
+        topic: "room:lobby",
+        transport: Elixir.Phoenix.Transports.WebSocket,
+        id: 1
+      }
+    ]
   end
 
-  test "instruments a channel action with a decorator" do
-    UsingAppsignalPhoenixChannel.handle_in("decorated", :payload, %Phoenix.Socket{})
+  test "instruments a channel action with a decorator", %{socket: socket} do
+    UsingAppsignalPhoenixChannel.handle_in("decorated", %{}, socket)
 
     assert [{"123", :channel}] == FakeTransaction.started_transactions
     assert "UsingAppsignalPhoenixChannel#decorated" == FakeTransaction.action
+    assert %{
+      "environment" => %{
+        channel: PhoenixChatExampleWeb.RoomChannel,
+        endpoint: PhoenixChatExampleWeb.Endpoint,
+        handler: PhoenixChatExampleWeb.UserSocket,
+        id: 1,
+        ref: 2,
+        topic: "room:lobby",
+        transport: Phoenix.Transports.WebSocket
+      },
+      "params" => %{}
+    } == FakeTransaction.sample_data
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions
   end
 
-  test "instruments a channel action with an instrumentation helper" do
-    UsingAppsignalPhoenixChannel.handle_in("instrumented", :payload, %Phoenix.Socket{})
+  test "instruments a channel action with an instrumentation helper", %{socket: socket} do
+    UsingAppsignalPhoenixChannel.handle_in("instrumented", %{}, socket)
 
     assert [{"123", :channel}] == FakeTransaction.started_transactions
     assert "UsingAppsignalPhoenixChannel#instrumented" == FakeTransaction.action
+    assert %{
+      "environment" => %{
+        channel: PhoenixChatExampleWeb.RoomChannel,
+        endpoint: PhoenixChatExampleWeb.Endpoint,
+        handler: PhoenixChatExampleWeb.UserSocket,
+        id: 1,
+        ref: 2,
+        topic: "room:lobby",
+        transport: Phoenix.Transports.WebSocket
+      },
+      "params" => %{}
+    } == FakeTransaction.sample_data
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions
   end

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -122,6 +122,25 @@ defmodule Appsignal.FakeTransaction do
     "123"
   end
 
+  def set_sample_data(transaction, key, payload) do
+    Agent.update(__MODULE__, fn(state) ->
+      {_, new_state} = Map.get_and_update(state, :sample_data, fn(current) ->
+        case current do
+          nil -> {nil, %{key => payload}}
+          _ -> {current, Map.put(current, key, payload)}
+        end
+      end)
+
+      new_state
+    end)
+
+    transaction
+  end
+
+  def sample_data do
+    Agent.get(__MODULE__, &Map.get(&1, :sample_data, %{}))
+  end
+
   def set_error(transaction, reason, message, stack) do
     Agent.update(__MODULE__, fn(state) ->
       {_, new_state} = Map.get_and_update(state, :errors, fn(current) ->
@@ -135,10 +154,6 @@ defmodule Appsignal.FakeTransaction do
       new_state
     end)
     transaction
-  end
-
-  def set_sample_data(transaction, key, payload) do
-    :ok
   end
 
   def errors do

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -4,7 +4,7 @@ defmodule Appsignal.FakeTransaction do
   def start_link do
     Agent.start_link(fn -> %{} end, name: __MODULE__)
   end
-  
+
   def start_event do
     Appsignal.Transaction.start_event
   end
@@ -135,6 +135,10 @@ defmodule Appsignal.FakeTransaction do
       new_state
     end)
     transaction
+  end
+
+  def set_sample_data(transaction, key, payload) do
+    :ok
   end
 
   def errors do


### PR DESCRIPTION
Closes #243 and #232.

Adds `Appsignal.Phoenix.Channel.channel_action/5`, which takes the action's params, sanitises them, and sends them along with the sample. It's also used in the `channel_action/2` decorator.

- Removes dependency on the `Mock` library in channel tests, and uses `FakeTransaction` instead.
- Deprecates `Appsignal.Channel.set_metadata/1`as `channel_action/5` now makes sure to set the metadata (like we do in `Appsignal.Plug`).
- Cleans up `Appsignal.Phoenix.Channel` tests
