### PR TITLE
Accept tags for (custom) metrics

### DIFF
--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "ca32965"
+  def version, do: "f781aa1"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "4536f611bf2e31137520fcbbf2175dd19e86d4ae8c1d2910b82cb63d67634a8e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "2d881b17e6400f6298acd1e565e714c873fd6e489cfcf19892c71c9fade06381",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "4536f611bf2e31137520fcbbf2175dd19e86d4ae8c1d2910b82cb63d67634a8e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "2d881b17e6400f6298acd1e565e714c873fd6e489cfcf19892c71c9fade06381",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "c5e0cfcc1a26bab694dda5297c9f34fd76d020709475062a2a5d7b1e11a02231",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "7e9547965dcb31b34fcd52e9cfc248d1f314feb74e1191b8e5061aadd6da14d1",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "c5e0cfcc1a26bab694dda5297c9f34fd76d020709475062a2a5d7b1e11a02231",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "7e9547965dcb31b34fcd52e9cfc248d1f314feb74e1191b8e5061aadd6da14d1",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "a6e45a2c4a9054cbfb71dcacd23c012dc01b4b0af40b356c67153ce728f57e16",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "cbfb6b1aaa2a6894b3bcc35f5879cfd232b9ccafe0bc4a95762d4155bf8a65a7",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "a6e45a2c4a9054cbfb71dcacd23c012dc01b4b0af40b356c67153ce728f57e16",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "cbfb6b1aaa2a6894b3bcc35f5879cfd232b9ccafe0bc4a95762d4155bf8a65a7",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "ec400854cc123e73655bb09ebc4554726a2658980cfe5347f36076f74dac0524",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "e994fff885d8fcae6aeb7e0e41c299b2d5d4a7a724cc7753db5225d54dc8dad9",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "84250cf6d97893c584f779c7ad600e4e7d1b280eae36a76815173a83df85bd3a",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "64b357d4af2be84010d35cc2cfa843350a6bb788d7eacf48150b0c01bb5e3dff",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "ce28eed8dd12e6886657517bc0e1da442fbad135e449fb3a430c35087ed13973",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "a3cb12c629f7b52dfab9ec02f755a0512cb104826123e1937e05711fed014f3f",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "ce28eed8dd12e6886657517bc0e1da442fbad135e449fb3a430c35087ed13973",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/ca32965/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "a3cb12c629f7b52dfab9ec02f755a0512cb104826123e1937e05711fed014f3f",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -410,8 +410,9 @@ static ERL_NIF_TERM _set_gauge(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
 {
     ErlNifBinary key;
     double value;
+    data_ptr *data_ptr;
 
-    if (argc != 2) {
+    if (argc != 3) {
       return enif_make_badarg(env);
     }
     if(!enif_inspect_iolist_as_binary(env, argv[0], &key)) {
@@ -420,8 +421,11 @@ static ERL_NIF_TERM _set_gauge(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
     if(!enif_get_double(env, argv[1], &value)) {
         return enif_make_badarg(env);
     }
+    if(!enif_get_resource(env, argv[2], appsignal_data_type, (void**) &data_ptr)) {
+      return enif_make_badarg(env);
+    }
 
-    appsignal_set_gauge(make_appsignal_string(key), value);
+    appsignal_set_gauge(make_appsignal_string(key), value, data_ptr->data);
 
     return enif_make_atom(env, "ok");
 }
@@ -430,8 +434,9 @@ static ERL_NIF_TERM _increment_counter(ErlNifEnv* env, int argc, const ERL_NIF_T
 {
     ErlNifBinary key;
     int count;
+    data_ptr *data_ptr;
 
-    if (argc != 2) {
+    if (argc != 3) {
       return enif_make_badarg(env);
     }
     if(!enif_inspect_iolist_as_binary(env, argv[0], &key)) {
@@ -440,8 +445,11 @@ static ERL_NIF_TERM _increment_counter(ErlNifEnv* env, int argc, const ERL_NIF_T
     if(!enif_get_int(env, argv[1], &count)) {
         return enif_make_badarg(env);
     }
+    if(!enif_get_resource(env, argv[2], appsignal_data_type, (void**) &data_ptr)) {
+      return enif_make_badarg(env);
+    }
 
-    appsignal_increment_counter(make_appsignal_string(key), count);
+    appsignal_increment_counter(make_appsignal_string(key), count, data_ptr->data);
 
     return enif_make_atom(env, "ok");
 }
@@ -450,8 +458,9 @@ static ERL_NIF_TERM _add_distribution_value(ErlNifEnv* env, int argc, const ERL_
 {
     ErlNifBinary key;
     double value;
+    data_ptr *data_ptr;
 
-    if (argc != 2) {
+    if (argc != 3) {
       return enif_make_badarg(env);
     }
     if(!enif_inspect_iolist_as_binary(env, argv[0], &key)) {
@@ -460,8 +469,11 @@ static ERL_NIF_TERM _add_distribution_value(ErlNifEnv* env, int argc, const ERL_
     if(!enif_get_double(env, argv[1], &value)) {
         return enif_make_badarg(env);
     }
+    if(!enif_get_resource(env, argv[2], appsignal_data_type, (void**) &data_ptr)) {
+      return enif_make_badarg(env);
+    }
 
-    appsignal_add_distribution_value(make_appsignal_string(key), value);
+    appsignal_add_distribution_value(make_appsignal_string(key), value, data_ptr->data);
 
     return enif_make_atom(env, "ok");
 }
@@ -792,9 +804,9 @@ static ErlNifFunc nif_funcs[] =
     {"_set_meta_data", 3, _set_meta_data, 0},
     {"_finish", 1, _finish, 0},
     {"_complete", 1, _complete, 0},
-    {"_set_gauge", 2, _set_gauge, 0},
-    {"_increment_counter", 2, _increment_counter, 0},
-    {"_add_distribution_value", 2, _add_distribution_value, 0},
+    {"_set_gauge", 3, _set_gauge, 0},
+    {"_increment_counter", 3, _increment_counter, 0},
+    {"_add_distribution_value", 3, _add_distribution_value, 0},
     {"_data_map_new", 0, _data_map_new, 0},
     {"_data_set_string", 3, _data_set_string, 0},
     {"_data_set_string", 2, _data_set_string, 0},

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -90,20 +90,23 @@ defmodule Appsignal do
   @doc """
   Set a gauge for a measurement of some metric.
   """
-  @spec set_gauge(String.t, float | integer) :: :ok
-  def set_gauge(key, value) when is_integer(value) do
-    set_gauge(key, value + 0.0)
+  @spec set_gauge(String.t, float | integer, Map) :: :ok
+  def set_gauge(key, value, tags \\ %{})
+  def set_gauge(key, value, tags) when is_integer(value) do
+    set_gauge(key, value + 0.0, tags)
   end
-  def set_gauge(key, value) when is_float(value) do
-    Appsignal.Nif.set_gauge(key, value)
+  def set_gauge(key, value, %{} = tags) when is_float(value) do
+    encoded_tags = Appsignal.Utils.DataEncoder.encode(tags)
+    :ok = Appsignal.Nif.set_gauge(key, value, encoded_tags)
   end
 
   @doc """
   Increment a counter of some metric.
   """
-  @spec increment_counter(String.t, integer) :: :ok
-  def increment_counter(key, count \\ 1) when is_integer(count) do
-    Appsignal.Nif.increment_counter(key, count)
+  @spec increment_counter(String.t, integer, Map) :: :ok
+  def increment_counter(key, count \\ 1, %{} = tags \\ %{}) when is_integer(count) do
+    encoded_tags = Appsignal.Utils.DataEncoder.encode(tags)
+    :ok = Appsignal.Nif.increment_counter(key, count, encoded_tags)
   end
 
   @doc """
@@ -112,12 +115,14 @@ defmodule Appsignal do
   Use this to collect multiple data points that will be merged into a
   graph.
   """
-  @spec add_distribution_value(String.t, float | integer) :: :ok
-  def add_distribution_value(key, value) when is_integer(value) do
-    add_distribution_value(key, value + 0.0)
+  @spec add_distribution_value(String.t, float | integer, Map) :: :ok
+  def add_distribution_value(key, value, tags \\ %{})
+  def add_distribution_value(key, value, tags) when is_integer(value) do
+    add_distribution_value(key, value + 0.0, tags)
   end
-  def add_distribution_value(key, value) when is_float(value) do
-    Appsignal.Nif.add_distribution_value(key, value)
+  def add_distribution_value(key, value, %{} = tags) when is_float(value) do
+    encoded_tags = Appsignal.Utils.DataEncoder.encode(tags)
+    :ok = Appsignal.Nif.add_distribution_value(key, value, encoded_tags)
   end
 
   @doc """

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -90,11 +90,13 @@ defmodule Appsignal do
   @doc """
   Set a gauge for a measurement of some metric.
   """
-  @spec set_gauge(String.t, float | integer, Map) :: :ok
+  @spec set_gauge(String.t(), float | integer, map) :: :ok
   def set_gauge(key, value, tags \\ %{})
+
   def set_gauge(key, value, tags) when is_integer(value) do
     set_gauge(key, value + 0.0, tags)
   end
+
   def set_gauge(key, value, %{} = tags) when is_float(value) do
     encoded_tags = Appsignal.Utils.DataEncoder.encode(tags)
     :ok = Appsignal.Nif.set_gauge(key, value, encoded_tags)
@@ -103,7 +105,7 @@ defmodule Appsignal do
   @doc """
   Increment a counter of some metric.
   """
-  @spec increment_counter(String.t, integer, Map) :: :ok
+  @spec increment_counter(String.t(), integer, map) :: :ok
   def increment_counter(key, count \\ 1, %{} = tags \\ %{}) when is_integer(count) do
     encoded_tags = Appsignal.Utils.DataEncoder.encode(tags)
     :ok = Appsignal.Nif.increment_counter(key, count, encoded_tags)
@@ -115,11 +117,13 @@ defmodule Appsignal do
   Use this to collect multiple data points that will be merged into a
   graph.
   """
-  @spec add_distribution_value(String.t, float | integer, Map) :: :ok
+  @spec add_distribution_value(String.t(), float | integer, map) :: :ok
   def add_distribution_value(key, value, tags \\ %{})
+
   def add_distribution_value(key, value, tags) when is_integer(value) do
     add_distribution_value(key, value + 0.0, tags)
   end
+
   def add_distribution_value(key, value, %{} = tags) when is_float(value) do
     encoded_tags = Appsignal.Utils.DataEncoder.encode(tags)
     :ok = Appsignal.Nif.add_distribution_value(key, value, encoded_tags)

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -123,16 +123,16 @@ defmodule Appsignal.Nif do
     _complete(transaction_resource)
   end
 
-  def set_gauge(key, value) do
-    _set_gauge(key, value)
+  def set_gauge(key, value, tags) do
+    _set_gauge(key, value, tags)
   end
 
-  def increment_counter(key, count) do
-    _increment_counter(key, count)
+  def increment_counter(key, count, tags) do
+    _increment_counter(key, count, tags)
   end
 
-  def add_distribution_value(key, value) do
-    _add_distribution_value(key, value)
+  def add_distribution_value(key, value, tags) do
+    _add_distribution_value(key, value, tags)
   end
 
   def data_map_new do
@@ -271,15 +271,15 @@ defmodule Appsignal.Nif do
     :ok
   end
 
-  def _set_gauge(_key, _value) do
+  def _set_gauge(_key, _value, _tags) do
     :ok
   end
 
-  def _increment_counter(_key, _count) do
+  def _increment_counter(_key, _count, _tags) do
     :ok
   end
 
-  def _add_distribution_value(_key, _value) do
+  def _add_distribution_value(_key, _value, _tags) do
     :ok
   end
 

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -6,16 +6,21 @@ defmodule AppsignalTest do
   test "set gauge" do
     Appsignal.set_gauge("key", 10.0)
     Appsignal.set_gauge("key", 10)
+    Appsignal.set_gauge("key", 10.0, %{:a => "b"})
+    Appsignal.set_gauge("key", 10.0, %{:a => "b"})
   end
 
   test "increment counter" do
     Appsignal.increment_counter("counter")
     Appsignal.increment_counter("counter", 5)
+    Appsignal.increment_counter("counter", 5, %{:a => "b"})
   end
 
   test "add distribution value" do
     Appsignal.add_distribution_value("dist_key", 10.0)
     Appsignal.add_distribution_value("dist_key", 10)
+    Appsignal.add_distribution_value("dist_key", 10.0, %{:a => "b"})
+    Appsignal.add_distribution_value("dist_key", 10, %{:a => "b"})
   end
 
   describe "plug?/0" do

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -7,7 +7,7 @@ defmodule AppsignalTest do
     Appsignal.set_gauge("key", 10.0)
     Appsignal.set_gauge("key", 10)
     Appsignal.set_gauge("key", 10.0, %{:a => "b"})
-    Appsignal.set_gauge("key", 10.0, %{:a => "b"})
+    Appsignal.set_gauge("key", 10, %{:a => "b"})
   end
 
   test "increment counter" do


### PR DESCRIPTION
Add 3rd argument to metric functions to accept tags.

* add tags to `set_gauge`
* add tags to `increment_counter`
* add tags to `add_distribution_value`

