### PR TITLE
Demonitor processes when the transaction completes

### DIFF
--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -48,14 +48,21 @@ defmodule Appsignal.TransactionRegistry do
   @doc """
   Given a process ID, return its associated transaction.
   """
-  @spec lookup(pid) :: Transaction.t | nil
+  @spec lookup(pid) :: Transaction.t() | nil
   def lookup(pid) do
     case registry_alive?() && :ets.lookup(@table, pid) do
-      [{^pid, %Transaction{} = transaction, _}] -> transaction
+      [{^pid, %Transaction{} = transaction, _}] ->
+        transaction
+
+      [{^pid, %Transaction{} = transaction}] ->
+        transaction
+
       false ->
         Logger.debug("AppSignal was not started, skipping transaction lookup.")
         nil
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
@@ -72,6 +79,9 @@ defmodule Appsignal.TransactionRegistry do
         end
 
       [{^pid, transaction, _}] ->
+        transaction
+
+      [{^pid, transaction}] ->
         transaction
 
       false ->

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -107,8 +107,8 @@ defmodule Appsignal.TransactionRegistry do
   def handle_call({:remove, transaction}, _from, state) do
     reply =
       case pids_and_monitor_references(transaction) do
-        [[_pid] | _] = pids ->
-          for [pid] <- pids do
+        [[_pid, _reference] | _] = pids_and_refs ->
+          for [pid, _reference] <- pids_and_refs do
             true = :ets.delete(@table, pid)
           end
 
@@ -147,6 +147,6 @@ defmodule Appsignal.TransactionRegistry do
   end
 
   defp pids_and_monitor_references(transaction) do
-    :ets.match(@table, {:'$1', transaction, :'_'})
+    :ets.match(@table, {:'$1', transaction, :'$2'})
   end
 end

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -36,7 +36,7 @@ defmodule Appsignal.TransactionRegistry do
     pid = self()
     if registry_alive?() do
       true = :ets.insert(@table, {pid, transaction})
-      GenServer.cast(__MODULE__, {:monitor, pid})
+      GenServer.call(__MODULE__, {:monitor, pid})
     else
       Logger.debug("AppSignal was not started, skipping transaction registration.")
       nil
@@ -111,9 +111,9 @@ defmodule Appsignal.TransactionRegistry do
     {:reply, reply, state}
   end
 
-  def handle_cast({:monitor, pid}, state) do
-    Process.monitor(pid)
-    {:noreply, state}
+  def handle_call({:monitor, pid}, state) do
+    monitor_reference = Process.monitor(pid)
+    {:reply, monitor_reference, state}
   end
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -106,7 +106,7 @@ defmodule Appsignal.TransactionRegistry do
 
   def handle_call({:remove, transaction}, _from, state) do
     reply =
-      case :ets.match(@table, {:"$1", transaction, :_}) do
+      case pids_and_monitor_references(transaction) do
         [[_pid] | _] = pids ->
           for [pid] <- pids do
             true = :ets.delete(@table, pid)
@@ -144,5 +144,9 @@ defmodule Appsignal.TransactionRegistry do
   defp registry_alive? do
     pid = Process.whereis(__MODULE__)
     !is_nil(pid) && Process.alive?(pid)
+  end
+
+  defp pids_and_monitor_references(transaction) do
+    :ets.match(@table, {:'$1', transaction, :'_'})
   end
 end

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -41,6 +41,19 @@ defmodule Appsignal.Transaction.RegistryTest do
     end
   end
 
+  describe "lookup/1, with an existing transaction without a monitor" do
+    setup do
+      transaction = %Transaction{id: Transaction.generate_id()}
+      true = :ets.insert(:'$appsignal_transaction_registry', {self(), transaction})
+
+      [transaction: transaction]
+    end
+
+    test "finds an existing transaction by pid", %{transaction: transaction} do
+      assert TransactionRegistry.lookup(self()) == transaction
+    end
+  end
+
   describe "register/1, when the registry is not running" do
     setup :terminate_registry
 

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -42,12 +42,7 @@ defmodule Appsignal.Transaction.RegistryTest do
   end
 
   describe "lookup/1, with an existing transaction without a monitor" do
-    setup do
-      transaction = %Transaction{id: Transaction.generate_id()}
-      true = :ets.insert(:'$appsignal_transaction_registry', {self(), transaction})
-
-      [transaction: transaction]
-    end
+    setup :register_transaction_without_monitor
 
     test "finds an existing transaction by pid", %{transaction: transaction} do
       assert TransactionRegistry.lookup(self()) == transaction
@@ -70,9 +65,34 @@ defmodule Appsignal.Transaction.RegistryTest do
     end
   end
 
+  describe "remove_transaction/1, with an existing transaction" do
+    setup :register_transaction
+
+    test "removes the transaction from the registry", %{transaction: transaction} do
+      assert TransactionRegistry.remove_transaction(transaction) == :ok
+      assert TransactionRegistry.lookup(self()) == nil
+    end
+  end
+
+  describe "remove_transaction/1, with an existing transaction without a monitor" do
+    setup :register_transaction_without_monitor
+
+    test "removes the transaction from the registry", %{transaction: transaction} do
+      assert TransactionRegistry.remove_transaction(transaction) == :ok
+      assert TransactionRegistry.lookup(self()) == nil
+    end
+  end
+
   defp register_transaction(_) do
     transaction = %Transaction{id: Transaction.generate_id()}
     TransactionRegistry.register(transaction)
+
+    [transaction: transaction]
+  end
+
+  def register_transaction_without_monitor(_) do
+    transaction = %Transaction{id: Transaction.generate_id()}
+    true = :ets.insert(:'$appsignal_transaction_registry', {self(), transaction})
 
     [transaction: transaction]
   end

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -3,15 +3,6 @@ defmodule Appsignal.Transaction.RegistryTest do
 
   alias Appsignal.{Transaction, TransactionRegistry}
 
-  test "transaction registration" do
-    transaction = %Transaction{}
-
-    TransactionRegistry.register(transaction)
-
-    assert transaction == TransactionRegistry.lookup(self())
-  end
-
-
   test "lookup/1 returns nil after process has ended" do
     transaction = %Transaction{id: Transaction.generate_id()}
 
@@ -36,22 +27,49 @@ defmodule Appsignal.Transaction.RegistryTest do
     {:error, :not_found} = TransactionRegistry.remove_transaction(transaction)
   end
 
-  describe "when registry is not running" do
-    setup do
-      :ok = Supervisor.terminate_child(Appsignal.Supervisor, TransactionRegistry)
-      on_exit fn ->
-        {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, TransactionRegistry)
-      end
-    end
+  describe "register/1 and lookup/1, with an existing transaction" do
+    setup :register_transaction
 
-    test "register/1 returns nil" do
-      transaction = %Transaction{id: Transaction.generate_id()}
-      assert nil == TransactionRegistry.register(transaction)
+    test "finds an existing transaction by pid", %{transaction: transaction} do
+      assert TransactionRegistry.lookup(self()) == transaction
     end
+  end
 
-    test "lookup/1 returns nil" do
-      assert nil == TransactionRegistry.lookup(self())
+  describe "lookup/1, without an existing transaction" do
+    test "does not find an existing transaction by pid" do
+      assert TransactionRegistry.lookup(self()) == nil
     end
+  end
+
+  describe "register/1, when the registry is not running" do
+    setup :terminate_registry
+
+    test "returns nil" do
+      assert nil == TransactionRegistry.register(%Transaction{})
+    end
+  end
+
+  describe "lookup/1, when the registry is not running" do
+    setup [:register_transaction, :terminate_registry]
+
+    test "does not find an existing transaction by pid" do
+      assert TransactionRegistry.lookup(self()) == nil
+    end
+  end
+
+  defp register_transaction(_) do
+    transaction = %Transaction{id: Transaction.generate_id()}
+    TransactionRegistry.register(transaction)
+
+    [transaction: transaction]
+  end
+
+  defp terminate_registry(_) do
+    :ok = Supervisor.terminate_child(Appsignal.Supervisor, TransactionRegistry)
+
+    on_exit(fn ->
+      {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, TransactionRegistry)
+    end)
   end
 
   defp wait_for_process_to_exit(pid) do


### PR DESCRIPTION
Closes #299.

*Note*: this is based on #332. 

Currently, we wait for process monitors to be removed automatically when the monitored process goes DOWN. This can be a problem for long-running processes, as the monitors are not removed from the registry.

This patch adds the monitor reference to the registry and makes sure the process gets demonitored when the transaction is completed.
