### PR TITLE
Ensure the appsignal application is started when running diagnose

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -9,6 +9,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   @shortdoc "Starts and tests AppSignal while validating the configuration."
 
   def run(_args) do
+    {:ok, _} = Application.ensure_all_started(:appsignal)
     report = %{process: %{uid: @system.uid}}
     configure_appsignal()
     config = Application.get_env(:appsignal, :config)


### PR DESCRIPTION
As reported via [support](https://app.intercom.io/a/apps/yzor8gyw/respond/inbox/search/conversations/13531351818?q=parker&tag=0) (private Intercom link)

When running the diagnose task from a release build, the appsignal
configuration is not loaded until the appsignal application is started.
This caused incorrect configuration in diagnose reports.