### PR TITLE
Allow OTP 18.3 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       elixir: 1.6.0
   allow_failures:
     - elixir: 1.6.0
+    - otp_release: 18.3
 before_script:
   - MIX_ENV=test mix compile --warnings-as-errors
   - MIX_ENV=test_phoenix mix compile --warnings-as-errors


### PR DESCRIPTION
Currently the only OTP version it randomly fails on to test the agent in
diagnose mode. Outside the test env this seems to work fine. Given
enough retries or luck it will eventually work on TravisCI, but it's not
helpful to developers continuously seeing a red mark for build status.