### PR TITLE
Fix transaction metadata for send_error

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -44,7 +44,7 @@ defmodule Appsignal.ErrorHandler do
   def submit_transaction(transaction, reason, message, stack, metadata, conn \\ nil)
   def submit_transaction(transaction, reason, message, stack, metadata, nil) do
     Transaction.set_error(transaction, reason, message, stack)
-    Transaction.set_meta_data(metadata)
+    Transaction.set_meta_data(transaction, metadata)
     Transaction.finish(transaction)
     Transaction.complete(transaction)
     Logger.debug fn ->

--- a/test/appsignal/error_handler_test.exs
+++ b/test/appsignal/error_handler_test.exs
@@ -60,7 +60,7 @@ defmodule Appsignal.ErrorHandlerTest do
     )
 
     assert called Transaction.set_error(transaction, reason, message, stacktrace)
-    assert called Transaction.set_meta_data(metadata)
+    assert called Transaction.set_meta_data(transaction, metadata)
     assert called Transaction.finish(transaction)
     assert called Transaction.complete(transaction)
   end


### PR DESCRIPTION
Closes #302.

When `Appsignal.send_error/6` is called the transaction found using
`Transaction.lookup/0` will never be the transaction for
`Appsignal.send_error/6`. It's removed from the `TransactionRegistery`
before `Appsignal.ErrorHandler.submit_transaction/6` will handle the
error.

Since we have the transaction available in
`Appsignal.ErrorHandler.submit_transaction/6`, let's just pass the given
transaction and avoid a broken lookup for `Appsignal.send_error`.

As reported in: https://app.intercom.io/a/apps/yzor8gyw/respond/inbox/unassigned/conversations/14370088531