### PR TITLE
Don't use :logger from @on_load

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -67,6 +67,11 @@ defmodule Appsignal do
         Logger.debug("AppSignal starting.")
         Config.write_to_environment
         Appsignal.Nif.start
+        if Appsignal.Nif.loaded? do
+          Logger.debug("AppSignal started.")
+        else
+          Logger.error("Failed to start AppSignal. Please run the diagnose task (https://docs.appsignal.com/elixir/command-line/diagnose.html) to debug your installation.")
+        end
       {:ok, false} ->
         Logger.info("AppSignal disabled.")
         :ok

--- a/lib/appsignal/diagnose/logs.ex
+++ b/lib/appsignal/diagnose/logs.ex
@@ -1,0 +1,19 @@
+defmodule Appsignal.Diagnose.Logs do
+  def info do
+    path = :appsignal
+    |> Application.app_dir
+    |> Path.join("install.log")
+
+    install_log = case File.read(path) do
+      {:ok, contents} ->
+        %{
+          path: path,
+          exists: true,
+          content: contents |> String.split("\n")
+        }
+      _ -> %{path: path, exists: false}
+    end
+
+    %{"install.log": install_log}
+  end
+end

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -42,7 +42,7 @@ defmodule Appsignal.Nif do
       :ok -> :ok
       {:error, {:load_failed, reason}} ->
         arch = :erlang.system_info(:system_architecture)
-        message = "[#{DateTime.utc_now |> to_string}] Error loading NIF, AppSignal integration disabled!\n\n#{reason}\n\nIs your operating system (#{arch}) supported?\nPlease check http://docs.appsignal.com/support/operating-systems.html"
+        message = "[#{DateTime.utc_now |> to_string}] Error loading NIF (Is your operating system (#{arch}) supported? Please check http://docs.appsignal.com/support/operating-systems.html):\n#{reason}\n\n"
 
         :appsignal
         |> Application.app_dir

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -35,15 +35,20 @@ defmodule Appsignal.Nif do
 
   @on_load :init
 
-  require Logger
-
   def init do
     path = :filename.join(:code.priv_dir(:appsignal), 'appsignal_extension')
+
     case :erlang.load_nif(path, 1) do
       :ok -> :ok
       {:error, {:load_failed, reason}} ->
         arch = :erlang.system_info(:system_architecture)
-        Logger.error "Error loading NIF, AppSignal integration disabled!\n\n#{reason}\n\nIs your operating system (#{arch}) supported?\nPlease check http://docs.appsignal.com/support/operating-systems.html"
+        message = "[#{DateTime.utc_now |> to_string}] Error loading NIF, AppSignal integration disabled!\n\n#{reason}\n\nIs your operating system (#{arch}) supported?\nPlease check http://docs.appsignal.com/support/operating-systems.html"
+
+        :appsignal
+        |> Application.app_dir
+        |> Path.join("install.log")
+        |> File.write(message, [:append])
+
         :ok
     end
   end

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -53,6 +53,11 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     path_report = Diagnose.Paths.info(config)
     report = Map.put(report, :paths, path_report)
     print_paths(path_report)
+    empty_line()
+
+    logs = Diagnose.Logs.info
+    report = Map.put(report, :logs, logs)
+    print_logs(logs)
 
     send_report_to_appsignal_if_agreed_upon(config, report)
   end
@@ -114,6 +119,21 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts "Paths"
     Enum.each(path_report, fn(path) ->
       print_path path
+    end)
+  end
+
+  defp print_logs(logs) do
+    IO.puts "Log files"
+    Enum.each(logs, fn({filename, log}) ->
+      IO.puts "  #{filename}:"
+      IO.puts "    Path: #{log[:path]}"
+      case log do
+        %{exists: false} -> IO.puts "    File not found."
+        %{content: lines} ->
+          IO.puts "    Contents:"
+          Enum.each(lines, &IO.puts/1)
+      end
+      empty_line()
     end)
   end
 


### PR DESCRIPTION
Closes #273.

Instead of using `:logger` from `Appsignal.Nif`'s on_load, we append to a file (install.log) using the `File` module, and print a message when the app starts without the nif being loaded. We'll include install.log in the diagnose output.