### PR TITLE
Hard-remove transactions from the Registry

### DIFF
--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -427,24 +427,13 @@ defmodule Appsignal.Transaction do
   defp to_s(value) when is_integer(value), do: Integer.to_string(value)
   defp to_s(value) when is_binary(value), do: value
 
-
   @doc """
   Return the transaction for the given process
 
   Creates a new one when not found. Can also return `nil`; in that
   case, we should not continue submitting the transaction.
   """
-  def lookup_or_create_transaction(origin \\ nil, namespace \\ :background_job) do
-    origin = origin || self()
-    case TransactionRegistry.lookup(origin, true) do
-      :removed ->
-        # transaction existed but has already been submitted, on the timer to be removed
-        nil
-      nil ->
-        # could not find a linked transaction; start new transaction
-        start("_" <> generate_id(), namespace)
-      t ->
-        t
-    end
+  def lookup_or_create_transaction(origin \\ self(), namespace \\ :background_job) do
+    TransactionRegistry.lookup(origin) || Transaction.start("_" <> generate_id(), namespace)
   end
 end

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -89,8 +89,6 @@ defmodule Appsignal.TransactionRegistry do
         [[_pid] | _] = pids ->
           for [pid] <- pids do
             true = :ets.delete(@table, pid)
-            true = :ets.insert(@table, {pid, :removed})
-            Process.send_after(self(), {:delete, pid}, 5000)
           end
           :ok
         [] ->

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -46,8 +46,22 @@ defmodule Appsignal.TransactionRegistry do
   @doc """
   Given a process ID, return its associated transaction.
   """
+  @spec lookup(pid) :: Transaction.t | nil
+  def lookup(pid) do
+    case registry_alive?() && :ets.lookup(@table, pid) do
+      [{^pid, %Transaction{} = transaction}] -> transaction
+      false ->
+        Logger.debug("AppSignal was not started, skipping transaction lookup.")
+        nil
+      _ -> nil
+    end
+  end
+
   @spec lookup(pid, boolean) :: Transaction.t | nil | :removed
-  def lookup(pid, return_removed \\ false) do
+  @doc false
+  def lookup(pid, return_removed) do
+    IO.warn "Appsignal.TransactionRegistry.lookup/2 is deprecated. Use Appsignal.TransactionRegistry.lookup/1 instead"
+
     case registry_alive?() && :ets.lookup(@table, pid) do
       [{^pid, :removed}] ->
         case return_removed do

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -27,9 +27,6 @@ defmodule Appsignal.Transaction.RegistryTest do
     :ok = TransactionRegistry.remove_transaction(transaction)
 
     assert nil == TransactionRegistry.lookup(pid)
-
-    # Lookup removed status
-    assert :removed == TransactionRegistry.lookup(pid, true)
   end
 
   test "delete entry by transaction" do


### PR DESCRIPTION
Back when we handled `:error` reports from `:error_logger` (which was removed in #193), we had to explicitly make sure errors weren't being sent twice by replacing transactions in ets with a `:removed` atom. This was to make sure an error from the then-Phoenix Plug, wouldn't be sent again after being caught by Erlang's error logger.

Because we only handle crashes now, that's no longer the case, so we can immediately hard-remove transactions when they're completed. We do, however, keep a timeout when a process registered in ets goes DOWN, to wait for an `error_report`, to come in before removing the transaction.