### PR TITLE
Take the Plug.Conn from Plug.Conn.WrapperErrors

### DIFF
--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -15,6 +15,8 @@ if Appsignal.plug?() do
         def call(conn, opts) do
           transaction = @transaction.start(@transaction.generate_id(), :http_request)
 
+          conn = Plug.Conn.put_private(conn, :appsignal_transaction, transaction)
+
           try do
             super(conn, opts)
           catch

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -57,6 +57,10 @@ if Appsignal.plug?() do
           :erlang.raise(kind, reason, stack)
         end
 
+        defp handle_error(_conn, kind, reason, _wrapped_reason, stack) do
+          :erlang.raise(kind, reason, stack)
+        end
+
         defp finish_with_conn(transaction, conn) do
           try_set_action(transaction, conn)
 

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -1,4 +1,4 @@
-if Appsignal.plug? do
+if Appsignal.plug?() do
   defmodule Appsignal.Plug do
     @moduledoc """
     Plug handler for Phoenix requests
@@ -6,7 +6,11 @@ if Appsignal.plug? do
 
     defmacro __using__(_) do
       quote do
-        @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
+        @transaction Application.get_env(
+                       :appsignal,
+                       :appsignal_transaction,
+                       Appsignal.Transaction
+                     )
 
         def call(conn, opts) do
           transaction = @transaction.start(@transaction.generate_id(), :http_request)
@@ -15,7 +19,7 @@ if Appsignal.plug? do
             super(conn, opts)
           catch
             kind, reason ->
-              stacktrace = System.stacktrace
+              stacktrace = System.stacktrace()
               exception = Exception.normalize(kind, reason, stacktrace)
 
               case Appsignal.Plug.extract_error_metadata(exception) do
@@ -23,7 +27,9 @@ if Appsignal.plug? do
                   transaction
                   |> @transaction.set_error(reason, message, stacktrace)
                   |> finish_with_conn(conn)
-                nil -> conn
+
+                nil ->
+                  conn
               end
 
               :erlang.raise(kind, reason, stacktrace)
@@ -34,6 +40,7 @@ if Appsignal.plug? do
 
         defp finish_with_conn(transaction, conn) do
           try_set_action(transaction, conn)
+
           if @transaction.finish(transaction) == :sample do
             @transaction.set_request_metadata(transaction, conn)
           end
@@ -58,44 +65,62 @@ if Appsignal.plug? do
     def extract_error_metadata(%{plug_status: status}) when status < 500 do
       nil
     end
+
     def extract_error_metadata(%Plug.Conn.WrapperError{reason: reason = %{}}) do
       Appsignal.ErrorHandler.extract_reason_and_message(reason, "HTTP request error")
     end
+
     def extract_error_metadata(reason) do
       Appsignal.ErrorHandler.extract_reason_and_message(reason, "HTTP request error")
     end
 
     @doc false
     def extract_error_metadata(reason, conn, stack) do
-      IO.warn "Appsignal.Plug.extract_error_metadata/3 is deprecated. Use Appsignal.Plug.extract_error_metadata/1 instead."
+      IO.warn(
+        "Appsignal.Plug.extract_error_metadata/3 is deprecated. Use Appsignal.Plug.extract_error_metadata/1 instead."
+      )
+
       {reason, message} = extract_error_metadata(reason)
       {reason, message, stack, conn}
     end
 
-    def extract_action(%Plug.Conn{private: %{phoenix_action: action, phoenix_controller: controller}}) do
+    def extract_action(%Plug.Conn{
+          private: %{phoenix_action: action, phoenix_controller: controller}
+        }) do
       merge_action_and_controller(action, controller)
     end
+
     def extract_action(%Plug.Conn{private: %{phoenix_endpoint: _}}), do: nil
+
     def extract_action(%Plug.Conn{method: method, request_path: path}) do
       "#{method} #{path}"
     end
 
-    def extract_sample_data(%Plug.Conn{params: params, host: host,
-      method: method, script_name: script_name, request_path: request_path,
-      port: port, query_string: query_string} = conn) do
-
+    def extract_sample_data(
+          %Plug.Conn{
+            params: params,
+            host: host,
+            method: method,
+            script_name: script_name,
+            request_path: request_path,
+            port: port,
+            query_string: query_string
+          } = conn
+        ) do
       %{
         "params" => Appsignal.Utils.ParamsFilter.filter_values(params),
-        "environment" => %{
-          "host" => host,
-          "method" => method,
-          "script_name" => script_name,
-          "request_path" => request_path,
-          "port" => port,
-          "query_string" => query_string,
-          "request_uri" => url(conn),
-          "peer" => peer(conn)
-        } |> Map.merge(extract_request_headers(conn))
+        "environment" =>
+          %{
+            "host" => host,
+            "method" => method,
+            "script_name" => script_name,
+            "request_path" => request_path,
+            "port" => port,
+            "query_string" => query_string,
+            "request_uri" => url(conn),
+            "peer" => peer(conn)
+          }
+          |> Map.merge(extract_request_headers(conn))
       }
     end
 
@@ -112,17 +137,17 @@ if Appsignal.plug? do
     )
 
     def extract_request_headers(%Plug.Conn{req_headers: req_headers}) do
-      for {key, value} <- req_headers,
-          key in @header_keys do
+      for {key, value} <- req_headers, key in @header_keys do
         {"req_headers.#{key}", value}
       end
       |> Enum.into(%{})
     end
 
     def extract_meta_data(%Plug.Conn{method: method, request_path: path} = conn) do
-      request_id = conn
-      |> Plug.Conn.get_resp_header("x-request-id")
-      |> List.first
+      request_id =
+        conn
+        |> Plug.Conn.get_resp_header("x-request-id")
+        |> List.first()
 
       %{
         "method" => method,
@@ -134,9 +159,10 @@ if Appsignal.plug? do
     defp merge_action_and_controller(action, controller) when is_atom(controller) do
       merge_action_and_controller(
         action,
-        controller |> Atom.to_string |> String.trim_leading("Elixir.")
+        controller |> Atom.to_string() |> String.trim_leading("Elixir.")
       )
     end
+
     defp merge_action_and_controller(action, controller) do
       "#{controller}##{action}"
     end
@@ -146,7 +172,7 @@ if Appsignal.plug? do
     end
 
     defp peer(%Plug.Conn{peer: {host, port}}) do
-      "#{:inet_parse.ntoa host}:#{port}"
+      "#{:inet_parse.ntoa(host)}:#{port}"
     end
   end
 end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -57,8 +57,8 @@ if Appsignal.plug?() do
           :erlang.raise(kind, reason, stack)
         end
 
-        defp handle_error(_conn, kind, reason, _wrapped_reason, stack) do
-          :erlang.raise(kind, reason, stack)
+        defp handle_error(conn, kind, reason, wrapped_reason, stack) do
+          Appsignal.Plug.handle_error(conn, kind, reason, wrapped_reason, stack)
         end
 
         defp finish_with_conn(transaction, conn) do
@@ -79,6 +79,10 @@ if Appsignal.plug?() do
           end
         end
       end
+    end
+
+    def handle_error(_conn, kind, reason, _wrapped_reason, stack) do
+      :erlang.raise(kind, reason, stack)
     end
 
     @doc """

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -57,6 +57,10 @@ defmodule Appsignal.PlugTest do
       assert conn.assigns[:called?]
     end
 
+    test "adds the transaction to the conn", %{conn: conn} do
+      assert %Appsignal.Transaction{id: "123"} = conn.private[:appsignal_transaction]
+    end
+
     test "sets the transaction's action name", %{fake_transaction: fake_transaction} do
       assert "AppsignalPhoenixExample.PageController#index" ==
                FakeTransaction.action(fake_transaction)
@@ -114,7 +118,7 @@ defmodule Appsignal.PlugTest do
   describe "for a transaction with an error" do
     setup do
       conn =
-        %Plug.Conn{}
+        %Plug.Conn{params: %{"foo" => "bar"}}
         |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
         |> Plug.Conn.put_private(:phoenix_action, :exception)
 
@@ -125,8 +129,6 @@ defmodule Appsignal.PlugTest do
           :error, %RuntimeError{message: "Exception!"} -> :ok
           type, reason -> {type, reason}
         end
-
-      [conn: conn]
     end
 
     test "sets the transaction error", %{fake_transaction: fake_transaction} do
@@ -150,10 +152,10 @@ defmodule Appsignal.PlugTest do
     end
 
     test "sets the transaction's request metadata", %{
-      conn: conn,
       fake_transaction: fake_transaction
     } do
-      assert conn == FakeTransaction.request_metadata(fake_transaction)
+      assert %Plug.Conn{params: %{"foo" => "bar"}} =
+        FakeTransaction.request_metadata(fake_transaction)
     end
 
     test "completes the transaction", %{fake_transaction: fake_transaction} do

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -419,4 +419,14 @@ defmodule Appsignal.PlugTest do
              }
     end
   end
+
+  describe "handling errors for a conn without a transaction" do
+    test "reraises the error" do
+      :ok = try do
+        Appsignal.Plug.handle_error(%Plug.Conn{}, :error, :undef, :undef, [])
+      rescue
+        UndefinedFunctionError -> :ok
+      end
+    end
+  end
 end

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -2,22 +2,29 @@ defmodule UsingAppsignalPlug do
   def call(%Plug.Conn{private: %{phoenix_action: :exception}}, _opts) do
     raise("Exception!")
   end
+
   def call(%Plug.Conn{private: %{phoenix_action: :timeout}}, _opts) do
     Task.async(fn -> :timer.sleep(10) end) |> Task.await(1)
   end
+
   def call(%Plug.Conn{private: %{phoenix_action: :bad_request}}, _opts) do
     raise %Plug.BadRequestError{}
   end
+
   def call(%Plug.Conn{private: %{phoenix_action: :undef}} = conn, _opts) do
     raise %Plug.Conn.WrapperError{
-      kind: :error, reason: :undef, stack: System.stacktrace, conn: conn
+      kind: :error,
+      reason: :undef,
+      stack: System.stacktrace(),
+      conn: conn
     }
   end
+
   def call(%Plug.Conn{} = conn, _opts) do
     conn |> Plug.Conn.assign(:called?, true)
   end
 
-  defoverridable [call: 2]
+  defoverridable call: 2
 
   use Appsignal.Plug
 end
@@ -27,16 +34,17 @@ defmodule Appsignal.PlugTest do
   alias Appsignal.FakeTransaction
 
   setup do
-    {:ok, fake_transaction} = FakeTransaction.start_link
+    {:ok, fake_transaction} = FakeTransaction.start_link()
     [fake_transaction: fake_transaction]
   end
 
   describe "for a :sample transaction" do
     setup do
-      conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-      |> Plug.Conn.put_private(:phoenix_action, :index)
-      |> UsingAppsignalPlug.call(%{})
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+        |> Plug.Conn.put_private(:phoenix_action, :index)
+        |> UsingAppsignalPlug.call(%{})
 
       [conn: conn]
     end
@@ -50,21 +58,23 @@ defmodule Appsignal.PlugTest do
     end
 
     test "sets the transaction's action name", %{fake_transaction: fake_transaction} do
-      assert "AppsignalPhoenixExample.PageController#index"
-        == FakeTransaction.action(fake_transaction)
+      assert "AppsignalPhoenixExample.PageController#index" ==
+               FakeTransaction.action(fake_transaction)
     end
 
     test "finishes the transaction", %{fake_transaction: fake_transaction} do
       assert [%Appsignal.Transaction{}] = FakeTransaction.finished_transactions(fake_transaction)
     end
 
-    test "sets the transaction's request metadata", %{conn: conn, fake_transaction: fake_transaction} do
+    test "sets the transaction's request metadata", %{
+      conn: conn,
+      fake_transaction: fake_transaction
+    } do
       assert conn == FakeTransaction.request_metadata(fake_transaction)
     end
 
     test "completes the transaction", %{fake_transaction: fake_transaction} do
-      assert [%Appsignal.Transaction{}] =
-        FakeTransaction.completed_transactions(fake_transaction)
+      assert [%Appsignal.Transaction{}] = FakeTransaction.completed_transactions(fake_transaction)
     end
   end
 
@@ -72,10 +82,11 @@ defmodule Appsignal.PlugTest do
     setup %{fake_transaction: fake_transaction} do
       FakeTransaction.update(fake_transaction, :finish, :no_sample)
 
-      conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-      |> Plug.Conn.put_private(:phoenix_action, :index)
-      |> UsingAppsignalPlug.call(%{})
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+        |> Plug.Conn.put_private(:phoenix_action, :index)
+        |> UsingAppsignalPlug.call(%{})
 
       [conn: conn]
     end
@@ -87,9 +98,10 @@ defmodule Appsignal.PlugTest do
 
   describe "for a transaction with a Phoenix endpoint, but no action" do
     setup do
-      conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_endpoint, MyEndpoint)
-      |> UsingAppsignalPlug.call(%{})
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.put_private(:phoenix_endpoint, MyEndpoint)
+        |> UsingAppsignalPlug.call(%{})
 
       [conn: conn]
     end
@@ -101,40 +113,46 @@ defmodule Appsignal.PlugTest do
 
   describe "for a transaction with an error" do
     setup do
-      conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-      |> Plug.Conn.put_private(:phoenix_action, :exception)
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+        |> Plug.Conn.put_private(:phoenix_action, :exception)
 
-      :ok = try do
-        UsingAppsignalPlug.call(conn, %{})
-      catch
-        :error, %RuntimeError{message: "Exception!"} -> :ok
-        type, reason -> {type, reason}
-      end
+      :ok =
+        try do
+          UsingAppsignalPlug.call(conn, %{})
+        catch
+          :error, %RuntimeError{message: "Exception!"} -> :ok
+          type, reason -> {type, reason}
+        end
 
       [conn: conn]
     end
 
     test "sets the transaction error", %{fake_transaction: fake_transaction} do
-      assert [{
-        %Appsignal.Transaction{},
-        "RuntimeError",
-        "HTTP request error: Exception!",
-        _stack
-      }] = FakeTransaction.errors(fake_transaction)
+      assert [
+               {
+                 %Appsignal.Transaction{},
+                 "RuntimeError",
+                 "HTTP request error: Exception!",
+                 _stack
+               }
+             ] = FakeTransaction.errors(fake_transaction)
     end
 
     test "sets the transaction's action name", %{fake_transaction: fake_transaction} do
-      assert "AppsignalPhoenixExample.PageController#exception"
-        == FakeTransaction.action(fake_transaction)
+      assert "AppsignalPhoenixExample.PageController#exception" ==
+               FakeTransaction.action(fake_transaction)
     end
 
     test "finishes the transaction", %{fake_transaction: fake_transaction} do
-      assert [%Appsignal.Transaction{}] =
-        FakeTransaction.finished_transactions(fake_transaction)
+      assert [%Appsignal.Transaction{}] = FakeTransaction.finished_transactions(fake_transaction)
     end
 
-    test "sets the transaction's request metadata", %{conn: conn, fake_transaction: fake_transaction} do
+    test "sets the transaction's request metadata", %{
+      conn: conn,
+      fake_transaction: fake_transaction
+    } do
       assert conn == FakeTransaction.request_metadata(fake_transaction)
     end
 
@@ -145,20 +163,22 @@ defmodule Appsignal.PlugTest do
 
   describe "for a transaction with a bad request error" do
     setup do
-      conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-      |> Plug.Conn.put_private(:phoenix_action, :bad_request)
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+        |> Plug.Conn.put_private(:phoenix_action, :bad_request)
 
       [conn: conn]
     end
 
     test "does not set the transaction error", %{conn: conn, fake_transaction: fake_transaction} do
-      :ok = try do
-        UsingAppsignalPlug.call(conn, %{})
-      catch
-        :error, %Plug.BadRequestError{} -> :ok
-        type, reason -> {type, reason}
-      end
+      :ok =
+        try do
+          UsingAppsignalPlug.call(conn, %{})
+        catch
+          :error, %Plug.BadRequestError{} -> :ok
+          type, reason -> {type, reason}
+        end
 
       assert [] = FakeTransaction.errors(fake_transaction)
     end
@@ -166,159 +186,163 @@ defmodule Appsignal.PlugTest do
 
   describe "for a wrapped undefined error" do
     setup do
-      conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-      |> Plug.Conn.put_private(:phoenix_action, :undef)
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+        |> Plug.Conn.put_private(:phoenix_action, :undef)
 
       [conn: conn]
     end
 
     test "sets the transaction error", %{conn: conn, fake_transaction: fake_transaction} do
-      :ok = try do
-        UsingAppsignalPlug.call(conn, %{})
-      rescue
-        Plug.Conn.WrapperError -> :ok
-      end
+      :ok =
+        try do
+          UsingAppsignalPlug.call(conn, %{})
+        rescue
+          Plug.Conn.WrapperError -> :ok
+        end
 
-      assert [{
-        %Appsignal.Transaction{},
-        "UndefinedFunctionError",
-        "HTTP request error: undefined function",
-        _stack
-      }] = FakeTransaction.errors(fake_transaction)
+      assert [
+               {
+                 %Appsignal.Transaction{},
+                 "UndefinedFunctionError",
+                 "HTTP request error: undefined function",
+                 _stack
+               }
+             ] = FakeTransaction.errors(fake_transaction)
     end
   end
 
   describe "for a transaction with an timeout" do
     setup do
-      conn = %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-      |> Plug.Conn.put_private(:phoenix_action, :timeout)
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+        |> Plug.Conn.put_private(:phoenix_action, :timeout)
 
       [conn: conn]
     end
 
     test "sets the transaction error", %{conn: conn, fake_transaction: fake_transaction} do
-      :ok = try do
-        UsingAppsignalPlug.call(conn, %{})
-      catch
-        :exit, {:timeout, {Task, :await, _}} -> :ok
-        type, reason -> {type, reason}
-      end
+      :ok =
+        try do
+          UsingAppsignalPlug.call(conn, %{})
+        catch
+          :exit, {:timeout, {Task, :await, _}} -> :ok
+          type, reason -> {type, reason}
+        end
 
-      assert [{
-        %Appsignal.Transaction{},
-        ":timeout",
-        "HTTP request error: {:timeout, {Task, :await, [%Task{owner: " <> _,
-        _stack
-      }] = FakeTransaction.errors(fake_transaction)
+      assert [
+               {
+                 %Appsignal.Transaction{},
+                 ":timeout",
+                 "HTTP request error: {:timeout, {Task, :await, [%Task{owner: " <> _,
+                 _stack
+               }
+             ] = FakeTransaction.errors(fake_transaction)
     end
   end
 
   describe "extracting error metadata" do
     test "with a RuntimeError" do
-      assert Appsignal.Plug.extract_error_metadata(%RuntimeError{})
-        == {"RuntimeError", "HTTP request error: runtime error"}
+      assert Appsignal.Plug.extract_error_metadata(%RuntimeError{}) ==
+               {"RuntimeError", "HTTP request error: runtime error"}
     end
 
     test "with a Plug.Conn.WrapperError" do
       error = %Plug.Conn.WrapperError{reason: %RuntimeError{}}
 
-      assert Appsignal.Plug.extract_error_metadata(error)
-        == {"RuntimeError", "HTTP request error: runtime error"}
+      assert Appsignal.Plug.extract_error_metadata(error) ==
+               {"RuntimeError", "HTTP request error: runtime error"}
     end
 
     test "with an error tuple" do
-      error = {:timeout,
-       {Task, :await,
-        [%Task{owner: self(), pid: self(), ref: make_ref()},
-         1]}}
+      error = {:timeout, {Task, :await, [%Task{owner: self(), pid: self(), ref: make_ref()}, 1]}}
 
-      assert Appsignal.Plug.extract_error_metadata(error)
-        == {":timeout", "HTTP request error: #{inspect(error)}"}
+      assert Appsignal.Plug.extract_error_metadata(error) ==
+               {":timeout", "HTTP request error: #{inspect(error)}"}
     end
 
     test "ignores errors with a plug_status < 500" do
-      assert Appsignal.Plug.extract_error_metadata(%Plug.BadRequestError{})
-        == nil
+      assert Appsignal.Plug.extract_error_metadata(%Plug.BadRequestError{}) == nil
     end
   end
 
   describe "extracting action names" do
     test "from a Plug conn" do
-      assert Appsignal.Plug.extract_action(
-        %Plug.Conn{method: "GET", request_path: "/foo"}
-      ) == "GET /foo"
+      assert Appsignal.Plug.extract_action(%Plug.Conn{method: "GET", request_path: "/foo"}) ==
+               "GET /foo"
     end
 
     test "from a Plug conn with a Phoenix endpoint, but no controller or action" do
       assert %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_endpoint, MyEndpoint)
-      |> Appsignal.Plug.extract_action == nil
+             |> Plug.Conn.put_private(:phoenix_endpoint, MyEndpoint)
+             |> Appsignal.Plug.extract_action() == nil
     end
 
     test "from a Plug conn with a Phoenix controller and action" do
       assert %Plug.Conn{}
-      |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-      |> Plug.Conn.put_private(:phoenix_action, :index)
-      |> Appsignal.Plug.extract_action == "AppsignalPhoenixExample.PageController#index"
+             |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
+             |> Plug.Conn.put_private(:phoenix_action, :index)
+             |> Appsignal.Plug.extract_action() == "AppsignalPhoenixExample.PageController#index"
     end
   end
 
   describe "extracting request metadata" do
     test "from a Plug conn" do
-      assert Appsignal.Plug.extract_meta_data(
-        %Plug.Conn{
-          method: "GET",
-          request_path: "/foo",
-          resp_headers: [{"x-request-id", "kk4hk5sis7c3b56t683nnmdig632c9ot"}]
-        }
-      ) == %{
-        "method" => "GET",
-        "path" => "/foo",
-        "request_id" => "kk4hk5sis7c3b56t683nnmdig632c9ot"
-      }
+      assert Appsignal.Plug.extract_meta_data(%Plug.Conn{
+               method: "GET",
+               request_path: "/foo",
+               resp_headers: [{"x-request-id", "kk4hk5sis7c3b56t683nnmdig632c9ot"}]
+             }) == %{
+               "method" => "GET",
+               "path" => "/foo",
+               "request_id" => "kk4hk5sis7c3b56t683nnmdig632c9ot"
+             }
     end
   end
 
   describe "extracting sample data" do
     setup do
-      %{conn: %Plug.Conn{
-        params: %{"foo" => "bar"},
-        host: "www.example.com",
-        method: "GET",
-        script_name: ["foo", "bar"],
-        request_path: "/foo/bar",
-        port: 80,
-        query_string: "foo=bar",
-        peer: {{127, 0, 0, 1}, 12345},
-        scheme: :http,
-        req_headers: [{"accept", "text/html"}]
-      }}
-    end
-
-    test "from a Plug conn", %{conn: conn} do
-      assert Appsignal.Plug.extract_sample_data(conn) == %{
-        "params" => %{"foo" => "bar"},
-        "environment" => %{
-          "host" => "www.example.com",
-          "method" => "GET",
-          "script_name" => ["foo", "bar"],
-          "request_path" => "/foo/bar",
-          "port" => 80,
-          "query_string" => "foo=bar",
-          "peer" => "127.0.0.1:12345",
-          "request_uri" => "http://www.example.com:80/foo/bar",
-          "req_headers.accept" => "text/html"
+      %{
+        conn: %Plug.Conn{
+          params: %{"foo" => "bar"},
+          host: "www.example.com",
+          method: "GET",
+          script_name: ["foo", "bar"],
+          request_path: "/foo/bar",
+          port: 80,
+          query_string: "foo=bar",
+          peer: {{127, 0, 0, 1}, 12345},
+          scheme: :http,
+          req_headers: [{"accept", "text/html"}]
         }
       }
     end
 
+    test "from a Plug conn", %{conn: conn} do
+      assert Appsignal.Plug.extract_sample_data(conn) == %{
+               "params" => %{"foo" => "bar"},
+               "environment" => %{
+                 "host" => "www.example.com",
+                 "method" => "GET",
+                 "script_name" => ["foo", "bar"],
+                 "request_path" => "/foo/bar",
+                 "port" => 80,
+                 "query_string" => "foo=bar",
+                 "peer" => "127.0.0.1:12345",
+                 "request_uri" => "http://www.example.com:80/foo/bar",
+                 "req_headers.accept" => "text/html"
+               }
+             }
+    end
+
     test "with a param that should be filtered out", %{conn: conn} do
-      AppsignalTest.Utils.with_config(%{filter_parameters: ["password"]}, fn() ->
+      AppsignalTest.Utils.with_config(%{filter_parameters: ["password"]}, fn ->
         conn = %{conn | params: %{"password" => "secret"}}
+
         assert %{"params" => %{"password" => "[FILTERED]"}} =
-          Appsignal.Plug.extract_sample_data(conn)
+                 Appsignal.Plug.extract_sample_data(conn)
       end)
     end
   end
@@ -344,19 +368,19 @@ defmodule Appsignal.PlugTest do
       }
 
       assert Appsignal.Plug.extract_request_headers(conn) == %{
-        "req_headers.content-length" => "1024",
-        "req_headers.accept" => "text/html",
-        "req_headers.accept-charset" => "utf-8",
-        "req_headers.accept-encoding" => "gzip, deflate",
-        "req_headers.accept-language" => "en-us",
-        "req_headers.cache-control" => "no-cache",
-        "req_headers.connection" => "keep-alive",
-        "req_headers.user-agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3...",
-        "req_headers.from" => "webmaster@example.org",
-        "req_headers.referer" => "http://localhost:4001/",
-        "req_headers.range" => "bytes=0-1023",
-        "req_headers.x-real-ip" => "179.146.231.170"
-      }
+               "req_headers.content-length" => "1024",
+               "req_headers.accept" => "text/html",
+               "req_headers.accept-charset" => "utf-8",
+               "req_headers.accept-encoding" => "gzip, deflate",
+               "req_headers.accept-language" => "en-us",
+               "req_headers.cache-control" => "no-cache",
+               "req_headers.connection" => "keep-alive",
+               "req_headers.user-agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3...",
+               "req_headers.from" => "webmaster@example.org",
+               "req_headers.referer" => "http://localhost:4001/",
+               "req_headers.range" => "bytes=0-1023",
+               "req_headers.x-real-ip" => "179.146.231.170"
+             }
     end
   end
 end

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -46,7 +46,7 @@ defmodule Appsignal.FakeTransaction do
     Agent.get(__MODULE__, &Map.get(&1, :finish, :sample))
   end
 
-  def set_request_metadata(_transation, conn) do
+  def set_request_metadata(_transaction, conn) do
     Agent.update(__MODULE__, &Map.put(&1, :request_metadata, conn))
   end
 


### PR DESCRIPTION
Closes #307.

As explained in the original issue, wrapping the `call/2` function in an endpoint takes the `Plug.Conn` *before* the request is executed. This is a regression introduced in #287, because we stopped using`Plug.Conn.ErrorHandler.__catch__/4`, which took care of taking the updated conn out of `Plug.Conn.WrapperErrors`.