### PR TITLE
Use Application.load/1 in diagnose task

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   @shortdoc "Starts and tests AppSignal while validating the configuration."
 
   def run(_args) do
-    {:ok, _} = Application.ensure_all_started(:appsignal)
+    Application.load(:appsignal)
     report = %{process: %{uid: @system.uid}}
     configure_appsignal()
     config = Application.get_env(:appsignal, :config)


### PR DESCRIPTION
Part of #295.

Instead of starting the whole app, the configuration is loaded when
using `Application.load/1`. This patch uses that over
`Application.ensure_all_started` to keep the lock file from being
stolen.