### PR TITLE
Don't crash with unbound channel payloads

### DIFF
--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -81,9 +81,23 @@ defmodule Appsignal.Instrumentation.Decorators do
 
   @doc false
   def channel_action(body, context = %{args: [action, payload, socket]}) do
+    do_channel_action(context.module, action, socket, payload, body)
+  end
+
+  defp do_channel_action(module, action, socket, {:_, _, _}, body) do
     quote do
       Appsignal.Phoenix.Channel.channel_action(
-        unquote(context.module),
+        unquote(module),
+        unquote(action),
+        unquote(socket),
+        fn -> unquote(body) end
+      )
+    end
+  end
+  defp do_channel_action(module, action, socket, payload, body) do
+    quote do
+      Appsignal.Phoenix.Channel.channel_action(
+        unquote(module),
         unquote(action),
         unquote(socket),
         unquote(payload),
@@ -91,5 +105,4 @@ defmodule Appsignal.Instrumentation.Decorators do
       )
     end
   end
-
 end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -7,6 +7,11 @@ defmodule UsingAppsignalPhoenixChannel do
     {:reply, {:ok, payload}, socket}
   end
 
+  @decorate channel_action()
+  def handle_in("decorated_with_unbound_payload", _, socket) do
+    {:reply, :ok, socket}
+  end
+
   def handle_in("instrumented" = action, payload, socket) do
     channel_action(__MODULE__, action, socket, payload, fn ->
       {:reply, {:ok, payload}, socket}
@@ -50,6 +55,27 @@ defmodule Appsignal.Phoenix.ChannelTest do
         transport: Phoenix.Transports.WebSocket
       },
       "params" => %{"body" => "Hello, world!"}
+    } == FakeTransaction.sample_data
+    assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
+    assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions
+  end
+
+  test "instruments a channel action with a decorator and an unbound payload", %{socket: socket} do
+    UsingAppsignalPhoenixChannel.handle_in("decorated_with_unbound_payload", %{"body" => "Hello, world!"}, socket)
+
+    assert [{"123", :channel}] == FakeTransaction.started_transactions
+    assert "UsingAppsignalPhoenixChannel#decorated_with_unbound_payload" == FakeTransaction.action
+    assert %{
+      "environment" => %{
+        channel: PhoenixChatExampleWeb.RoomChannel,
+        endpoint: PhoenixChatExampleWeb.Endpoint,
+        handler: PhoenixChatExampleWeb.UserSocket,
+        id: 1,
+        ref: 2,
+        topic: "room:lobby",
+        transport: Phoenix.Transports.WebSocket
+      },
+      "params" => %{}
     } == FakeTransaction.sample_data
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions


### PR DESCRIPTION
Since 0ab1e198f4e8b99d114f7098a7eb34f339091655,
Appsignal.Instrumentation.Decorators.channel_action/2 uses
Appsignal.Phoenix.Channel.channel_action/5 to add the payload to the
transaction as params. Since this doesn't work when the payload is
unbound, this patch adds a fallback to channel_action/4.