### PR TITLE
Don't use Plug.ErrorHandler.__catch__/4 in Appsignal.Plug

### DIFF
--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -135,8 +135,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "sets the transaction's request metadata", %{conn: conn, fake_transaction: fake_transaction} do
-      assert Plug.Conn.put_status(conn, 500) ==
-        FakeTransaction.request_metadata(fake_transaction)
+      assert conn == FakeTransaction.request_metadata(fake_transaction)
     end
 
     test "completes the transaction", %{fake_transaction: fake_transaction} do


### PR DESCRIPTION
Closes #285.

As explained in #285, relying on `Plug.ErrorHandler.__catch__/4` causes exceptions to not be reported if the response is already sent. This patch removes this issue by calling `Exception.normalize/3` from the `call/2` wrapper and reraising the error using `:erlang.raise/3`.

@schnittchen, if you have time, could you try this branch out locally to see if it solves your issue? We'll do some more testing ourselves to make sure everything keeps working properly. 