### PR TITLE
Add architecture for elixir:alpine Docker image

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -136,6 +136,7 @@ defmodule Mix.Appsignal.Helper do
     defp map_arch('x86_64-pc-linux-gnu' ++ _), do: "x86_64-linux"
     defp map_arch('x86_64-redhat-linux-gnu' ++ _), do: "x86_64-linux"
     defp map_arch('x86_64-unknown-linux' ++ _), do: "x86_64-linux"
+    defp map_arch('x86_64-pc-linux-musl' ++_), do: "x86_64-linux"
     defp map_arch('x86_64-apple-darwin' ++ _), do: "x86_64-darwin"
   end
   defp map_arch(_), do: :unsupported


### PR DESCRIPTION
As of 2017-09-13, the elixir:*-alpine Docker images are returning `:erlang.system_info(:system_architecture)` as `x86_64-pc-linux-musl ` instead of `x86_64-unknown-linux-gnu`.

There seems to be no change in the images themselves (https://github.com/c0b/docker-elixir/commits), but all of them have just been updated (https://hub.docker.com/r/library/elixir/tags/). I suspect this was the change in the underlying erlang:*-alpine images: https://github.com/c0b/docker-erlang-otp/commit/e7d145c915458e5bbb857a57c9aad7125f95a853