### PR TITLE
Remove transaction from registry in send error

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -130,10 +130,10 @@ defmodule Appsignal do
         Appsignal.Transaction.set_sample_data(transaction, "key", %{foo: "bar"})
       end)
   """
-  def send_error(reason, message \\ "", stack \\ nil, metadata \\ %{}, conn \\ nil, fun \\ fn(t) -> t end) do
+  def send_error(reason, message \\ "", stack \\ nil, metadata \\ %{}, conn \\ nil, fun \\ fn(t) -> t end, namespace \\ :http_request) do
     stack = stack || System.stacktrace()
 
-    transaction = Appsignal.Transaction.start("_" <> Appsignal.Transaction.generate_id(), :http_request)
+    transaction = Appsignal.Transaction.start("_" <> Appsignal.Transaction.generate_id(), namespace)
     fun.(transaction)
     {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, message)
     Appsignal.ErrorHandler.submit_transaction(transaction, reason, message, stack, metadata, conn)

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -132,12 +132,11 @@ defmodule Appsignal do
   """
   def send_error(reason, message \\ "", stack \\ nil, metadata \\ %{}, conn \\ nil, fun \\ fn(t) -> t end) do
     stack = stack || System.stacktrace()
-    transaction = Appsignal.Transaction.lookup_or_create_transaction(self())
-    if transaction != nil do
-      fun.(transaction)
-      {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, message)
-      Appsignal.ErrorHandler.submit_transaction(transaction, reason, message, stack, metadata, conn)
-      :ok = Appsignal.TransactionRegistry.remove_transaction(transaction)
-    end
+
+    transaction = Appsignal.Transaction.start("_" <> Appsignal.Transaction.generate_id(), :background_job)
+    fun.(transaction)
+    {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, message)
+    Appsignal.ErrorHandler.submit_transaction(transaction, reason, message, stack, metadata, conn)
+    :ok = Appsignal.TransactionRegistry.remove_transaction(transaction)
   end
 end

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -133,7 +133,7 @@ defmodule Appsignal do
   def send_error(reason, message \\ "", stack \\ nil, metadata \\ %{}, conn \\ nil, fun \\ fn(t) -> t end) do
     stack = stack || System.stacktrace()
 
-    transaction = Appsignal.Transaction.start("_" <> Appsignal.Transaction.generate_id(), :background_job)
+    transaction = Appsignal.Transaction.start("_" <> Appsignal.Transaction.generate_id(), :http_request)
     fun.(transaction)
     {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, message)
     Appsignal.ErrorHandler.submit_transaction(transaction, reason, message, stack, metadata, conn)

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -137,6 +137,7 @@ defmodule Appsignal do
       fun.(transaction)
       {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, message)
       Appsignal.ErrorHandler.submit_transaction(transaction, reason, message, stack, metadata, conn)
+      :ok = Appsignal.TransactionRegistry.remove_transaction(transaction)
     end
   end
 end

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -136,6 +136,7 @@ defmodule AppsignalTest do
 
       assert called TransactionRegistry.remove_transaction(t)
 
+      assert called Transaction.start(:_, :http_request)
       assert called Transaction.set_error(t, "RuntimeError", "Oops: Some bad stuff happened", stack)
       assert called Transaction.set_sample_data(t, "key", %{foo: "bar"})
       assert called Transaction.finish(t)

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -106,34 +106,4 @@ defmodule Appsignal.PhoenixTest do
       assert [transaction] == FakeTransaction.completed_transactions
     end
   end
-
-  test_with_mock "send_error with metadata and conn", Appsignal.Transaction, [:passthrough], [] do
-    conn = %Plug.Conn{peer: {{127, 0, 0, 1}, 12345}}
-    stack = System.stacktrace()
-    Appsignal.send_error(%RuntimeError{message: "Some bad stuff happened"}, "Oops", stack, %{foo: "bar"}, conn)
-
-    assert called Transaction.set_error(:_, "RuntimeError", "Oops: Some bad stuff happened", stack)
-    assert called Transaction.set_meta_data(:_, :foo, "bar")
-    assert called Transaction.set_request_metadata(:_, conn)
-    assert called Transaction.finish(:_)
-    assert called Transaction.complete(:_)
-  end
-
-
-  @headers [{"accept", "text/plain"}]
-
-  test_with_mock "all request headers are sent", Appsignal.Transaction, [:passthrough], [] do
-    conn = %Plug.Conn{peer: {{127, 0, 0, 1}, 12345}, req_headers: @headers}
-    Appsignal.send_error(%RuntimeError{message: "Some bad stuff happened"}, "Oops", [], %{}, conn)
-
-    env = %{
-      "host" => "www.example.com", "method" => "GET",
-      "peer" => "127.0.0.1:12345", "port" => 0, "query_string" => "",
-      "request_path" => "", "request_uri" => "http://www.example.com:0",
-      "script_name" => [], "req_headers.accept" => "text/plain",
-    }
-
-    assert called Transaction.set_sample_data(:_, "environment", env)
-  end
-
 end

--- a/test/phoenix/phoenix_test.exs
+++ b/test/phoenix/phoenix_test.exs
@@ -32,7 +32,7 @@ defmodule Appsignal.PhoenixTest do
   use ExUnit.Case
   import Mock
 
-  alias Appsignal.{Transaction, TransactionRegistry, FakeTransaction}
+  alias Appsignal.{Transaction, FakeTransaction}
 
   setup do
     FakeTransaction.start_link
@@ -112,13 +112,11 @@ defmodule Appsignal.PhoenixTest do
     stack = System.stacktrace()
     Appsignal.send_error(%RuntimeError{message: "Some bad stuff happened"}, "Oops", stack, %{foo: "bar"}, conn)
 
-    t = %Transaction{} = TransactionRegistry.lookup(self())
-
-    assert called Transaction.set_error(t, "RuntimeError", "Oops: Some bad stuff happened", stack)
-    assert called Transaction.set_meta_data(t, :foo, "bar")
-    assert called Transaction.set_request_metadata(t, conn)
-    assert called Transaction.finish(t)
-    assert called Transaction.complete(t)
+    assert called Transaction.set_error(:_, "RuntimeError", "Oops: Some bad stuff happened", stack)
+    assert called Transaction.set_meta_data(:_, :foo, "bar")
+    assert called Transaction.set_request_metadata(:_, conn)
+    assert called Transaction.finish(:_)
+    assert called Transaction.complete(:_)
   end
 
 
@@ -128,8 +126,6 @@ defmodule Appsignal.PhoenixTest do
     conn = %Plug.Conn{peer: {{127, 0, 0, 1}, 12345}, req_headers: @headers}
     Appsignal.send_error(%RuntimeError{message: "Some bad stuff happened"}, "Oops", [], %{}, conn)
 
-    t = %Transaction{} = TransactionRegistry.lookup(self())
-
     env = %{
       "host" => "www.example.com", "method" => "GET",
       "peer" => "127.0.0.1:12345", "port" => 0, "query_string" => "",
@@ -137,7 +133,7 @@ defmodule Appsignal.PhoenixTest do
       "script_name" => [], "req_headers.accept" => "text/plain",
     }
 
-    assert called Transaction.set_sample_data(t, "environment", env)
+    assert called Transaction.set_sample_data(:_, "environment", env)
   end
 
 end


### PR DESCRIPTION
Before this change calling send error multiple times in the same process would only post an error once because the submitted transaction was still around.