### PR TITLE
ErrorHandler unwraps Plug.Conn.WrapperError

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -114,6 +114,11 @@ defmodule Appsignal.ErrorHandler do
   Also returns a 'message' which is supposed to contain extra error information.
   """
   @spec extract_reason_and_message(any(), binary()) :: {any(), binary()}
+  def extract_reason_and_message(%Plug.Conn.WrapperError{reason: reason, kind: kind, stack: stacktrace}, message) do
+    kind
+    |> Exception.normalize(reason, stacktrace)
+    |> extract_reason_and_message(message)
+  end
   def extract_reason_and_message(reason, message) when is_binary(reason) do
     {reason, message}
   end

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -8,6 +8,11 @@ defmodule UsingAppsignalPlug do
   def call(%Plug.Conn{private: %{phoenix_action: :bad_request}}, _opts) do
     raise %Plug.BadRequestError{}
   end
+  def call(%Plug.Conn{private: %{phoenix_action: :undef}} = conn, _opts) do
+    raise %Plug.Conn.WrapperError{
+      kind: :error, reason: :undef, stack: System.stacktrace, conn: conn
+    }
+  end
   def call(%Plug.Conn{} = conn, _opts) do
     conn |> Plug.Conn.assign(:called?, true)
   end
@@ -157,6 +162,31 @@ defmodule Appsignal.PlugTest do
       end
 
       assert [] = FakeTransaction.errors(fake_transaction)
+    end
+  end
+
+  describe "for a wrapped undefined error" do
+    setup do
+      conn = %Plug.Conn{}
+      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+      |> Plug.Conn.put_private(:phoenix_action, :undef)
+
+      [conn: conn]
+    end
+
+    test "sets the transaction error", %{conn: conn, fake_transaction: fake_transaction} do
+      :ok = try do
+        UsingAppsignalPlug.call(conn, %{})
+      rescue
+        Plug.Conn.WrapperError -> :ok
+      end
+
+      assert [{
+        %Appsignal.Transaction{},
+        "UndefinedFunctionError",
+        "HTTP request error: undefined function",
+        _stack
+      }] = FakeTransaction.errors(fake_transaction)
     end
   end
 


### PR DESCRIPTION
Tested this in the plug_test by raising the wrapped error. We couldn't
find a way to raise the unwrapped error, e.g. `nil.undefined_function`
and make the test pass.

Closes #245.