### PR TITLE
Add specific musl host triple architecture

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -31,10 +31,21 @@ defmodule Mix.Appsignal.Helper do
         File.cp(project_ext_path(file), priv_path(file))
       end)
     else
-      unless has_files?() and has_correct_agent_version?() do
+      if has_files?() and has_correct_agent_version?() do
+        :ok
+      else
+        if is_nil(arch_config) do
+          raise Mix.Error, message: """
+          No config found for architecture '#{arch}'.
+          Please check http://docs.appsignal.com/support/operating-systems.html
+          And inform us about this error at support@appsignal.com
+          """
+        end
+
         version = Appsignal.Agent.version
         File.rm_rf!(priv_dir())
         File.mkdir_p!(priv_dir())
+
         try do
           download_and_extract(arch_config[:download_url], version, arch_config[:checksum])
         catch
@@ -51,8 +62,6 @@ defmodule Mix.Appsignal.Helper do
                 """
             end
         end
-      else
-        :ok
       end
     end
   end

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -9,7 +9,8 @@ defmodule Mix.Appsignal.Helper do
 
   def verify_system_architecture() do
     input_arch = :erlang.system_info(:system_architecture)
-    case map_arch(input_arch) do
+    force_musl = !(System.get_env("APPSIGNAL_BUILD_FOR_MUSL") |> is_nil())
+    case map_arch(input_arch, force_musl) do
       :unsupported ->
         {:error, {:unsupported, input_arch}}
       arch when is_binary(arch) ->
@@ -128,18 +129,22 @@ defmodule Mix.Appsignal.Helper do
   defp make_args(_), do: []
 
   if Mix.env != :test_no_nif do
-    defp map_arch('i686-alpine-linux' ++ _), do: "i686-linux"
-    defp map_arch('i686-pc-linux-gnu' ++ _), do: "i686-linux"
-    defp map_arch('i686-redhat-linux-gnu' ++ _), do: "i686-linux"
-    defp map_arch('i686-unknown-linux' ++ _), do: "i686-linux"
-    defp map_arch('x86_64-alpine-linux' ++ _), do: "x86_64-linux"
-    defp map_arch('x86_64-pc-linux-gnu' ++ _), do: "x86_64-linux"
-    defp map_arch('x86_64-redhat-linux-gnu' ++ _), do: "x86_64-linux"
-    defp map_arch('x86_64-unknown-linux' ++ _), do: "x86_64-linux"
-    defp map_arch('x86_64-pc-linux-musl' ++_), do: "x86_64-linux"
-    defp map_arch('x86_64-apple-darwin' ++ _), do: "x86_64-darwin"
+    defp map_arch('i686-' ++ _, true), do: "i686-linux-musl"
+    defp map_arch('x86_64-' ++ _, true), do: "x86_64-linux-musl"
+
+    defp map_arch('i686-alpine-linux' ++ _, _), do: "i686-linux-musl"
+    defp map_arch('i686-pc-linux-gnu' ++ _, _), do: "i686-linux"
+    defp map_arch('i686-pc-linux-musl' ++ _, _), do: "i686-linux-musl"
+    defp map_arch('i686-redhat-linux-gnu' ++ _, _), do: "i686-linux"
+    defp map_arch('i686-unknown-linux' ++ _, _), do: "i686-linux"
+    defp map_arch('x86_64-alpine-linux' ++ _, _), do: "x86_64-linux-musl"
+    defp map_arch('x86_64-apple-darwin' ++ _, _), do: "x86_64-darwin"
+    defp map_arch('x86_64-pc-linux-gnu' ++ _, _), do: "x86_64-linux"
+    defp map_arch('x86_64-pc-linux-musl' ++ _, _), do: "x86_64-linux-musl"
+    defp map_arch('x86_64-redhat-linux-gnu' ++ _, _), do: "x86_64-linux"
+    defp map_arch('x86_64-unknown-linux' ++ _, _), do: "x86_64-linux"
   end
-  defp map_arch(_), do: :unsupported
+  defp map_arch(_, _), do: :unsupported
 
   defp tmp_dir do
     default_tmp_dir = "/tmp"


### PR DESCRIPTION
This allows us to ship separate agent builds for GNU and musl builds.
Hopefully solving the DNS timeouts issue for good:
https://docs.appsignal.com/support/known-issues.html#dns-timeouts

The musl-compatible agent can be force installed with the
`APPSIGNAL_BUILD_FOR_MUSL` environment variable.

Override with `export APPSIGNAL_BUILD_FOR_MUSL=1` before calling `mix
{task}` if this doesn't work automatically.

## Raise error if no config is found for architecture

This to prevent it from downloading an empty string and returning a less
than helpful error message about a failed download.

---

Also fixes #258 

Part of https://github.com/appsignal/appsignal-agent/pull/286 (private link)

## TODO

- [x] Wait until the new build PR is merged PR https://github.com/appsignal/appsignal-agent/issues/286
- [x] Add an updated `agent.ex` to ~this PR~ develop
- [x] Test things
- [x] Get reviews
- [x] Update docs with `APPSIGNAL_BUILD_FOR_MUSL` env var