### PR TITLE
Support ENV var with distillery config

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -170,7 +170,7 @@ defmodule Appsignal.Config do
   defp write_to_environment(config) do
     reset_environment_config!()
 
-    System.put_env("_APPSIGNAL_ACTIVE", Atom.to_string(config[:active]))
+    System.put_env("_APPSIGNAL_ACTIVE", to_string(config[:active]))
     System.put_env("_APPSIGNAL_AGENT_PATH", List.to_string(:code.priv_dir(:appsignal)))
     System.put_env("_APPSIGNAL_AGENT_VERSION", @agent_version)
     System.put_env("_APPSIGNAL_APP_PATH", List.to_string(:code.priv_dir(:appsignal))) # FIXME - app_path should not be necessary
@@ -180,13 +180,13 @@ defmodule Appsignal.Config do
     unless empty?(config[:ca_file_path]) do
       System.put_env("_APPSIGNAL_CA_FILE_PATH", config[:ca_file_path])
     end
-    System.put_env("_APPSIGNAL_DEBUG_LOGGING", Atom.to_string(config[:debug]))
+    System.put_env("_APPSIGNAL_DEBUG_LOGGING", to_string(config[:debug]))
     unless empty?(config[:dns_servers]) do
       System.put_env("_APPSIGNAL_DNS_SERVERS", config[:dns_servers] |> Enum.join(","))
     end
 
-    System.put_env("_APPSIGNAL_ENABLE_HOST_METRICS", Atom.to_string(config[:enable_host_metrics]))
-    System.put_env("_APPSIGNAL_ENVIRONMENT", Atom.to_string(config[:env]))
+    System.put_env("_APPSIGNAL_ENABLE_HOST_METRICS", to_string(config[:enable_host_metrics]))
+    System.put_env("_APPSIGNAL_ENVIRONMENT", to_string(config[:env]))
     unless empty?(config[:filter_parameters]) do
       System.put_env("_APPSIGNAL_FILTER_PARAMETERS", config[:filter_parameters] |> Enum.join(","))
     end
@@ -205,14 +205,14 @@ defmodule Appsignal.Config do
     System.put_env("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
     System.put_env("_APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")
     unless empty?(config[:running_in_container]) do
-      System.put_env("_APPSIGNAL_RUNNING_IN_CONTAINER", Atom.to_string(config[:running_in_container]))
+      System.put_env("_APPSIGNAL_RUNNING_IN_CONTAINER", to_string(config[:running_in_container]))
     end
-    System.put_env("_APPSIGNAL_SEND_PARAMS", Atom.to_string(config[:send_params]))
+    System.put_env("_APPSIGNAL_SEND_PARAMS", to_string(config[:send_params]))
     unless empty?(config[:working_dir_path]) do
       System.put_env("_APPSIGNAL_WORKING_DIR_PATH", config[:working_dir_path])
     end
     unless empty?(config[:files_world_accessible]) do
-      System.put_env("_APPSIGNAL_FILES_WORLD_ACCESSIBLE", Atom.to_string(config[:files_world_accessible]))
+      System.put_env("_APPSIGNAL_FILES_WORLD_ACCESSIBLE", to_string(config[:files_world_accessible]))
     end
   end
 


### PR DESCRIPTION
We would like to configure `env` via ENV var. We also use [distillery](https://github.com/bitwalker/distillery) for the release and it doesn't support Dynamic code.

https://hexdocs.pm/distillery/getting-started.html#application-configuration

So you can't do `env: System.get_env("APP_SIGNAL_ENV") |> String.to_atom`.

The PR just allows binary (String) to be given as configuration parameters.