### PR TITLE
🐞Use musl build for older systems

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,6 +6,7 @@ if Mix.env in [:test, :test_phoenix, :test_no_nif] do
     handle_otp_reports: false,
     handle_sasl_reports: false
 
+  config :appsignal, os: FakeOS
   config :appsignal, appsignal_system: Appsignal.FakeSystem
   config :appsignal, appsignal_nif: Appsignal.FakeNif
   config :appsignal, appsignal_demo: Appsignal.FakeDemo

--- a/lib/appsignal/diagnose/library.ex
+++ b/lib/appsignal/diagnose/library.ex
@@ -7,7 +7,7 @@ defmodule Appsignal.Diagnose.Library do
     %{
       language: "elixir",
       agent_version: @agent_version,
-      agent_platform: Appsignal.System.agent_platform(),
+      agent_architecture: Appsignal.System.installed_agent_architecture,
       package_version: @appsignal_version,
       extension_loaded: @nif.loaded?
     }

--- a/lib/appsignal/diagnose/library.ex
+++ b/lib/appsignal/diagnose/library.ex
@@ -7,6 +7,7 @@ defmodule Appsignal.Diagnose.Library do
     %{
       language: "elixir",
       agent_version: @agent_version,
+      agent_platform: Appsignal.System.agent_platform(),
       package_version: @appsignal_version,
       extension_loaded: @nif.loaded?
     }

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -72,7 +72,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts "  Language: Elixir"
     IO.puts "  Package version: #{library_report[:package_version]}"
     IO.puts "  Agent version: #{library_report[:agent_version]}"
-    IO.puts "  Agent platform: #{library_report[:agent_platform]}"
+    IO.puts "  Agent architecture: #{library_report[:agent_architecture]}"
     IO.puts "  Nif loaded: #{yes_or_no(library_report[:extension_loaded])}"
   end
 

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -72,6 +72,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts "  Language: Elixir"
     IO.puts "  Package version: #{library_report[:package_version]}"
     IO.puts "  Agent version: #{library_report[:agent_version]}"
+    IO.puts "  Agent platform: #{library_report[:agent_platform]}"
     IO.puts "  Nif loaded: #{yes_or_no(library_report[:extension_loaded])}"
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,13 @@ defmodule Mix.Tasks.Compile.Appsignal do
           "http://docs.appsignal.com/support/operating-systems.html"
         )
         :ok = Mix.Appsignal.Helper.store_architecture(arch)
+      {:error, {:unknown, {arch, platform}}} ->
+        Mix.Shell.IO.error(
+          "Unknown target platform #{arch} - #{platform}, AppSignal " <>
+          "integration disabled!\nPlease check " <>
+          "http://docs.appsignal.com/support/operating-systems.html"
+        )
+        :ok = Mix.Appsignal.Helper.store_architecture(arch)
     end
 
     purge_module Appsignal.SystemBehaviour

--- a/mix.exs
+++ b/mix.exs
@@ -15,13 +15,14 @@ defmodule Mix.Tasks.Compile.Appsignal do
       {:ok, arch} ->
         :ok = Mix.Appsignal.Helper.ensure_downloaded(arch)
         :ok = Mix.Appsignal.Helper.compile
+        :ok = Mix.Appsignal.Helper.store_architecture(arch)
       {:error, {:unsupported, arch}} ->
         Mix.Shell.IO.error(
           "Unsupported target platform #{arch}, AppSignal integration " <>
           "disabled!\nPlease check " <>
           "http://docs.appsignal.com/support/operating-systems.html"
         )
-        :ok
+        :ok = Mix.Appsignal.Helper.store_architecture(arch)
     end
 
     purge_module Appsignal.SystemBehaviour

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,9 @@
 unless Code.ensure_loaded?(Appsignal.Agent) do
   {_, _} = Code.eval_file("agent.ex")
 end
+unless Code.ensure_loaded?(Appsignal.System) do
+  {_, _} = Code.eval_file("lib/appsignal/system.ex")
+end
 
 defmodule Mix.Tasks.Compile.Appsignal do
   use Mix.Task
@@ -20,6 +23,17 @@ defmodule Mix.Tasks.Compile.Appsignal do
         )
         :ok
     end
+
+    purge_module Appsignal.SystemBehaviour
+    purge_module Appsignal.System
+    :ok
+  end
+
+  # Unload loaded module so that it can be loaded again for the application
+  # itself, when it's already loaded in the mix setup.
+  def purge_module(mod) do
+    :code.purge mod
+    :code.delete mod
   end
 end
 

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -65,6 +65,17 @@ defmodule Mix.Appsignal.Helper do
     end
   end
 
+  def store_architecture(arch) do
+    File.mkdir_p!(priv_dir())
+    case File.open priv_path("appsignal.architecture"), [:write] do
+      {:ok, file} ->
+        result = IO.binwrite(file, arch)
+        File.close(file)
+        result
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp download_and_extract(url, version, checksum) do
     download_file(url, version)
     |> verify_checksum(checksum)
@@ -120,7 +131,6 @@ defmodule Mix.Appsignal.Helper do
     end
   end
 
-
   def compile do
     {result, error_code} = System.cmd("make", make_args(to_string(Mix.env)))
     IO.binwrite(result)
@@ -167,20 +177,7 @@ defmodule Mix.Appsignal.Helper do
     end
   end
 
-  defp priv_dir() do
-    case :code.priv_dir(:appsignal) do
-      {:error, :bad_name} ->
-        # this happens on initial compilation
-        Mix.Tasks.Compile.Erlang.manifests
-        |> List.first
-        |> String.to_charlist
-        |> :filename.dirname
-        |> :filename.join('priv')
-      path ->
-        path
-    end
-    |> List.to_string
-  end
+  defp priv_dir(), do: Appsignal.System.priv_dir
 
   defp priv_path(filename) do
     Path.join(priv_dir(), filename)

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -9,8 +9,7 @@ defmodule Mix.Appsignal.Helper do
 
   def verify_system_architecture() do
     input_arch = :erlang.system_info(:system_architecture)
-    force_musl = !(System.get_env("APPSIGNAL_BUILD_FOR_MUSL") |> is_nil())
-    case map_arch(input_arch, force_musl) do
+    case map_arch(input_arch, String.contains?(Appsignal.System.agent_platform(), "musl")) do
       :unsupported ->
         {:error, {:unsupported, input_arch}}
       arch when is_binary(arch) ->

--- a/test/appsignal/system_test.exs
+++ b/test/appsignal/system_test.exs
@@ -125,4 +125,22 @@ defmodule Appsignal.SystemTest do
       end
     end
   end
+
+  describe ".installed_agent_architecture" do
+    test "returns nil if the architecture doesn't exist" do
+      File.rm(agent_architecture_path)
+      assert Appsignal.System.installed_agent_architecture() == nil
+    end
+
+    test "returns the architecure if appsignal.architecure exists" do
+      File.write(agent_architecture_path, "x86_64-linux")
+      assert Appsignal.System.installed_agent_architecture() == "x86_64-linux"
+    end
+  end
+
+  defp agent_architecture_path do
+    :appsignal
+    |> Application.app_dir
+    |> Path.join("priv/appsignal.architecture")
+  end
 end

--- a/test/appsignal/system_test.exs
+++ b/test/appsignal/system_test.exs
@@ -5,7 +5,6 @@ defmodule Appsignal.SystemTest do
   import AppsignalTest.Utils
   setup do
     FakeOS.start_link
-    FakeOS.set(:type, {:unix, :linux})
     :ok
   end
 
@@ -44,7 +43,6 @@ defmodule Appsignal.SystemTest do
 
   describe ".agent_platform" do
     test "agent_platform returns libc build when the system detection doesn't work" do
-      FakeOS.set(:type, {:unix, :linux})
       with_mock System, [:passthrough], [cmd: fn(_, _, _) -> raise "oh no!" end] do
         assert Appsignal.System.agent_platform() == "linux"
       end
@@ -57,7 +55,6 @@ defmodule Appsignal.SystemTest do
     end
 
     test "returns the musl build when on a musl system" do
-      FakeOS.set(:type, {:unix, :linux})
       with_mock System, [:passthrough], [
         cmd: fn(_, _, _) -> {"musl libc (x86_64)\nVersion 1.1.16", 1} end
       ] do
@@ -66,7 +63,6 @@ defmodule Appsignal.SystemTest do
     end
 
     test "returns the libc build when on a libc linux system" do
-      FakeOS.set(:type, {:unix, :linux})
       with_mocks([
         {System,
           [:passthrough],
@@ -78,7 +74,6 @@ defmodule Appsignal.SystemTest do
     end
 
     test "returns the musl build when on an old libc linux system" do
-      FakeOS.set(:type, {:unix, :linux})
       with_mocks([
         {System,
           [:passthrough],
@@ -90,7 +85,6 @@ defmodule Appsignal.SystemTest do
     end
 
     test "returns the musl build when on a very old libc linux system" do
-      FakeOS.set(:type, {:unix, :linux})
       with_mocks([
         {System,
           [:passthrough],

--- a/test/appsignal/system_test.exs
+++ b/test/appsignal/system_test.exs
@@ -3,6 +3,11 @@ defmodule Appsignal.SystemTest do
 
   import Mock
   import AppsignalTest.Utils
+  setup do
+    FakeOS.start_link
+    FakeOS.set(:type, {:unix, :linux})
+    :ok
+  end
 
   test "hostname_with_domain" do
     with_mocks([
@@ -34,6 +39,90 @@ defmodule Appsignal.SystemTest do
 
     test "returns true" do
       assert Appsignal.System.heroku?
+    end
+  end
+
+  describe ".agent_platform" do
+    test "agent_platform returns libc build when the system detection doesn't work" do
+      FakeOS.set(:type, {:unix, :linux})
+      with_mock System, [:passthrough], [cmd: fn(_, _, _) -> raise "oh no!" end] do
+        assert Appsignal.System.agent_platform() == "linux"
+      end
+    end
+
+    test "returns the musl build when using the APPSIGNAL_BUILD_FOR_MUSL env var" do
+      with_env %{"APPSIGNAL_BUILD_FOR_MUSL" => "1"}, fn() ->
+        assert Appsignal.System.agent_platform() == "linux-musl"
+      end
+    end
+
+    test "returns the musl build when on a musl system" do
+      FakeOS.set(:type, {:unix, :linux})
+      with_mock System, [:passthrough], [
+        cmd: fn(_, _, _) -> {"musl libc (x86_64)\nVersion 1.1.16", 1} end
+      ] do
+        assert Appsignal.System.agent_platform() == "linux-musl"
+      end
+    end
+
+    test "returns the libc build when on a libc linux system" do
+      FakeOS.set(:type, {:unix, :linux})
+      with_mocks([
+        {System,
+          [:passthrough],
+          [cmd: fn(_, _, _) -> {"ldd (Debian GLIBC 2.15-18+deb8u7) 2.15", 1} end]
+        }
+      ]) do
+        assert Appsignal.System.agent_platform() == "linux"
+      end
+    end
+
+    test "returns the musl build when on an old libc linux system" do
+      FakeOS.set(:type, {:unix, :linux})
+      with_mocks([
+        {System,
+          [:passthrough],
+          [cmd: fn(_, _, _) -> {"ldd (Debian GLIBC 2.14-18+deb8u7) 2.14", 1} end]
+        }
+      ]) do
+        assert Appsignal.System.agent_platform() == "linux-musl"
+      end
+    end
+
+    test "returns the musl build when on a very old libc linux system" do
+      FakeOS.set(:type, {:unix, :linux})
+      with_mocks([
+        {System,
+          [:passthrough],
+          [cmd: fn(_, _, _) -> {"ldd (Debian GLIBC 2.5-18+deb8u7) 2.5", 1} end]
+        }
+      ]) do
+        assert Appsignal.System.agent_platform() == "linux-musl"
+      end
+    end
+
+    test "returns the darwin build when on a darwin system" do
+      FakeOS.set(:type, {:unix, :darwin})
+      with_mocks([
+        {System,
+          [:passthrough],
+          [cmd: fn(_, _, _) -> {"ldd: command not found", 1} end]
+        }
+      ]) do
+        assert Appsignal.System.agent_platform() == "darwin"
+      end
+    end
+
+    test "returns the darwin build when on a freebsd system" do
+      FakeOS.set(:type, {:unix, :freebsd})
+      with_mocks([
+        {System,
+          [:passthrough],
+          [cmd: fn(_, _, _) -> {"ldd: illegal option -- -", 1} end]
+        }
+      ]) do
+        assert Appsignal.System.agent_platform() == "freebsd"
+      end
     end
   end
 end

--- a/test/appsignal/test_helper.exs
+++ b/test/appsignal/test_helper.exs
@@ -1,3 +1,10 @@
+# Make sure the Appsignal.System module is recompiled in the test environment
+# by unloading it first.
+# Otherwise, it would use the already compiled Appsignal.System module loaded
+# in `mix.exs` and not have FakeOS configured as `@os`.
+AppsignalTest.Utils.purge Appsignal.SystemBehaviour
+AppsignalTest.Utils.purge Appsignal.System
+
 :error_logger.tty(false)
 excludes = [String.to_atom("skip_env_#{Mix.env}")]
 ExUnit.start(exclude: excludes)

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     report = received_report()
     assert report[:library] == %{
       agent_version: @agent_version,
-      agent_platform: Appsignal.System.agent_platform(),
+      agent_architecture: Appsignal.System.installed_agent_architecture,
       extension_loaded: Appsignal.Nif.loaded?,
       language: "elixir",
       package_version: @appsignal_version

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -14,6 +14,8 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   defp run_fn, do: Mix.Tasks.Appsignal.Diagnose.run(nil)
 
   setup do
+    FakeOS.start_link
+    FakeOS.set(:type, {:unix, :linux})
     @diagnose_report.start_link
     @system.start_link
     @nif.start_link
@@ -56,6 +58,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     report = received_report()
     assert report[:library] == %{
       agent_version: @agent_version,
+      agent_platform: Appsignal.System.agent_platform(),
       extension_loaded: Appsignal.Nif.loaded?,
       language: "elixir",
       package_version: @appsignal_version

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -15,7 +15,6 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
   setup do
     FakeOS.start_link
-    FakeOS.set(:type, {:unix, :linux})
     @diagnose_report.start_link
     @system.start_link
     @nif.start_link

--- a/test/support/fake_os.ex
+++ b/test/support/fake_os.ex
@@ -1,0 +1,13 @@
+defmodule FakeOS do
+  def start_link do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  def set(key, value) do
+    Agent.update(__MODULE__, &Map.put(&1, key, value))
+  end
+
+  def type do
+    Agent.get(__MODULE__, &Map.get(&1, :type, {:unix, :linux}))
+  end
+end

--- a/test/support/fake_system.ex
+++ b/test/support/fake_system.ex
@@ -24,4 +24,8 @@ defmodule Appsignal.FakeSystem do
   def uid do
     Agent.get(__MODULE__, &Map.get(&1, :uid, 999))
   end
+
+  def agent_platform do
+    Agent.get(__MODULE__, &Map.get(&1, :agent_platform, "linux"))
+  end
 end

--- a/test/support/fake_system.ex
+++ b/test/support/fake_system.ex
@@ -13,6 +13,10 @@ defmodule Appsignal.FakeSystem do
     Agent.update(__MODULE__, &Map.put(&1, key, value))
   end
 
+  def priv_dir do
+    Agent.get(__MODULE__, &Map.get(&1, :priv_dir, Appsignal.System.priv_dir))
+  end
+
   def root? do
     Agent.get(__MODULE__, &Map.get(&1, :root, false))
   end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -1,4 +1,11 @@
 defmodule AppsignalTest.Utils do
+  # Remove loaded from the app so the module is recompiled when called. Do this
+  # if the module is already loaded before the test env, such as in `mix.exs`.
+  def purge(mod) do
+    :code.purge mod
+    :code.delete mod
+  end
+
   def with_frozen_environment(function) do
     environment = freeze_environment()
     result = function.()


### PR DESCRIPTION
With the AppSignal for Elixir package v1.4.0 release we dropped support
for some older Operating Systems that use a libc version older than
2.12.

Since package v0.11.0 we started using a musl build so the libc version
didn't matter on the user's machine. Before that we used a very old
machine that used the libc version from CentOS 5, so we supported some
very old systems.

To now support older Operating System versions, with a libc older than
2.12, this change adds a check for the older versions and selects the
musl build instead.

This should fix the problem for people upgrading to (future) package
1.4.1 and higher.

Also move the build detection to the System module so we can reuse the
logic and add specs for its behavior.

## TODO

- [x] Fix random failures with `FakeOS` agent: https://travis-ci.org/appsignal/appsignal-elixir/jobs/301957061 - assigned to Jeff - Fixed in #279 
- [x] Add specs for `Appsignal.System.installed_agent_architecture`
- [x] Include platform save behavior as added in https://github.com/appsignal/appsignal-ruby/pull/366
  - how would that work in a release binary? Seems to work