### PR TITLE
Don't register Transactions created by `Appsignal.send_error/7`

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -138,10 +138,9 @@ defmodule Appsignal do
   def send_error(reason, message \\ "", stack \\ nil, metadata \\ %{}, conn \\ nil, fun \\ fn(t) -> t end, namespace \\ :http_request) do
     stack = stack || System.stacktrace()
 
-    transaction = Appsignal.Transaction.start("_" <> Appsignal.Transaction.generate_id(), namespace)
+    transaction = Appsignal.Transaction.create("_" <> Appsignal.Transaction.generate_id(), namespace)
     fun.(transaction)
     {reason, message} = Appsignal.ErrorHandler.extract_reason_and_message(reason, message)
-    Appsignal.TransactionRegistry.remove_transaction(transaction)
     Appsignal.ErrorHandler.submit_transaction(transaction, reason, message, stack, metadata, conn)
   end
 end

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -218,7 +218,7 @@ defmodule Appsignal.Nif do
   end
 
   def _start_transaction(_id, _namespace) do
-    {:ok, <<>>}
+    {:ok, make_ref()}
   end
 
   def _start_event(_transaction_resource) do

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -218,7 +218,11 @@ defmodule Appsignal.Nif do
   end
 
   def _start_transaction(_id, _namespace) do
-    {:ok, make_ref()}
+    if System.otp_release >= "20" do
+      {:ok, make_ref()}
+    else
+      {:ok, <<>>}
+    end
   end
 
   def _start_event(_transaction_resource) do

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -46,7 +46,7 @@ defmodule Appsignal.Transaction do
   @type t :: %Transaction{}
 
   @doc """
-  Start a transaction
+  Create and register a transaction.
 
   Call this when a transaction such as a http request or background job starts.
 
@@ -65,9 +65,23 @@ defmodule Appsignal.Transaction do
   """
   @spec start(String.t, atom) :: Transaction.t
   def start(transaction_id, namespace) when is_binary(transaction_id) do
+    transaction_id
+    |> create(namespace)
+    |> register
+  end
+
+  @doc """
+  Create a transaction with a transaction resource.
+  """
+  @spec create(String.t, atom) :: Transaction.t
+  def create(transaction_id, namespace) when is_binary(transaction_id) and is_atom(namespace) do
     {:ok, resource} = Nif.start_transaction(transaction_id, Atom.to_string(namespace))
-    transaction = %Appsignal.Transaction{resource: resource, id: transaction_id}
-    TransactionRegistry.register(transaction)
+    %Transaction{resource: resource, id: transaction_id}
+  end
+
+  @spec register(Transaction.t) :: Transaction.t
+  defp register(transaction) do
+    :ok = TransactionRegistry.register(transaction)
     transaction
   end
 

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -125,7 +125,7 @@ defmodule AppsignalTest do
 
       assert called TransactionRegistry.remove_transaction(t)
 
-      assert called Transaction.start(:_, :http_request)
+      assert called Transaction.create(:_, :http_request)
       assert called Transaction.set_error(t, "RuntimeError", "Oops: Some bad stuff happened", [])
       assert called Transaction.set_sample_data(t, "key", %{foo: "bar"})
       assert called Transaction.finish(t)
@@ -150,7 +150,7 @@ defmodule AppsignalTest do
 
       assert called TransactionRegistry.remove_transaction(t)
 
-      assert called Transaction.start(:_, :background_job)
+      assert called Transaction.create(:_, :background_job)
       assert called Transaction.set_error(t, "RuntimeError", "Oops: Some bad stuff happened", [])
       assert called Transaction.finish(t)
       assert called Transaction.complete(t)

--- a/test/appsignal/nif_test.exs
+++ b/test/appsignal/nif_test.exs
@@ -1,5 +1,6 @@
 defmodule Appsignal.NifTest do
   use ExUnit.Case
+  import AppsignalTest.Utils, only: [is_reference_or_binary: 1]
 
   test "whether the agent starts" do
     assert :ok = Appsignal.Nif.start
@@ -9,18 +10,10 @@ defmodule Appsignal.NifTest do
     assert :ok = Appsignal.Nif.stop
   end
 
-  if System.otp_release >= "20" do
-    @tag :skip_env_test_no_nif
-    test "starting transaction returns a reference to the transaction resource" do
-      assert {:ok, transaction} = Appsignal.Nif.start_transaction("transaction id", "http_request")
-      assert is_reference(transaction)
-    end
-  else
-    @tag :skip_env_test_no_nif
-    test "starting transaction returns a resource term" do
-      assert {:ok, transaction} = Appsignal.Nif.start_transaction("transaction id", "http_request")
-      assert is_binary(transaction)
-    end
+  @tag :skip_env_test_no_nif
+  test "starting transaction returns a reference to the transaction resource" do
+    assert {:ok, reference} = Appsignal.Nif.start_transaction("transaction id", "http_request")
+    assert is_reference_or_binary(reference)
   end
 
   if not(Mix.env in [:test_no_nif]) do

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -184,7 +184,7 @@ defmodule AppsignalTransactionTest do
     end
 
     test "creates a transaction_reference", %{transaction: transaction} do
-      assert is_reference(transaction.resource)
+      assert is_reference_or_binary(transaction.resource)
     end
   end
 

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -169,6 +169,40 @@ defmodule AppsignalTransactionTest do
     end
   end
 
+  describe "creating a transaction" do
+    setup do
+      id = Transaction.generate_id
+      [id: id, transaction: Transaction.create(id, :http_request)]
+    end
+
+    test "returns a transaction", %{transaction: transaction} do
+      assert %Transaction{} = transaction
+    end
+
+    test "uses the passed transaction ID", %{id: id, transaction: transaction} do
+      assert %{id: ^id} = transaction
+    end
+
+    test "creates a transaction_reference", %{transaction: transaction} do
+      assert is_reference(transaction.resource)
+    end
+  end
+
+  describe "starting a transaction" do
+    setup do
+      id = Transaction.generate_id
+      [id: id, transaction: Transaction.start(id, :http_request)]
+    end
+
+    test "creates a transaction", %{transaction: transaction} do
+      assert %Transaction{id: id} = transaction
+    end
+
+    test "registers the transaction", %{transaction: transaction} do
+      assert :ok == TransactionRegistry.remove_transaction(transaction)
+    end
+  end
+
   describe "completing a transaction" do
     test "removes the transaction from the registry" do
       transaction = Transaction.start(Transaction.generate_id, :http_request)

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -69,6 +69,14 @@ defmodule AppsignalTest.Utils do
     end
   end
 
+  def is_reference_or_binary(term) do
+    if System.otp_release >= "20" do
+      is_reference(term)
+    else
+      is_binary(term)
+    end
+  end
+
   defp put_merged_env(env) do
     System.get_env
     |> Map.merge(env)


### PR DESCRIPTION
For `Appsignal.send_error/7`, we need a Transaction to put the error in, but we don't need to register the created transaction in the `TransactionRegistry`/

Before, there was no way to create a Transaction without registering it. This patch adds `Transaction.create/2` which creates a Transaction with a resource, but doesn't register it, which is then used by `Appsignal.send_error/7`.