### PR TITLE
Map FreeBSD target triples

### DIFF
--- a/agent.ex
+++ b/agent.ex
@@ -27,14 +27,6 @@ defmodule Appsignal.Agent do
         checksum: "aaee5ccd80c8dc96401182238d39cc16f5dd9566b23e0395f316f294f08cfc73",
         download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/bd1eb5f/appsignal-i686-linux-musl-all-static.tar.gz"
        },
-      "i686-freebsd" => %{
-        checksum: "79a67cc440adb0901b47dea54d0bef25cfbcc5c5ae5b61b2500b42a72271a87e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/bd1eb5f/appsignal-i686-freebsd-all-static.tar.gz"
-       },
-      "x86-freebsd" => %{
-        checksum: "79a67cc440adb0901b47dea54d0bef25cfbcc5c5ae5b61b2500b42a72271a87e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/bd1eb5f/appsignal-i686-freebsd-all-static.tar.gz"
-       },
       "x86_64-linux" => %{
         checksum: "e90af03dc243a4752137018ff92b8da2eb600c5074a841aa2d996484b9315c54",
         download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/bd1eb5f/appsignal-x86_64-linux-all-static.tar.gz"

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -152,6 +152,9 @@ defmodule Mix.Appsignal.Helper do
     defp map_arch('x86_64-pc-linux-musl' ++ _, _), do: "x86_64-linux-musl"
     defp map_arch('x86_64-redhat-linux-gnu' ++ _, _), do: "x86_64-linux"
     defp map_arch('x86_64-unknown-linux' ++ _, _), do: "x86_64-linux"
+    defp map_arch('x86_64-unknown-freebsd' ++ _, _), do: "x86_64-freebsd"
+    defp map_arch('amd64-portbld-freebsd' ++ _, _), do: "x86_64-freebsd"
+    defp map_arch('amd64-freebsd' ++ _, _), do: "x86_64-freebsd"
   end
   defp map_arch(_, _), do: :unsupported
 


### PR DESCRIPTION
A new FreeBSD package to support FreeBSD hosts was added in commit
b9546ca, but no architecture mapping
was present in our mix helpers yet.

Based on #265 

Part of https://github.com/appsignal/appsignal-agent/issues/175