### PR TITLE
Explicit header whitelist in configuration

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -21,8 +21,8 @@ defmodule Appsignal.Config do
 
   @suggested_request_headers [
     ~w(accept accept-charset accept-encoding accept-language cache-control),
-    ~w(connection content-length path-info range referer request-method),
-    ~w(request-uri server-name server-port server-protocol user-agent)
+    ~w(connection content-length path-info range request-method),
+    ~w(request-uri server-name server-port server-protocol)
   ]
 
   @doc """

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -21,8 +21,8 @@ defmodule Appsignal.Config do
 
   @suggested_request_headers [
     ~w(accept accept-charset accept-encoding accept-language cache-control),
-    ~w(connection content-length path-info range request-method),
-    ~w(request-uri server-name server-port server-protocol)
+    ~w(connection content-length path-info range request-method request-uri),
+    ~w(server-name server-port server-protocol)
   ]
 
   @doc """

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -19,6 +19,12 @@ defmodule Appsignal.Config do
     log: "file"
   }
 
+  @suggested_request_headers [
+    ~w(accept accept-charset accept-encoding accept-language cache-control),
+    ~w(connection content-length path-info range referer request-method),
+    ~w(request-uri server-name server-port server-protocol user-agent)
+  ]
+
   @doc """
   Initializes the AppSignal config. Looks at the config default, the
   Elixir-provided configuration and the various `APPSIGNAL_*`
@@ -36,12 +42,31 @@ defmodule Appsignal.Config do
       |> Map.merge(app_config)
       |> Map.merge(env_config)
 
+
     # Config is valid when we have a push api key
     config =
       config
       |> Map.put(:valid, !empty?(config[:push_api_key]))
 
     Application.put_env(:appsignal, :config, config)
+
+    if config[:valid] && !config[:request_headers] && !test?() do
+      require Logger
+
+      Logger.warn("""
+      The :request_headers config was not set in the AppSignal configuration, falling back to the default list. Please explicitly list response headers to send to AppSignal in config/appsignal.exs:
+
+        request_headers: ~w(
+      #{multiline_suggested_request_headers()}
+        )
+
+      Or set the APPSIGNAL_REQUEST_HEADERS environment variable:
+
+        $ export APPSIGNAL_REQUEST_HEADERS="#{single_line_suggested_request_headers()}"
+
+      Please check https://github.com/appsignal/appsignal-elixir/pull/336 for more information on this change.
+      """)
+    end
 
     case config[:valid] do
       true ->
@@ -230,6 +255,24 @@ defmodule Appsignal.Config do
       _ -> false
     end)
     |> Enum.into(%{})
+  end
+
+  def single_line_suggested_request_headers do
+    @suggested_request_headers
+    |> List.flatten
+    |> Enum.join(",")
+  end
+
+  def multiline_suggested_request_headers do
+    Enum.map_join(@suggested_request_headers, "\n", fn(row) ->
+      "    #{Enum.join(row, " ")}"
+    end)
+  end
+
+  defp test? do
+    Mix.env
+    |> Atom.to_string()
+    |> String.starts_with?("test")
   end
 
   # When you use Appsignal.Config you get a handy config macro which

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -4,6 +4,13 @@ defmodule Mix.Tasks.Appsignal.Install do
 
   @demo Application.get_env(:appsignal, :appsignal_demo, Appsignal.Demo)
 
+  @request_headers [
+    ~w(accept accept-charset accept-encoding accept-language cache-control),
+    ~w(client-ip connection content-length path-info range referer remote-addr),
+    ~w(remote-host request-method request-uri server-name server-port),
+    ~w(server-protocol user-agent x-forwarded-for x-real-ip)
+  ]
+
   def run([]) do
     header()
     IO.puts "We're missing an AppSignal Push API key and cannot continue."
@@ -152,16 +159,19 @@ defmodule Mix.Tasks.Appsignal.Install do
     end
   end
 
+  defp multiline_request_headers do
+    Enum.map_join(@request_headers, "\n", fn(row) ->
+      "    #{Enum.join(row, " ")}"
+    end)
+  end
+
   # Contents for the config/appsignal.exs file.
   defp appsignal_config_file_contents(config) do
     options = [
       ~s(  name: "#{config[:name]}",),
       ~s(  push_api_key: "#{config[:push_api_key]}",),
       ~s{  request_headers: ~w(},
-      ~s{    accept accept-charset accept-encoding accept-language cache-control},
-      ~s{    client-ip connection content-length path-info range referer remote-addr},
-      ~s{    remote-host request-method request-uri server-name server-port},
-      ~s{    server-protocol user-agent x-forwarded-for x-real-ip},
+      multiline_request_headers(),
       ~s{  ),},
       ~s(  env: Mix.env)
     ]

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -104,6 +104,7 @@ defmodule Mix.Tasks.Appsignal.Install do
     IO.puts ~s(  export APPSIGNAL_APP_NAME="#{config[:name]}")
     IO.puts ~s(  export APPSIGNAL_APP_ENV="production")
     IO.puts ~s(  export APPSIGNAL_PUSH_API_KEY="#{config[:push_api_key]}")
+    IO.puts ~s(  export APPSIGNAL_REQUEST_HEADERS="#{single_line_request_headers()}")
   end
 
   defp write_config_file(config) do
@@ -157,6 +158,12 @@ defmodule Mix.Tasks.Appsignal.Install do
         IO.puts "Failure! #{reason}"
         exit :shutdown
     end
+  end
+
+  defp single_line_request_headers do
+    @request_headers
+    |> List.flatten
+    |> Enum.join(",")
   end
 
   defp multiline_request_headers do

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -6,9 +6,8 @@ defmodule Mix.Tasks.Appsignal.Install do
 
   @request_headers [
     ~w(accept accept-charset accept-encoding accept-language cache-control),
-    ~w(client-ip connection content-length path-info range referer remote-addr),
-    ~w(remote-host request-method request-uri server-name server-port),
-    ~w(server-protocol user-agent x-forwarded-for x-real-ip)
+    ~w(connection content-length path-info range referer request-method),
+    ~w(request-uri server-name server-port server-protocol user-agent)
   ]
 
   def run([]) do

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Appsignal.Install do
   end
 
   def run([push_api_key]) do
-    config = %{active: true, push_api_key: push_api_key}
+    config = %{active: true, push_api_key: push_api_key, request_headers: []}
     Application.put_env(:appsignal, :config, config)
     Config.initialize
 

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -155,19 +155,25 @@ defmodule Mix.Tasks.Appsignal.Install do
   # Contents for the config/appsignal.exs file.
   defp appsignal_config_file_contents(config) do
     options = [
-      ~s(  name: "#{config[:name]}"),
-      ~s(  push_api_key: "#{config[:push_api_key]}"),
+      ~s(  name: "#{config[:name]}",),
+      ~s(  push_api_key: "#{config[:push_api_key]}",),
+      ~s{  request_headers: ~w(},
+      ~s{    accept accept-charset accept-encoding accept-language cache-control},
+      ~s{    client-ip connection content-length path-info range referer remote-addr},
+      ~s{    remote-host request-method request-uri server-name server-port},
+      ~s{    server-protocol user-agent x-forwarded-for x-real-ip},
+      ~s{  ),},
       ~s(  env: Mix.env)
     ]
 
     options_with_active = case has_environment_configuration_files?() do
-      false -> [~s(  active: true)] ++ options
+      false -> [~s(  active: true,)] ++ options
       true -> options
     end
 
     "use Mix.Config\n\n" <>
       "config :appsignal, :config,\n" <>
-      Enum.join(options_with_active, ",\n") <>
+      Enum.join(options_with_active, "\n") <>
       "\n"
   end
 

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -155,7 +155,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? output, ~s(APPSIGNAL_APP_NAME="AppSignal test suite app")
       assert String.contains? output, ~s(APPSIGNAL_APP_ENV="production")
       assert String.contains? output, ~s(APPSIGNAL_PUSH_API_KEY="my_push_api_key")
-      assert String.contains? output, ~s(APPSIGNAL_REQUEST_HEADERS="accept,accept-charset,accept-encoding,accept-language,cache-control,connection,content-length,path-info,range,referer,request-method,request-uri,server-name,server-port,server-protocol,user-agent")
+      assert String.contains? output, ~s(APPSIGNAL_REQUEST_HEADERS="accept,accept-charset,accept-encoding,accept-language,cache-control,connection,content-length,path-info,range,request-method,request-uri,server-name,server-port,server-protocol")
     end
 
     @tag :file_config
@@ -175,8 +175,8 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(  push_api_key: "my_push_api_key",\n) <>
         ~s{  request_headers: ~w(\n} <>
         ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
-        ~s{    connection content-length path-info range referer request-method\n} <>
-        ~s{    request-uri server-name server-port server-protocol user-agent\n} <>
+        ~s{    connection content-length path-info range request-method\n} <>
+        ~s{    request-uri server-name server-port server-protocol\n} <>
         ~s{  ),\n} <>
         ~s(  env: Mix.env\n)
 
@@ -216,8 +216,8 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(  push_api_key: "my_push_api_key",\n) <>
         ~s{  request_headers: ~w(\n} <>
         ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
-        ~s{    connection content-length path-info range referer request-method\n} <>
-        ~s{    request-uri server-name server-port server-protocol user-agent\n} <>
+        ~s{    connection content-length path-info range request-method\n} <>
+        ~s{    request-uri server-name server-port server-protocol\n} <>
         ~s{  ),\n} <>
         ~s(  env: Mix.env\n)
 

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -155,6 +155,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? output, ~s(APPSIGNAL_APP_NAME="AppSignal test suite app")
       assert String.contains? output, ~s(APPSIGNAL_APP_ENV="production")
       assert String.contains? output, ~s(APPSIGNAL_PUSH_API_KEY="my_push_api_key")
+      assert String.contains? output, ~s(APPSIGNAL_REQUEST_HEADERS="accept,accept-charset,accept-encoding,accept-language,cache-control,client-ip,connection,content-length,path-info,range,referer,remote-addr,remote-host,request-method,request-uri,server-name,server-port,server-protocol,user-agent,x-forwarded-for,x-real-ip")
     end
 
     @tag :file_config

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -175,8 +175,8 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(  push_api_key: "my_push_api_key",\n) <>
         ~s{  request_headers: ~w(\n} <>
         ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
-        ~s{    connection content-length path-info range request-method\n} <>
-        ~s{    request-uri server-name server-port server-protocol\n} <>
+        ~s{    connection content-length path-info range request-method request-uri\n} <>
+        ~s{    server-name server-port server-protocol\n} <>
         ~s{  ),\n} <>
         ~s(  env: Mix.env\n)
 
@@ -216,8 +216,8 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(  push_api_key: "my_push_api_key",\n) <>
         ~s{  request_headers: ~w(\n} <>
         ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
-        ~s{    connection content-length path-info range request-method\n} <>
-        ~s{    request-uri server-name server-port server-protocol\n} <>
+        ~s{    connection content-length path-info range request-method request-uri\n} <>
+        ~s{    server-name server-port server-protocol\n} <>
         ~s{  ),\n} <>
         ~s(  env: Mix.env\n)
 

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -172,6 +172,12 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(config :appsignal, :config,\n) <>
         ~s(  name: "AppSignal test suite app",\n) <>
         ~s(  push_api_key: "my_push_api_key",\n) <>
+        ~s{  request_headers: ~w(\n} <>
+        ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
+        ~s{    client-ip connection content-length path-info range referer remote-addr\n} <>
+        ~s{    remote-host request-method request-uri server-name server-port\n} <>
+        ~s{    server-protocol user-agent x-forwarded-for x-real-ip\n} <>
+        ~s{  ),\n} <>
         ~s(  env: Mix.env\n)
 
       # Imports AppSignal config in config.exs file
@@ -208,6 +214,12 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(  active: true,\n) <>
         ~s(  name: "AppSignal test suite app",\n) <>
         ~s(  push_api_key: "my_push_api_key",\n) <>
+        ~s{  request_headers: ~w(\n} <>
+        ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
+        ~s{    client-ip connection content-length path-info range referer remote-addr\n} <>
+        ~s{    remote-host request-method request-uri server-name server-port\n} <>
+        ~s{    server-protocol user-agent x-forwarded-for x-real-ip\n} <>
+        ~s{  ),\n} <>
         ~s(  env: Mix.env\n)
 
       # Imports AppSignal config in config.exs file

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -155,7 +155,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? output, ~s(APPSIGNAL_APP_NAME="AppSignal test suite app")
       assert String.contains? output, ~s(APPSIGNAL_APP_ENV="production")
       assert String.contains? output, ~s(APPSIGNAL_PUSH_API_KEY="my_push_api_key")
-      assert String.contains? output, ~s(APPSIGNAL_REQUEST_HEADERS="accept,accept-charset,accept-encoding,accept-language,cache-control,client-ip,connection,content-length,path-info,range,referer,remote-addr,remote-host,request-method,request-uri,server-name,server-port,server-protocol,user-agent,x-forwarded-for,x-real-ip")
+      assert String.contains? output, ~s(APPSIGNAL_REQUEST_HEADERS="accept,accept-charset,accept-encoding,accept-language,cache-control,connection,content-length,path-info,range,referer,request-method,request-uri,server-name,server-port,server-protocol,user-agent")
     end
 
     @tag :file_config
@@ -175,9 +175,8 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(  push_api_key: "my_push_api_key",\n) <>
         ~s{  request_headers: ~w(\n} <>
         ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
-        ~s{    client-ip connection content-length path-info range referer remote-addr\n} <>
-        ~s{    remote-host request-method request-uri server-name server-port\n} <>
-        ~s{    server-protocol user-agent x-forwarded-for x-real-ip\n} <>
+        ~s{    connection content-length path-info range referer request-method\n} <>
+        ~s{    request-uri server-name server-port server-protocol user-agent\n} <>
         ~s{  ),\n} <>
         ~s(  env: Mix.env\n)
 
@@ -217,9 +216,8 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(  push_api_key: "my_push_api_key",\n) <>
         ~s{  request_headers: ~w(\n} <>
         ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
-        ~s{    client-ip connection content-length path-info range referer remote-addr\n} <>
-        ~s{    remote-host request-method request-uri server-name server-port\n} <>
-        ~s{    server-protocol user-agent x-forwarded-for x-real-ip\n} <>
+        ~s{    connection content-length path-info range referer request-method\n} <>
+        ~s{    request-uri server-name server-port server-protocol user-agent\n} <>
         ~s{  ),\n} <>
         ~s(  env: Mix.env\n)
 


### PR DESCRIPTION
Adds an explicit header whitelist to the configuration file or environment variables created/suggested by the installer. Closes #317.

## TODO
- [x] Add a warning if no request headers are configured (https://github.com/appsignal/appsignal-elixir/pull/327#discussion_r180010430 )

*Note*: This is a work in progress until we've decided on the final list of default headers.