### PR TITLE
Log with :info level instead of :warn when AppSignal is disabled

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -62,7 +62,7 @@ defmodule Appsignal do
 
   @doc false
   def initialize() do
-    case {Config.initialize(), Config.active?()} do
+    case {Config.initialize(), Config.configured_as_active?()} do
       {_, false} ->
         Logger.info("AppSignal disabled.")
 

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -56,7 +56,10 @@ defmodule Appsignal.Config do
   Returns whether the AppSignal agent is configured to start on application launch.
   """
   @spec active?() :: boolean
-  def active?, do: Application.fetch_env!(:appsignal, :config).active
+  def active? do
+    config = Application.fetch_env!(:appsignal, :config)
+    config.valid && config.active
+  end
 
   def request_headers do
     Application.fetch_env!(:appsignal, :config)[:request_headers]

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -56,10 +56,7 @@ defmodule Appsignal.Config do
   Returns whether the AppSignal agent is configured to start on application launch.
   """
   @spec active?() :: boolean
-  def active? do
-    config = Application.fetch_env!(:appsignal, :config)
-    config.valid && config.active
-  end
+  def active?, do: Application.fetch_env!(:appsignal, :config).active
 
   def request_headers do
     Application.fetch_env!(:appsignal, :config)[:request_headers]

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -53,7 +53,17 @@ defmodule Appsignal.Config do
   end
 
   @doc """
-  Returns whether the AppSignal agent is configured to start on application launch.
+  Returns whether the AppSignal agent is configured to start on application
+  launch.
+  """
+  @spec configured_as_active?() :: boolean
+  def configured_as_active? do
+    Application.fetch_env!(:appsignal, :config).active
+  end
+
+  @doc """
+  Returns true if the configuration is valid and the AppSignal agent is
+  configured to start on application launch.
   """
   @spec active?() :: boolean
   def active? do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -39,25 +39,12 @@ defmodule Appsignal.ConfigTest do
   end
 
   describe "active?" do
-    test "when active and valid" do
-      assert with_config(
-        %{active: true, valid: true},
-        &Config.active?/0
-      )
+    test "returns true when active" do
+      assert with_config(%{active: true}, &Config.active?/0)
     end
 
-    test "when active but not valid" do
-      refute with_config(
-        %{active: true, valid: false},
-        &Config.active?/0
-      )
-    end
-
-    test "when not active and not valid" do
-      refute with_config(
-        %{active: false, valid: true},
-        &Config.active?/0
-      )
+    test "returns false when not active" do
+      assert with_config(%{active: true}, &Config.active?/0)
     end
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -39,12 +39,25 @@ defmodule Appsignal.ConfigTest do
   end
 
   describe "active?" do
-    test "returns true when active" do
-      assert with_config(%{active: true}, &Config.active?/0)
+    test "when active and valid" do
+      assert with_config(
+        %{active: true, valid: true},
+        &Config.active?/0
+      )
     end
 
-    test "returns false when not active" do
-      assert with_config(%{active: true}, &Config.active?/0)
+    test "when active but not valid" do
+      refute with_config(
+        %{active: true, valid: false},
+        &Config.active?/0
+      )
+    end
+
+    test "when not active and not valid" do
+      refute with_config(
+        %{active: false, valid: true},
+        &Config.active?/0
+      )
     end
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -38,6 +38,23 @@ defmodule Appsignal.ConfigTest do
     assert default_configuration() == init_config()
   end
 
+  describe "configured_as_active?" do
+    test "when active" do
+      assert with_config(
+        %{active: true, valid: true},
+        &Config.configured_as_active?/0
+      )
+    end
+
+    test "when not active" do
+      refute with_config(
+        %{active: false, valid: true},
+        &Config.configured_as_active?/0
+      )
+    end
+  end
+
+
   describe "active?" do
     test "when active and valid" do
       assert with_config(


### PR DESCRIPTION
Closes #335. Thanks for reporting this, @axelson!

If AppSignal is not active, we'll :info-log the "AppSignal disabled"
line. This will show in a Phoenix app in development, but not in tests
(as the default :logger level for tests is :warn in Phoenix).

We'll only warn if the configuration is invalid, but AppSignal was set
to active (like when omitting the push_api_key from
config/appsignal.exs).