### PR TITLE
Remove transaction when calling `Transaction.complete`

### DIFF
--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -1,6 +1,6 @@
 defmodule Appsignal.DemoBehaviour do
-  @callback create_transaction_error_request :: :ok
-  @callback create_transaction_performance_request :: :ok
+  @callback create_transaction_error_request :: Appsignal.Transaction.t
+  @callback create_transaction_performance_request :: Appsignal.Transaction.t
 end
 
 defmodule Appsignal.Demo do
@@ -9,7 +9,7 @@ defmodule Appsignal.Demo do
   @behaviour Appsignal.DemoBehaviour
 
   @doc false
-  @spec create_transaction_error_request :: :ok
+  @spec create_transaction_error_request :: Appsignal.Transaction.t
   def create_transaction_error_request do
     create_demo_transaction()
     |> Appsignal.Transaction.set_error(
@@ -21,7 +21,7 @@ defmodule Appsignal.Demo do
   end
 
   @doc false
-  @spec create_transaction_performance_request :: :ok
+  @spec create_transaction_performance_request :: Appsignal.Transaction.t
   def create_transaction_performance_request do
     transaction = create_demo_transaction()
 
@@ -56,5 +56,7 @@ defmodule Appsignal.Demo do
   defp finish_demo_transaction(transaction) do
     Appsignal.Transaction.finish(transaction)
     :ok = Appsignal.Transaction.complete(transaction)
+
+    transaction
   end
 end

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -358,6 +358,7 @@ defmodule Appsignal.Transaction do
   @spec complete(Transaction.t | nil) :: :ok
   def complete(nil), do: nil
   def complete(%Transaction{} = transaction) do
+    TransactionRegistry.remove_transaction(transaction)
     :ok = Nif.complete(transaction.resource)
   end
 

--- a/test/appsignal/demo_test.exs
+++ b/test/appsignal/demo_test.exs
@@ -1,12 +1,10 @@
 defmodule AppsignalDemoTest do
   use ExUnit.Case
   import Mock
-  alias Appsignal.{Transaction, TransactionRegistry}
 
   test_with_mock "sends a demonstration error", Appsignal.Transaction, [:passthrough], [] do
-    Appsignal.Demo.create_transaction_error_request
+    t = Appsignal.Demo.create_transaction_error_request
 
-    t = %Transaction{} = TransactionRegistry.lookup(self())
     assert called Appsignal.Transaction.set_action(t, "DemoController#hello")
     assert called Appsignal.Transaction.set_error(t, "TestError", "Hello world! This is an error used for demonstration purposes.", :_)
     assert called Appsignal.Transaction.set_meta_data(t, "demo_sample", "true")
@@ -15,9 +13,8 @@ defmodule AppsignalDemoTest do
   end
 
   test_with_mock "sends a performance issue", Appsignal.Transaction, [:passthrough], [] do
-    Appsignal.Demo.create_transaction_performance_request
+    t = Appsignal.Demo.create_transaction_performance_request
 
-    t = %Transaction{} = TransactionRegistry.lookup(self())
     assert called Appsignal.Transaction.set_action(t, "DemoController#hello")
     assert called Appsignal.Transaction.set_meta_data(t, "demo_sample", "true")
     assert called Appsignal.Transaction.start_event(t)

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -3,7 +3,7 @@ defmodule AppsignalTransactionTest do
   import Mock
   import AppsignalTest.Utils
 
-  alias Appsignal.Transaction
+  alias Appsignal.{Transaction, TransactionRegistry}
 
   test "transaction lifecycle" do
     transaction = Transaction.start("test1", :http_request)
@@ -166,6 +166,15 @@ defmodule AppsignalTransactionTest do
       assert not called Appsignal.Transaction.set_sample_data(
         transaction, "session_data", context[:conn].private.plug_session
       )
+    end
+  end
+
+  describe "completing a transaction" do
+    test "removes the transaction from the registry" do
+      transaction = Transaction.start(Transaction.generate_id, :http_request)
+      Transaction.finish(transaction)
+      :ok = Transaction.complete(transaction)
+      {:error, :not_found} = TransactionRegistry.remove_transaction(transaction)
     end
   end
 end

--- a/test/support/fake_demo.ex
+++ b/test/support/fake_demo.ex
@@ -1,12 +1,15 @@
 defmodule Appsignal.FakeDemo do
   @behaviour Appsignal.DemoBehaviour
   use TestAgent
+  alias Appsignal.Transaction
 
   def create_transaction_error_request do
     update(__MODULE__, :create_transaction_error_request, true)
+    %Transaction{}
   end
 
   def create_transaction_performance_request do
     update(__MODULE__, :create_transaction_performance_request, true)
+    %Transaction{}
   end
 end


### PR DESCRIPTION
Part of #299.

Explicitly remove completed Transactions from the TransactionRegistry instead of waiting for a Transaction's process to go DOWN. For convenience, `Demo.create_transaction_(error|performance)_request` now returns the transaction object, because it'll be removed before it reaches the test.