### PR TITLE
🐞 Fix DataEncoder.encode error

### DIFF
--- a/test/appsignal/utils/data_encoder_test.exs
+++ b/test/appsignal/utils/data_encoder_test.exs
@@ -98,11 +98,6 @@ defmodule Appsignal.Utils.DataEncoderTest do
     assert {:ok, '[]'} == Nif.data_to_json(resource)
   end
 
-  test "encode a list a cons operator" do
-    resource = DataEncoder.encode(["" | "foo"])
-    assert {:ok, '["foo"]'} == Nif.data_to_json(resource)
-  end
-
   test "encode a list with a string item" do
     resource = DataEncoder.encode(["foo"])
     assert {:ok, '["foo"]'} == Nif.data_to_json(resource)
@@ -151,6 +146,19 @@ defmodule Appsignal.Utils.DataEncoderTest do
   test "encode a list with a list item" do
     resource = DataEncoder.encode(["foo", ["bar"]])
     assert {:ok, '["foo",["bar"]]'} == Nif.data_to_json(resource)
+  end
+
+  test "encode a list with an improper list as string representation" do
+    resource = DataEncoder.encode([1, ["foo" | "bar"]])
+    assert {:ok, '[1,"improper_list:[\\"foo\\" | \\"bar\\"]"]'} == Nif.data_to_json(resource)
+  end
+
+  test "encode a map with an improper list as string representation" do
+    resource = DataEncoder.encode(%{foo: ["foo" | "bar"]})
+    assert {:ok, '{"foo":"improper_list:[\\"foo\\" | \\"bar\\"]"}'} == Nif.data_to_json(resource)
+
+    resource = DataEncoder.encode(%{foo: [1, "foo" | "bar"]})
+    assert {:ok, '{"foo":"improper_list:[1, \\"foo\\" | \\"bar\\"]"}'} == Nif.data_to_json(resource)
   end
 
   test "encode a list with a tuple item" do

--- a/test/appsignal/utils/data_encoder_test.exs
+++ b/test/appsignal/utils/data_encoder_test.exs
@@ -98,6 +98,11 @@ defmodule Appsignal.Utils.DataEncoderTest do
     assert {:ok, '[]'} == Nif.data_to_json(resource)
   end
 
+  test "encode a list a cons operator" do
+    resource = DataEncoder.encode(["" | "foo"])
+    assert {:ok, '["foo"]'} == Nif.data_to_json(resource)
+  end
+
   test "encode a list with a string item" do
     resource = DataEncoder.encode(["foo"])
     assert {:ok, '["foo"]'} == Nif.data_to_json(resource)


### PR DESCRIPTION
## Reproduce DataEncoder.encode error

When given a list with a cons operator, an improper list, the DataEncoder has some trouble
encoding the value, instead giving the following error for this test:

```
1) test encode a list a cons operator (Appsignal.Utils.DataEncoderTest)
    test/appsignal/utils/data_encoder_test.exs:101
    ** (FunctionClauseError) no function clause matching in Enum."-each/2-lists^foreach/1-0-"/2

    The following arguments were given to Enum."-each/2-lists^foreach/1-0-"/2:

        # 1
        #Function<1.110451145/1 in Appsignal.Utils.DataEncoder.encode/1>

        # 2
        "foo"

    code: resource = DataEncoder.encode(["" | "foo"])
    stacktrace:
      (elixir) lib/enum.ex:675: Enum."-each/2-lists^foreach/1-0-"/2
      (elixir) lib/enum.ex:675: Enum.each/2
      (appsignal) lib/appsignal/utils/data_encoder.ex:21: Appsignal.Utils.DataEncoder.encode/1
      test/appsignal/utils/data_encoder_test.exs:102: (test)
```

## Fix improper list data encoder handling

"Fix" this by saving the improper list as a serialized string. We can't
save the real value of the improper list in our extension data encoder
as it's a Erlang specific type.

The prefix of "improper_list" will be parsed on our front-end as an
improper list and displayed as such. Only for data handling it will be
stored as such. This same fix was applied for the "bigint" value in
8b5de8d.

```
[1, 2, 3 | 4]
"improper_list:[1, 2, 3 | 4]"
```

## TODO

- [x] Find the cause of the problem
- [x] Fix the problem
  - [x] Store as `"improper_list:[1 | 2]"`
  - [x] Fix syntax highlighting on the front-end - PR https://github.com/appsignal/appsignal-server/pull/2856

As reported in https://app.intercom.io/a/apps/yzor8gyw/respond/inbox/540709/conversations/13626699157