### PR TITLE
Fetch request_id in Appsignal.Plug.extract_meta_data/1

### DIFF
--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -269,8 +269,16 @@ defmodule Appsignal.PlugTest do
   describe "extracting request metadata" do
     test "from a Plug conn" do
       assert Appsignal.Plug.extract_meta_data(
-        %Plug.Conn{method: "GET", request_path: "/foo"}
-      ) == %{"method" => "GET", "path" => "/foo"}
+        %Plug.Conn{
+          method: "GET",
+          request_path: "/foo",
+          resp_headers: [{"x-request-id", "kk4hk5sis7c3b56t683nnmdig632c9ot"}]
+        }
+      ) == %{
+        "method" => "GET",
+        "path" => "/foo",
+        "request_id" => "kk4hk5sis7c3b56t683nnmdig632c9ot"
+      }
     end
   end
 


### PR DESCRIPTION
Since the request_id hasn't been set when the Transaction gets started
in `Appsignal.Plug.call/2`, the previous implementation never actually
found the current request's ID.

This patch generates a Transaction ID and adds the reuqest ID to the
metadata later when extracting the metadata from the conn. This causes
the Transaction ID to be different than the request ID in the metadata,
so we don't rely on the processor falling back to the transaction ID
when no request ID is set.

Closes #282.