### PR TITLE
⌨️ Filter arguments in backtraces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
     - otp_release: 18.3
       elixir: 1.5.3
   allow_failures:
-    - elixir: 1.6.4
     - otp_release: 18.3
 before_script:
   - MIX_ENV=test mix compile --warnings-as-errors

--- a/lib/appsignal/backtrace.ex
+++ b/lib/appsignal/backtrace.ex
@@ -3,24 +3,13 @@ defmodule Appsignal.Backtrace do
   Parses the given stacktrace into a backtrace list.
   """
   def from_stacktrace(stacktrace) do
-    stacktrace
-    |> remove_error_entries
-    |> format_stacktrace
-  end
-
-  defp remove_error_entries([]), do: []
-  defp remove_error_entries([{_, _, arity, _}|tail]) when is_list(arity) do
-    remove_error_entries(tail)
-  end
-  defp remove_error_entries([entry|tail]) do
-    [entry|remove_error_entries(tail)]
-  end
-
-  defp format_stacktrace(stacktrace) do
     Enum.map(stacktrace, &format_stacktrace_entry/1)
   end
 
   defp format_stacktrace_entry(entry) when is_binary(entry), do: entry
+  defp format_stacktrace_entry({module, function, arity, location}) when is_list(arity) do
+    format_stacktrace_entry({module, function, length(arity), location})
+  end
   defp format_stacktrace_entry(entry) do
     Exception.format_stacktrace_entry(entry)
   end

--- a/test/appsignal/backtrace_test.exs
+++ b/test/appsignal/backtrace_test.exs
@@ -10,12 +10,12 @@ defmodule Appsignal.BacktraceTest do
     ]
   end
 
-  test "removes error lines" do
+  test "replaces arguments with arities" do
     stacktrace = [{:erl_internal, :op_type, [:get_stacktrace, 0],
-        [file: 'erl_internal.erl', line: 212]}, @match_line]
+        [file: 'erl_internal.erl', line: 212]}]
 
     assert Appsignal.Backtrace.from_stacktrace(stacktrace) == [
-      Exception.format_stacktrace_entry(@match_line)
+      "(stdlib) erl_internal.erl:212: :erl_internal.op_type/2"
     ]
   end
 

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -24,7 +24,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       {:noreply, nil}
     end
     def handle_info(:timeout, :function_error) do
-      String.length(:notastring)
+      Float.ceil(1)
       {:noreply, nil}
     end
   end
@@ -102,13 +102,13 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
   test "proc_lib.spawn + function error" do
     :proc_lib.spawn(fn() ->
-      String.length(:notastring)
+      Float.ceil(1)
     end)
     |> assert_crash_caught
     |> reason("{:error, :function_clause}")
     |> message(~r(Process #PID<[\d.]+> terminating$))
     |> stacktrace([
-      ~r{\(elixir\) (lib/elixir/)?unicode/unicode.ex:\d+: String.Unicode.length/1},
+      ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
@@ -173,7 +173,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     if System.otp_release >= "20" do
       stacktrace(result, [
-        ~r{\(elixir\) (lib/elixir/)?unicode/unicode.ex:\d+: String.Unicode.length/1},
+        ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
         ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2},
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.handle_msg/6},
@@ -181,7 +181,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       ])
     else
       stacktrace(result, [
-        ~r{\(elixir\) (lib/elixir/)?unicode/unicode.ex:\d+: String.Unicode.length/1},
+        ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
         ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2},
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.handle_msg/5},
@@ -192,15 +192,15 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
   test "Task" do
     Task.start(fn() ->
-      String.length(:notastring)
+      Float.ceil(1)
     end)
     |> assert_crash_caught
     |> reason(":function_clause")
     |> message(
-      ~r(Process #PID<[\d.]+> terminating: {:function_clause, \[{String.Uni...)
+      ~r(Process #PID<[\d.]+> terminating: {:function_clause, \[{Float, :cei...)
     )
     |> stacktrace([
-      ~r{\(elixir\) (lib/elixir/)?unicode/unicode.ex:\d+: String.Unicode.length/1},
+      ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
       ~r{\(elixir\) lib/task/supervised.ex:\d+: Task.Supervised.do_apply/2},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
     ])


### PR DESCRIPTION
Closes #325.

Instead of taking off the first backtrace line to make sure no function arguments end up in the backtrace, this patch replaces the argument list with the function arity, turning it into a "normal" backtrace line. Also, the test uses `Float.ceil` to trigger a badarg error instead of `String.length`, because the latter has different implementations on different Elixir versions (which makes it harder to assert stacktraces).

This patch fixes the test failures we've been seeing on Elixir 1.6, so it removes 1.6 from the allowed failures list in the Travis config.