### PR TITLE
Remove filter_parameters config for extension

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -190,7 +190,6 @@ defmodule Appsignal.Config do
     System.put_env("_APPSIGNAL_DNS_SERVERS", config[:dns_servers] |> Enum.join(","))
     System.put_env("_APPSIGNAL_ENABLE_HOST_METRICS", to_string(config[:enable_host_metrics]))
     System.put_env("_APPSIGNAL_ENVIRONMENT", to_string(config[:env]))
-    System.put_env("_APPSIGNAL_FILTER_PARAMETERS", config[:filter_parameters] |> Enum.join(","))
     System.put_env("_APPSIGNAL_HOSTNAME", config[:hostname])
     System.put_env("_APPSIGNAL_HTTP_PROXY", to_string(config[:http_proxy]))
     System.put_env("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -450,7 +450,6 @@ defmodule Appsignal.ConfigTest do
       write_to_environment()
       assert System.get_env("_APPSIGNAL_APP_NAME") == ""
       assert System.get_env("_APPSIGNAL_CA_FILE_PATH") == ""
-      assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == ""
       assert System.get_env("_APPSIGNAL_HTTP_PROXY") == ""
       assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == ""
       assert System.get_env("_APPSIGNAL_IGNORE_ERRORS") == ""
@@ -484,7 +483,6 @@ defmodule Appsignal.ConfigTest do
         enable_host_metrics: false,
         endpoint: "https://push.staging.lol",
         env: :prod,
-        filter_parameters: ~w(password secret),
         push_api_key: "00000000-0000-0000-0000-000000000000",
         hostname: "My hostname",
         http_proxy: "http://10.10.10.10:8888",
@@ -512,7 +510,6 @@ defmodule Appsignal.ConfigTest do
         assert System.get_env("_APPSIGNAL_DNS_SERVERS") == "8.8.8.8,8.8.4.4"
         assert System.get_env("_APPSIGNAL_ENABLE_HOST_METRICS") == "false"
         assert System.get_env("_APPSIGNAL_ENVIRONMENT") == "prod"
-        assert System.get_env("_APPSIGNAL_FILTER_PARAMETERS") == "password,secret"
         assert System.get_env("_APPSIGNAL_HOSTNAME") == "My hostname"
         assert System.get_env("_APPSIGNAL_HTTP_PROXY") == "http://10.10.10.10:8888"
         assert System.get_env("_APPSIGNAL_IGNORE_ACTIONS") == "ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"


### PR DESCRIPTION
It is unused in the extension as it's filtered in the Elixir package
already. The extension ignores this config option, so let's remove it.