### PR TITLE
Fix compile errors on Elixir 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ elixir:
   - 1.3.4
   - 1.4.5
   - 1.5.2
+  - 1.6.0
 otp_release:
   - 20.1
   - 19.3
@@ -11,6 +12,10 @@ matrix:
   exclude:
     - otp_release: 20.1
       elixir: 1.3.4
+    - otp_release: 18.3
+      elixir: 1.6.0
+  allow_failures:
+    - elixir: 1.6.0
 before_script:
   - MIX_ENV=test mix compile --warnings-as-errors
   - MIX_ENV=test_phoenix mix compile --warnings-as-errors

--- a/lib/appsignal/system.ex
+++ b/lib/appsignal/system.ex
@@ -18,6 +18,7 @@ defmodule Appsignal.System do
         Mix.Tasks.Compile.Erlang.manifests
         |> List.first
         |> Path.dirname
+        |> String.trim_trailing(".mix")
         |> Path.join("priv")
       path ->
         path


### PR DESCRIPTION
I thought I might be able to get the ball rolling on Elixir 1.6 support.  This PR adds Elixir 1.6.0 as a build target, and addresses the compilation errors in #296 which are the result of this manifest directory consolidation: elixir-lang/elixir@d941fe0

Please note, this does not make the lib totally ready for primetime on 1.6. Given a few test regressions, I added `elixir: 1.6.0` to the `allow_failures:` list for now.

Not sure if this would really be considered a "bugfix", so let me know if I should open this PR on a different branch.