### PR TITLE
Remove default hostname

### DIFF
--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "f781aa1"
+  def version, do: "e8718b8"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "2d881b17e6400f6298acd1e565e714c873fd6e489cfcf19892c71c9fade06381",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "4e8e62f97286783a3a78d5de5939d2c77e965fa2b408a0857680254629f47b82",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "2d881b17e6400f6298acd1e565e714c873fd6e489cfcf19892c71c9fade06381",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "4e8e62f97286783a3a78d5de5939d2c77e965fa2b408a0857680254629f47b82",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "7e9547965dcb31b34fcd52e9cfc248d1f314feb74e1191b8e5061aadd6da14d1",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "899754322392f754bcae57e9fbc8daf3852115b8f08c2617a485a6a747aa2dac",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "7e9547965dcb31b34fcd52e9cfc248d1f314feb74e1191b8e5061aadd6da14d1",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "899754322392f754bcae57e9fbc8daf3852115b8f08c2617a485a6a747aa2dac",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "cbfb6b1aaa2a6894b3bcc35f5879cfd232b9ccafe0bc4a95762d4155bf8a65a7",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "777626cedb283037379e00dcabc9d9789bc6e6c53609767a3034120c1874ded1",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "cbfb6b1aaa2a6894b3bcc35f5879cfd232b9ccafe0bc4a95762d4155bf8a65a7",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "777626cedb283037379e00dcabc9d9789bc6e6c53609767a3034120c1874ded1",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "e994fff885d8fcae6aeb7e0e41c299b2d5d4a7a724cc7753db5225d54dc8dad9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "729a340523ddfa0a14f2f24eeee723d4f33116b2dcb384875b603e991bddf26b",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "64b357d4af2be84010d35cc2cfa843350a6bb788d7eacf48150b0c01bb5e3dff",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "1634d9f1dd16ea8ed9603cd44071e6b136bf505f953507bcebb9385b5207a00b",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "a3cb12c629f7b52dfab9ec02f755a0512cb104826123e1937e05711fed014f3f",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "06fdaafcd0754efa64a399d91af55186d1038c1dec873e9d6e10a5277faa44ec",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "a3cb12c629f7b52dfab9ec02f755a0512cb104826123e1937e05711fed014f3f",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f781aa1/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "06fdaafcd0754efa64a399d91af55186d1038c1dec873e9d6e10a5277faa44ec",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e8718b8/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -1,6 +1,4 @@
 defmodule Appsignal.Config do
-  @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
-
   @default_config %{
     active: false,
     debug: false,
@@ -111,7 +109,7 @@ defmodule Appsignal.Config do
   end
 
   defp load_from_system() do
-    config = %{hostname: @system.hostname_with_domain}
+    config = %{}
 
     # Make AppSignal active by default if the APPSIGNAL_PUSH_API_KEY
     # environment variable is present.
@@ -190,7 +188,7 @@ defmodule Appsignal.Config do
     System.put_env("_APPSIGNAL_DNS_SERVERS", config[:dns_servers] |> Enum.join(","))
     System.put_env("_APPSIGNAL_ENABLE_HOST_METRICS", to_string(config[:enable_host_metrics]))
     System.put_env("_APPSIGNAL_ENVIRONMENT", to_string(config[:env]))
-    System.put_env("_APPSIGNAL_HOSTNAME", config[:hostname])
+    System.put_env("_APPSIGNAL_HOSTNAME", to_string(config[:hostname]))
     System.put_env("_APPSIGNAL_HTTP_PROXY", to_string(config[:http_proxy]))
     System.put_env("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
     System.put_env("_APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))

--- a/lib/appsignal/system.ex
+++ b/lib/appsignal/system.ex
@@ -1,5 +1,4 @@
 defmodule Appsignal.SystemBehaviour do
-  @callback hostname_with_domain() :: String.t | nil
   @callback root?() :: boolean()
   @callback heroku?() :: boolean()
   @callback uid() :: integer | nil
@@ -7,19 +6,6 @@ end
 
 defmodule Appsignal.System do
   @behaviour Appsignal.SystemBehaviour
-
-  @doc """
-  Get the full host name, including the domain.
-  """
-  def hostname_with_domain do
-    case :inet_udp.open(0) do
-      {:ok, port} ->
-        {:ok, hostname} = :inet.gethostname(port)
-        :inet_udp.close(port)
-        to_string(hostname)
-      _ -> nil
-    end
-  end
 
   def heroku? do
     System.get_env("DYNO") != nil

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -589,8 +589,7 @@ defmodule Appsignal.ConfigTest do
       skip_session_data: false,
       files_world_accessible: true,
       valid: false,
-      log: "file",
-      hostname: "Alices-MBP.example.com"
+      log: "file"
     }
   end
 

--- a/test/appsignal/diagnose/report_test.exs
+++ b/test/appsignal/diagnose/report_test.exs
@@ -15,7 +15,6 @@ defmodule Mix.Tasks.Appsignal.Diagnose.ReportTest do
       api_key: "foo",
       name: "AppSignal test suite app",
       environment: "production",
-      hostname: "foo",
       diagnose_endpoint: "http://localhost:#{diagnose_bypass.port}/diag"
     })
 

--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -46,7 +46,6 @@ defmodule Appsignal.ReleaseUpgradeTest do
       endpoint: "https://push.appsignal.com",
       env: :dev,
       filter_parameters: [],
-      hostname: "Alices-MBP.example.com",
       ignore_actions: [],
       ignore_errors: [],
       log: "file",

--- a/test/appsignal/system_test.exs
+++ b/test/appsignal/system_test.exs
@@ -1,26 +1,6 @@
 defmodule Appsignal.SystemTest do
   use ExUnit.Case, async: true
-  import Mock
   import AppsignalTest.Utils
-
-  test "hostname_with_domain" do
-    with_mocks([
-      {:inet_udp, [:unstick], [open: fn(0) -> {:ok, "PORT"} end]},
-      {:inet, [:unstick], [gethostname: fn("PORT") -> {:ok, "Alices-MBP.example.com"} end]},
-      {:inet_udp, [:unstick], [close: fn("PORT") -> :ok end]}
-    ]) do
-      assert "Alices-MBP.example.com" == Appsignal.System.hostname_with_domain()
-      assert called :inet_udp.close("PORT")
-    end
-  end
-
-  test "hostname_with_domain, when unable to upen a UDP socket" do
-    with_mocks([
-      {:inet_udp, [:unstick], [open: fn(0) -> {:error, :eacces} end]}
-    ]) do
-      assert nil == Appsignal.System.hostname_with_domain()
-    end
-  end
 
   describe "when not on Heroku" do
     test "returns false" do

--- a/test/support/fake_system.ex
+++ b/test/support/fake_system.ex
@@ -2,8 +2,6 @@ defmodule Appsignal.FakeSystem do
   @behaviour Appsignal.SystemBehaviour
   use TestAgent, %{uid: 999, heroku: false, root: false}
 
-  def hostname_with_domain, do: "Alices-MBP.example.com"
-
   def root?, do: get(__MODULE__, :root)
 
   def heroku?, do: get(__MODULE__, :heroku)


### PR DESCRIPTION
Instead we'll base determine this default as a fallback in the
extension. The integrations don't need to know about the default
hostname, also reduces the logic in the integrations.

The integrations will only set the hostname config option in the
environment `_APPSIGNAL_HOSTNAME` when it has been configured in the
app. If not, it will set an empty string, which is interpreted as an
empty value by the extension.

Depends on https://github.com/appsignal/appsignal-agent/pull/335

🚨  Needs an agent release before merging! 🚨 