### PR TITLE
Convert FakeOS to a TestAgent

### DIFF
--- a/test/appsignal/system_test.exs
+++ b/test/appsignal/system_test.exs
@@ -4,8 +4,8 @@ defmodule Appsignal.SystemTest do
   import Mock
   import AppsignalTest.Utils
   setup do
-    FakeOS.start_link
-    :ok
+    {:ok, fake_os} = FakeOS.start_link
+    [fake_os: fake_os]
   end
 
   test "hostname_with_domain" do
@@ -95,8 +95,8 @@ defmodule Appsignal.SystemTest do
       end
     end
 
-    test "returns the darwin build when on a darwin system" do
-      FakeOS.set(:type, {:unix, :darwin})
+    test "returns the darwin build when on a darwin system", %{fake_os: fake_os} do
+      FakeOS.update(fake_os, :type, {:unix, :darwin})
       with_mocks([
         {System,
           [:passthrough],
@@ -107,8 +107,8 @@ defmodule Appsignal.SystemTest do
       end
     end
 
-    test "returns the darwin build when on a freebsd system" do
-      FakeOS.set(:type, {:unix, :freebsd})
+    test "returns the darwin build when on a freebsd system", %{fake_os: fake_os} do
+      FakeOS.update(fake_os, :type, {:unix, :freebsd})
       with_mocks([
         {System,
           [:passthrough],

--- a/test/support/fake_os.ex
+++ b/test/support/fake_os.ex
@@ -1,13 +1,5 @@
 defmodule FakeOS do
-  def start_link do
-    Agent.start_link(fn -> %{} end, name: __MODULE__)
-  end
+  use TestAgent, %{type: {:unix, :linux}}
 
-  def set(key, value) do
-    Agent.update(__MODULE__, &Map.put(&1, key, value))
-  end
-
-  def type do
-    Agent.get(__MODULE__, &Map.get(&1, :type, {:unix, :linux}))
-  end
+  def type, do: get(__MODULE__, :type)
 end


### PR DESCRIPTION
Use the new `TestAgent` module, which has logic to make sure the process exits after the test is done, to build `FakeOS`.