### PR TITLE
Show Appsignal as doc index, mention install guide

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -1,6 +1,6 @@
 defmodule Appsignal do
   @moduledoc """
-  Main library entrypoint.
+  AppSignal for Elixir. Follow the [installation guide](https://docs.appsignal.com/elixir/installation.html) to install AppSignal into your Elixir app.
 
   This module contains the main AppSignal OTP application, as well as
   a few helper functions for sending metrics to AppSignal.

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Appsignal.Mixfile do
      compilers: compilers(Mix.env),
      elixirc_paths: elixirc_paths(Mix.env),
      deps: deps(),
-     docs: [logo: "logo.png"],
+     docs: [main: "Appsignal", logo: "logo.png"],
      agent_version: @agent_version
     ]
   end


### PR DESCRIPTION
This is mostly to link to the install guide from the Hex docs. After this patch, the documentation index is https://hexdocs.pm/appsignal/Appsignal.html#content instead of https://hexdocs.pm/appsignal/api-reference.html, and there's a quick note of the install guide.