### PR TITLE
Allow custom category in Appsignal.Ecto

### DIFF
--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -17,7 +17,7 @@ defmodule Appsignal.Ecto do
 
   @nano_seconds :erlang.convert_time_unit(1, :nano_seconds, :native)
 
-  def log(entry) do
+  def log(entry, category \\ "ecto") do
 
     # See if we have a transaction registered for the current process
     case TransactionRegistry.lookup(self()) do
@@ -28,7 +28,7 @@ defmodule Appsignal.Ecto do
         # record the event
         total_time = (entry.queue_time || 0) + (entry.query_time || 0) + (entry.decode_time || 0)
         duration = trunc(total_time / @nano_seconds)
-        Transaction.record_event(transaction, "query.ecto", "", entry.query, duration, 1)
+        Transaction.record_event(transaction, "query.#{category}", "", entry.query, duration, 1)
     end
     entry
   end


### PR DESCRIPTION
This allows to change the default `ecto` category name for Ecto queries. This is super useful when multiple repos are used in a single project and during single transaction, as it allows to put those queries into distinct category buckets as well as easily differentiate them within a single transaction sample.

In order to use it, one has to change the default:

```elixir
config :my_app, MyApp.Repo,
  loggers: [Appsignal.Ecto, Ecto.LogEntry]
```
 
to something along these lines:

```elixir
config :my_app, MyApp.Repo,
  loggers: [{Appsignal.Ecto, :log, [:ecto_repo]}, Ecto.LogEntry]

config :my_app, MyApp.OtherRepo,
  loggers: [{Appsignal.Ecto, :log, [:ecto_other_repo]}, Ecto.LogEntry]
```

It would be nice to update the docs accordingly after this gets released.