### PR TITLE
Add TestAgent, pass test agent pids explicitly

### DIFF
--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -15,9 +15,8 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     {:ok, fake_report} = FakeReport.start_link
     {:ok, fake_system} = Appsignal.FakeSystem.start_link
     # Set loaded? to the actual state of the Nif
-    {:ok, fake_nif} = Appsignal.FakeNif.start_link(
-      %{loaded?: Appsignal.Nif.loaded?}
-    )
+    {:ok, fake_nif} = Appsignal.FakeNif.start_link
+    Appsignal.FakeNif.update(fake_nif, :loaded?, Appsignal.Nif.loaded?)
 
     # By default, Push API key is valid
     auth_bypass = Bypass.open

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -2,18 +2,17 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
   import AppsignalTest.Utils
-
-  @demo Application.get_env(:appsignal, :appsignal_demo, Appsignal.Demo)
+  alias Appsignal.FakeDemo
 
   setup do
-    @demo.start_link
+    {:ok, fake_demo} = FakeDemo.start_link
 
     bypass = Bypass.open
     setup_with_env(%{
       "APPSIGNAL_PUSH_API_ENDPOINT" => "http://localhost:#{bypass.port}"
     })
 
-    {:ok, %{bypass: bypass}}
+    {:ok, %{bypass: bypass, fake_demo: fake_demo}}
   end
 
   describe "without push api key" do
@@ -263,10 +262,10 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? output, "http://docs.appsignal.com/elixir/integrations/phoenix.html"
     end
 
-    test "sends a demo sample to AppSignal" do
+    test "sends a demo sample to AppSignal", %{fake_demo: fake_demo} do
       output = run_with_environment_config()
-      assert @demo.get(:create_transaction_error_request)
-      assert @demo.get(:create_transaction_performance_request)
+      assert FakeDemo.get(fake_demo, :create_transaction_error_request)
+      assert FakeDemo.get(fake_demo, :create_transaction_performance_request)
       assert String.contains? output, "Demonstration sample data sent!"
     end
   end

--- a/test/support/fake_demo.ex
+++ b/test/support/fake_demo.ex
@@ -1,19 +1,12 @@
 defmodule Appsignal.FakeDemo do
   @behaviour Appsignal.DemoBehaviour
-
-  def start_link do
-    Agent.start_link(fn -> %{} end, name: __MODULE__)
-  end
-
-  def get(key) do
-    Agent.get(__MODULE__, &Map.get(&1, key))
-  end
+  use TestAgent
 
   def create_transaction_error_request do
-    Agent.update(__MODULE__, &Map.put(&1, :create_transaction_error_request, true))
+    update(__MODULE__, :create_transaction_error_request, true)
   end
 
   def create_transaction_performance_request do
-    Agent.update(__MODULE__, &Map.put(&1, :create_transaction_performance_request, true))
+    update(__MODULE__, :create_transaction_performance_request, true)
   end
 end

--- a/test/support/fake_diagnose_report.ex
+++ b/test/support/fake_diagnose_report.ex
@@ -1,21 +1,11 @@
 defmodule Appsignal.Diagnose.FakeReport do
   @behaviour Appsignal.Diagnose.ReportBehaviour
-
-  def start_link do
-    Agent.start_link(fn -> %{} end, name: __MODULE__)
-  end
-
-  def get(key) do
-    Agent.get(__MODULE__, &Map.get(&1, key))
-  end
-
-  def set(key, value) do
-    Agent.update(__MODULE__, &Map.put(&1, key, value))
-  end
+  use TestAgent
 
   def send(_, report) do
-    Agent.update(__MODULE__, &Map.put(&1, :report_sent?, true))
-    Agent.update(__MODULE__, &Map.put(&1, :sent_report, report))
-    get(:response) || {:error, %{reason: "response not set"}}
+    update(__MODULE__, :report_sent?, true)
+    update(__MODULE__, :sent_report, report)
+
+    get(__MODULE__, :response) || {:error, %{reason: "response not set"}}
   end
 end

--- a/test/support/fake_nif.ex
+++ b/test/support/fake_nif.ex
@@ -1,27 +1,15 @@
 defmodule Appsignal.FakeNif do
   @behaviour Appsignal.NifBehaviour
+  use TestAgent, %{loaded?: true, running_in_container?: true, run_diagnose: false, diagnose: "%{}"}
 
-  def start_link do
-    Agent.start_link(fn -> %{} end, name: __MODULE__)
-  end
-
-  def set(key, value) do
-    Agent.update(__MODULE__, &Map.put(&1, key, value))
-  end
-
-  def loaded? do
-    Agent.get(__MODULE__, &Map.get(&1, :loaded?, true))
-  end
-
-  def running_in_container? do
-    Agent.get(__MODULE__, &Map.get(&1, :running_in_container?, true))
-  end
+  def loaded?, do: get(__MODULE__, :loaded?)
+  def running_in_container?, do: get(__MODULE__, :running_in_container?)
 
   def diagnose do
-    if Agent.get(__MODULE__, &Map.get(&1, :run_diagnose, false)) do
+    if get(__MODULE__, :run_diagnose) do
       Appsignal.Nif.diagnose
     else
-      Agent.get(__MODULE__, &Map.get(&1, :diagnose, "{}"))
+      get(__MODULE__, :diagnose)
     end
   end
 end

--- a/test/support/fake_system.ex
+++ b/test/support/fake_system.ex
@@ -1,27 +1,12 @@
 defmodule Appsignal.FakeSystem do
   @behaviour Appsignal.SystemBehaviour
+  use TestAgent, %{uid: 999, heroku: false, root: false}
 
-  def hostname_with_domain do
-    "Alices-MBP.example.com"
-  end
+  def hostname_with_domain, do: "Alices-MBP.example.com"
 
-  def start_link do
-    Agent.start_link(fn -> %{} end, name: __MODULE__)
-  end
+  def root?, do: get(__MODULE__, :root)
 
-  def set(key, value) do
-    Agent.update(__MODULE__, &Map.put(&1, key, value))
-  end
+  def heroku?, do: get(__MODULE__, :heroku)
 
-  def root? do
-    Agent.get(__MODULE__, &Map.get(&1, :root, false))
-  end
-
-  def heroku? do
-    Agent.get(__MODULE__, &Map.get(&1, :heroku, false))
-  end
-
-  def uid do
-    Agent.get(__MODULE__, &Map.get(&1, :uid, 999))
-  end
+  def uid, do: get(__MODULE__, :uid)
 end

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -1,13 +1,8 @@
 defmodule Appsignal.FakeTransaction do
   @behaviour Appsignal.TransactionBehaviour
+  use TestAgent, %{started_transactions: [], finished_events: [], finished_transactions: [], errors: []}
 
-  def start_link do
-    Agent.start_link(fn -> %{} end, name: __MODULE__)
-  end
-
-  def start_event do
-    Appsignal.Transaction.start_event
-  end
+  def start_event, do: Appsignal.Transaction.start_event
 
   def finish_event(transaction, name, title, body, body_format) do
     Agent.update(__MODULE__, fn(state) ->
@@ -30,17 +25,9 @@ defmodule Appsignal.FakeTransaction do
     end)
   end
 
-  def finished_events do
-    Agent.get(__MODULE__, &Map.get(&1, :finished_events, []))
-  end
-
   def set_action(_transaction, conn), do: set_action(conn)
   def set_action(action) do
     Agent.update(__MODULE__, &Map.put(&1, :action, action))
-  end
-
-  def action do
-    Agent.get(__MODULE__, &Map.get(&1, :action))
   end
 
   def finish, do: self() |> Appsignal.TransactionRegistry.lookup |> finish
@@ -59,67 +46,8 @@ defmodule Appsignal.FakeTransaction do
     Agent.get(__MODULE__, &Map.get(&1, :finish, :sample))
   end
 
-  def set_finish(result) do
-    Agent.update(__MODULE__, &Map.put(&1, :finish, result))
-  end
-
-  def finished_transactions do
-    Agent.get(__MODULE__, &Map.get(&1, :finished_transactions, []))
-  end
-
   def set_request_metadata(_transation, conn) do
     Agent.update(__MODULE__, &Map.put(&1, :request_metadata, conn))
-  end
-
-  def request_metadata do
-    Agent.get(__MODULE__, &Map.get(&1, :request_metadata))
-  end
-
-  def complete, do: self() |> Appsignal.TransactionRegistry.lookup |> complete
-  def complete(transaction) do
-    Agent.update(__MODULE__, fn(state) ->
-      {_, new_state} = Map.get_and_update(state, :completed_transactions, fn(current) -> 
-        case current do
-          nil -> {nil, [transaction]}
-          _ -> {current, [transaction|current]}
-        end
-      end)
-
-      new_state
-    end)
-
-    :ok
-  end
-
-  def completed_transactions do
-    Agent.get(__MODULE__, &Map.get(&1, :completed_transactions, []))
-  end
-
-  def start(id, namespace) do
-    Agent.update(__MODULE__, fn(state) ->
-      {_, new_state} = Map.get_and_update(state, :started_transactions, fn(current) ->
-        case current do
-          nil -> {nil, [{id, namespace}]}
-          _ -> {current, [{id, namespace}|current]}
-        end
-      end)
-
-      new_state
-    end)
-
-    Appsignal.Transaction.start(id, namespace)
-  end
-
-  def started_transactions do
-    Agent.get(__MODULE__, &Map.get(&1, :started_transactions, []))
-  end
-
-  def started_transaction? do
-    started_transactions() |> Enum.any?
-  end
-
-  def generate_id do
-    "123"
   end
 
   def set_sample_data(transaction, key, payload) do
@@ -137,9 +65,39 @@ defmodule Appsignal.FakeTransaction do
     transaction
   end
 
-  def sample_data do
-    Agent.get(__MODULE__, &Map.get(&1, :sample_data, %{}))
+
+  def complete, do: self() |> Appsignal.TransactionRegistry.lookup |> complete
+  def complete(transaction) do
+    Agent.update(__MODULE__, fn(state) ->
+      {_, new_state} = Map.get_and_update(state, :completed_transactions, fn(current) -> 
+        case current do
+          nil -> {nil, [transaction]}
+          _ -> {current, [transaction|current]}
+        end
+      end)
+
+      new_state
+    end)
+
+    :ok
   end
+
+  def start(id, namespace) do
+    Agent.update(__MODULE__, fn(state) ->
+      {_, new_state} = Map.get_and_update(state, :started_transactions, fn(current) ->
+        case current do
+          nil -> {nil, [{id, namespace}]}
+          _ -> {current, [{id, namespace}|current]}
+        end
+      end)
+
+      new_state
+    end)
+
+    Appsignal.Transaction.start(id, namespace)
+  end
+
+  def generate_id, do: "123"
 
   def set_error(transaction, reason, message, stack) do
     Agent.update(__MODULE__, fn(state) ->
@@ -156,7 +114,41 @@ defmodule Appsignal.FakeTransaction do
     transaction
   end
 
-  def errors do
-    Agent.get(__MODULE__, &Map.get(&1, :errors, []))
+  # Convenience methods for testing
+
+  def finished_events(pid_or_module) do
+    get(pid_or_module, :finished_events)
+  end
+
+  def action(pid_or_module) do
+    get(pid_or_module, :action)
+  end
+
+  def started_transactions(pid_or_module) do
+    get(pid_or_module, :started_transactions)
+  end
+
+  def started_transaction?(pid_or_module) do
+    started_transactions(pid_or_module) |> Enum.any?
+  end
+
+  def finished_transactions(pid_or_module) do
+    get(pid_or_module, :finished_transactions)
+  end
+
+  def completed_transactions(pid_or_module) do
+    get(pid_or_module, :completed_transactions)
+  end
+
+  def request_metadata(pid_or_module) do
+    get(pid_or_module, :request_metadata)
+  end
+
+  def sample_data(pid_or_module) do
+    get(pid_or_module, :sample_data)
+  end
+
+  def errors(pid_or_module) do
+    get(pid_or_module, :errors)
   end
 end

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -6,7 +6,7 @@ defmodule Appsignal.FakeTransaction do
 
   def finish_event(transaction, name, title, body, body_format) do
     Agent.update(__MODULE__, fn(state) ->
-      {_, new_state} = Map.get_and_update(state, :finished_events, fn(current) -> 
+      {_, new_state} = Map.get_and_update(state, :finished_events, fn(current) ->
         finished_event = %{
           transaction: transaction,
           name: name,
@@ -33,7 +33,7 @@ defmodule Appsignal.FakeTransaction do
   def finish, do: self() |> Appsignal.TransactionRegistry.lookup |> finish
   def finish(transaction) do
     Agent.update(__MODULE__, fn(state) ->
-      {_, new_state} = Map.get_and_update(state, :finished_transactions, fn(current) -> 
+      {_, new_state} = Map.get_and_update(state, :finished_transactions, fn(current) ->
         case current do
           nil -> {nil, [transaction]}
           _ -> {current, [transaction|current]}
@@ -65,11 +65,10 @@ defmodule Appsignal.FakeTransaction do
     transaction
   end
 
-
   def complete, do: self() |> Appsignal.TransactionRegistry.lookup |> complete
   def complete(transaction) do
     Agent.update(__MODULE__, fn(state) ->
-      {_, new_state} = Map.get_and_update(state, :completed_transactions, fn(current) -> 
+      {_, new_state} = Map.get_and_update(state, :completed_transactions, fn(current) ->
         case current do
           nil -> {nil, [transaction]}
           _ -> {current, [transaction|current]}

--- a/test/support/test_agent.ex
+++ b/test/support/test_agent.ex
@@ -1,0 +1,22 @@
+defmodule TestAgent do
+  defmacro __using__(initial_state) do
+    quote do
+      def start_link do
+        Agent.start_link(fn() ->
+            unquote(initial_state) |> Enum.into(%{})
+          end,
+          name: __MODULE__
+        )
+      end
+
+      def get(pid_or_module, key) do
+        Agent.get(pid_or_module, &Map.get(&1, key))
+      end
+
+      def update(pid_or_module, key, value) do
+        Agent.update(pid_or_module, &Map.put(&1, key, value))
+      end
+    end
+  end
+end
+

--- a/test/support/test_agent.ex
+++ b/test/support/test_agent.ex
@@ -31,4 +31,3 @@ defmodule TestAgent do
     end
   end
 end
-

--- a/test/support/test_agent.ex
+++ b/test/support/test_agent.ex
@@ -1,11 +1,9 @@
 defmodule TestAgent do
   defmacro __using__(default_state) do
     quote do
-      def start_link(state \\ %{}) do
+      def start_link do
         Agent.start_link(fn() ->
-            unquote(default_state)
-            |> Enum.into(%{})
-            |> Map.merge(state)
+            unquote(default_state) |> Enum.into(%{})
           end,
           name: __MODULE__
         )

--- a/test/support/test_agent.ex
+++ b/test/support/test_agent.ex
@@ -1,9 +1,11 @@
 defmodule TestAgent do
-  defmacro __using__(initial_state) do
+  defmacro __using__(default_state) do
     quote do
-      def start_link do
+      def start_link(state \\ %{}) do
         Agent.start_link(fn() ->
-            unquote(initial_state) |> Enum.into(%{})
+            unquote(default_state)
+            |> Enum.into(%{})
+            |> Map.merge(state)
           end,
           name: __MODULE__
         )

--- a/test/support/test_agent.ex
+++ b/test/support/test_agent.ex
@@ -1,12 +1,24 @@
 defmodule TestAgent do
   defmacro __using__(default_state) do
     quote do
+      import ExUnit.Assertions
+
       def start_link do
-        Agent.start_link(fn() ->
+        {:ok, pid} = Agent.start_link(fn() ->
             unquote(default_state) |> Enum.into(%{})
           end,
           name: __MODULE__
         )
+
+        # Make sure the spawned process receives DOWN after its parent process
+        # is finished (as per https://elixirforum.com/t/3794/5), with a 500 ms
+        # timeout.
+        ExUnit.Callbacks.on_exit(fn() ->
+          ref = Process.monitor(pid)
+          assert_receive {:DOWN, ^ref, _, _, _}, 500
+        end)
+
+        {:ok, pid}
       end
 
       def get(pid_or_module, key) do


### PR DESCRIPTION
Instead of relying on the agent names, this patch uses pids whenever possible to prevent random test failures caused by tests terminating each other's agents.