### PR TITLE
No channel payloads in the channel_action decorator

### DIFF
--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -80,27 +80,12 @@ defmodule Appsignal.Instrumentation.Decorators do
   end
 
   @doc false
-  def channel_action(body, context = %{args: [action, payload, socket]}) do
-    do_channel_action(context.module, action, socket, payload, body)
-  end
-
-  defp do_channel_action(module, action, socket, {:_, _, _}, body) do
+  def channel_action(body, context = %{args: [action, _payload, socket]}) do
     quote do
       Appsignal.Phoenix.Channel.channel_action(
-        unquote(module),
+        unquote(context.module),
         unquote(action),
         unquote(socket),
-        fn -> unquote(body) end
-      )
-    end
-  end
-  defp do_channel_action(module, action, socket, payload, body) do
-    quote do
-      Appsignal.Phoenix.Channel.channel_action(
-        unquote(module),
-        unquote(action),
-        unquote(socket),
-        unquote(payload),
         fn -> unquote(body) end
       )
     end

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -24,10 +24,28 @@ if Appsignal.phoenix? do
     Channel events will be displayed under the "Background jobs" tab,
     showing the channel module and the action argument that you entered.
 
+    ### Adding channel payloads
+
+    Channel payloads aren't included by default, but can be added by using
+    `Appsignal.Transaction.set_sample_data/2` using the "params" key:
+
+        defmodule SomeApp.MyChannel do
+          use Appsignal.Instrumentation.Decorators
+
+          @decorate channel_action
+          def handle_in("ping", payload, socket) do
+            Appsignal.Transaction.set_sample_data(
+              "params", Appsignal.Utils.ParamsFilter.filter_values(payload)
+            )
+
+            # your code here..
+          end
+        end
+
     ## Instrumenting without decorators
 
     You can also decide not to use function decorators. In that case,
-    use the `channel_action/3` function directly, passing in a name for
+    use the `channel_action/4` function directly, passing in a name for
     the channel action, the socket and the actual code that you are
     executing in the channel handler:
 
@@ -36,6 +54,22 @@ if Appsignal.phoenix? do
 
           def handle_in("ping" = action, _payload, socket) do
             channel_action(__MODULE__, action, socket, fn ->
+              # do some heave processing here...
+              reply = perform_work()
+              {:reply, {:ok, reply}, socket}
+            end)
+          end
+        end
+
+    ### Adding channel payloads
+
+    To add channel payloads, use `channel_action/5`:
+
+        defmodule SomeApp.MyChannel do
+          import Appsignal.Phoenix.Channel, only: [channel_action: 4]
+
+          def handle_in("ping" = action, payload, socket) do
+            channel_action(__MODULE__, action, socket, payload, fn ->
               # do some heave processing here...
               reply = perform_work()
               {:reply, {:ok, reply}, socket}

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -54,27 +54,6 @@ defmodule Appsignal.Phoenix.ChannelTest do
         topic: "room:lobby",
         transport: Phoenix.Transports.WebSocket
       },
-      "params" => %{"body" => "Hello, world!"}
-    } == FakeTransaction.sample_data
-    assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions
-    assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions
-  end
-
-  test "instruments a channel action with a decorator and an unbound payload", %{socket: socket} do
-    UsingAppsignalPhoenixChannel.handle_in("decorated_with_unbound_payload", %{"body" => "Hello, world!"}, socket)
-
-    assert [{"123", :channel}] == FakeTransaction.started_transactions
-    assert "UsingAppsignalPhoenixChannel#decorated_with_unbound_payload" == FakeTransaction.action
-    assert %{
-      "environment" => %{
-        channel: PhoenixChatExampleWeb.RoomChannel,
-        endpoint: PhoenixChatExampleWeb.Endpoint,
-        handler: PhoenixChatExampleWeb.UserSocket,
-        id: 1,
-        ref: 2,
-        topic: "room:lobby",
-        transport: Phoenix.Transports.WebSocket
-      },
       "params" => %{}
     } == FakeTransaction.sample_data
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.finished_transactions


### PR DESCRIPTION
## TODO

- [x] Document how to work with channel parameters

Due to the structure of the decorators, we can't handle unbound
parameters in the channel_action decorator. To make sure we don't break
compilation for apps that don't bind all parameters, we've disabled
sending parameters in the `channel_action` decorator.

To include parameters, please use
`Appsignal.Phoenix.Channel.channel_action/5` directly:

    defmodule PhoenixChatExampleWeb.RoomChannel do
      use Phoenix.Channel
      import Appsignal.Phoenix.Channel, only: [channel_action: 5]

      # ...

      def handle_in("new_msg" = action, payload, socket) do
        channel_action(__MODULE__, action, socket, payload, fn ->
          broadcast! socket, "new_msg", %{body: 'body'}
          {:noreply, assign(socket, :user_id, 4)}
        end)
      end

      # ...
    end