### PR TITLE
Use "unknown" as action for Plug-only transactions, set action before `call/2`

### DIFF
--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -122,7 +122,7 @@ if Appsignal.plug?() do
     def extract_action(%Plug.Conn{private: %{phoenix_endpoint: _}}), do: nil
 
     def extract_action(%Plug.Conn{method: method, request_path: path}) do
-      "#{method} #{path}"
+      :unknown
     end
 
     def extract_sample_data(

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -14,6 +14,7 @@ if Appsignal.plug?() do
 
         def call(conn, opts) do
           transaction = @transaction.start(@transaction.generate_id(), :http_request)
+          Appsignal.Plug.try_set_action(transaction, conn)
 
           conn = Plug.Conn.put_private(conn, :appsignal_transaction, transaction)
 
@@ -70,8 +71,6 @@ if Appsignal.plug?() do
     end
 
     def finish_with_conn(transaction, conn) do
-      try_set_action(transaction, conn)
-
       if @transaction.finish(transaction) == :sample do
         @transaction.set_request_metadata(transaction, conn)
       end
@@ -80,7 +79,7 @@ if Appsignal.plug?() do
       conn
     end
 
-    defp try_set_action(transaction, conn) do
+    def try_set_action(transaction, conn) do
       case Appsignal.Plug.extract_action(conn) do
         nil -> nil
         :unknown -> @transaction.set_action(transaction, "unknown")

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -82,7 +82,6 @@ if Appsignal.plug?() do
     def try_set_action(transaction, conn) do
       case Appsignal.Plug.extract_action(conn) do
         nil -> nil
-        :unknown -> @transaction.set_action(transaction, "unknown")
         action -> @transaction.set_action(transaction, action)
       end
     end
@@ -122,7 +121,7 @@ if Appsignal.plug?() do
     def extract_action(%Plug.Conn{private: %{phoenix_endpoint: _}}), do: nil
 
     def extract_action(%Plug.Conn{method: method, request_path: path}) do
-      :unknown
+      "unknown"
     end
 
     def extract_sample_data(

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -83,6 +83,7 @@ if Appsignal.plug?() do
     defp try_set_action(transaction, conn) do
       case Appsignal.Plug.extract_action(conn) do
         nil -> nil
+        :unknown -> @transaction.set_action(transaction, "unknown")
         action -> @transaction.set_action(transaction, action)
       end
     end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -13,8 +13,9 @@ if Appsignal.plug?() do
                      )
 
         def call(conn, opts) do
-          transaction = @transaction.start(@transaction.generate_id(), :http_request)
-          Appsignal.Plug.try_set_action(transaction, conn)
+          transaction = @transaction.generate_id()
+          |> @transaction.start(:http_request)
+          |> Appsignal.Plug.try_set_action(conn)
 
           conn = Plug.Conn.put_private(conn, :appsignal_transaction, transaction)
 
@@ -81,7 +82,7 @@ if Appsignal.plug?() do
 
     def try_set_action(transaction, conn) do
       case Appsignal.Plug.extract_action(conn) do
-        nil -> nil
+        nil -> transaction
         action -> @transaction.set_action(transaction, action)
       end
     end
@@ -120,7 +121,7 @@ if Appsignal.plug?() do
 
     def extract_action(%Plug.Conn{private: %{phoenix_endpoint: _}}), do: nil
 
-    def extract_action(%Plug.Conn{method: method, request_path: path}) do
+    def extract_action(%Plug.Conn{method: _method, request_path: _path}) do
       "unknown"
     end
 

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -325,7 +325,7 @@ defmodule Appsignal.PlugTest do
   describe "extracting action names" do
     test "from a Plug conn" do
       assert Appsignal.Plug.extract_action(%Plug.Conn{method: "GET", request_path: "/foo"}) ==
-               :unknown
+               "unknown"
     end
 
     test "from a Plug conn with a Phoenix endpoint, but no controller or action" do

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -311,7 +311,7 @@ defmodule Appsignal.PlugTest do
   describe "extracting action names" do
     test "from a Plug conn" do
       assert Appsignal.Plug.extract_action(%Plug.Conn{method: "GET", request_path: "/foo"}) ==
-               "GET /foo"
+               :unknown
     end
 
     test "from a Plug conn with a Phoenix endpoint, but no controller or action" do

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -109,6 +109,20 @@ defmodule Appsignal.PlugTest do
     end
   end
 
+  describe "for a transaction without a Phoenix endpoint" do
+    setup do
+      conn =
+        %Plug.Conn{method: "GET", request_path: "/foo"}
+        |> UsingAppsignalPlug.call(%{})
+
+      [conn: conn]
+    end
+
+    test "does not set the transaction's action name", %{fake_transaction: fake_transaction} do
+      assert FakeTransaction.action(fake_transaction) == "unknown"
+    end
+  end
+
   describe "for a transaction with a Phoenix endpoint, but no action" do
     setup do
       conn =

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -25,7 +25,10 @@ defmodule Appsignal.FakeTransaction do
     end)
   end
 
-  def set_action(_transaction, conn), do: set_action(conn)
+  def set_action(transaction, conn) do
+    set_action(conn)
+    transaction
+  end
   def set_action(action) do
     Agent.update(__MODULE__, &Map.put(&1, :action, action))
   end


### PR DESCRIPTION
Previously, `Appsignal.Plug` used the method and the path as the action name in plug-only apps. This caused problems for apps with unique URLs, as it creates a seperate performance/error incident for each variation of the URL. To fix this, we're using "unknown" as the default action name in Plug apps, and we're allowing users to override that by using `Appsignal.Transaction.set_action/1-2`:

```elixir
  get "/users/:id" do
    Appsignal.Transaction.set_action("GET /users/:id")
    send_resp(conn, 200, "Welcome")
  end
```