### PR TITLE
Don't suggest request headers on install, replace fallback header list

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -18,12 +18,6 @@ defmodule Appsignal.Config do
     log: "file"
   }
 
-  @suggested_request_headers [
-    ~w(accept accept-charset accept-encoding accept-language cache-control),
-    ~w(connection content-length path-info range request-method request-uri),
-    ~w(server-name server-port server-protocol)
-  ]
-
   @doc """
   Initializes the AppSignal config. Looks at the config default, the
   Elixir-provided configuration and the various `APPSIGNAL_*`
@@ -48,24 +42,6 @@ defmodule Appsignal.Config do
       |> Map.put(:valid, !empty?(config[:push_api_key]))
 
     Application.put_env(:appsignal, :config, config)
-
-    if config[:valid] && !config[:request_headers] && !test?() do
-      require Logger
-
-      Logger.warn("""
-      The :request_headers config was not set in the AppSignal configuration, falling back to the default list. Please explicitly list response headers to send to AppSignal in config/appsignal.exs:
-
-        request_headers: ~w(
-      #{multiline_suggested_request_headers()}
-        )
-
-      Or set the APPSIGNAL_REQUEST_HEADERS environment variable:
-
-        $ export APPSIGNAL_REQUEST_HEADERS="#{single_line_suggested_request_headers()}"
-
-      Please check https://github.com/appsignal/appsignal-elixir/pull/336 for more information on this change.
-      """)
-    end
 
     case config[:valid] do
       true ->
@@ -265,24 +241,6 @@ defmodule Appsignal.Config do
       _ -> false
     end)
     |> Enum.into(%{})
-  end
-
-  def single_line_suggested_request_headers do
-    @suggested_request_headers
-    |> List.flatten
-    |> Enum.join(",")
-  end
-
-  def multiline_suggested_request_headers do
-    Enum.map_join(@suggested_request_headers, "\n", fn(row) ->
-      "    #{Enum.join(row, " ")}"
-    end)
-  end
-
-  defp test? do
-    Mix.env
-    |> Atom.to_string()
-    |> String.starts_with?("test")
   end
 
   # When you use Appsignal.Config you get a handy config macro which

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -15,7 +15,12 @@ defmodule Appsignal.Config do
     send_params: true,
     skip_session_data: false,
     files_world_accessible: true,
-    log: "file"
+    log: "file",
+    request_headers: ~w(
+      accept accept-charset accept-encoding accept-language cache-control
+      connection content-length path-info range request-method request-uri
+      server-name server-port server-protocol
+    )
   }
 
   @doc """

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -159,15 +159,9 @@ if Appsignal.plug?() do
       }
     end
 
-    @fallback_request_headers ~w(
-      accept accept-charset accept-encoding accept-language cache-control
-      connection content-length path-info range request-method request-uri
-      server-name server-port server-protocol
-    )
-
     def extract_request_headers(%Plug.Conn{req_headers: req_headers}) do
       for {key, value} <- req_headers,
-          key in (Config.request_headers() || @fallback_request_headers) do
+          key in (Config.request_headers()) do
         {"req_headers.#{key}", value}
       end
       |> Enum.into(%{})

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -161,14 +161,8 @@ if Appsignal.plug?() do
 
     @fallback_request_headers ~w(
       accept accept-charset accept-encoding accept-language cache-control
-      connection content-length user-agent from negotiate pragma referer range
-
-      auth-type gateway-interface path-translated remote-host remote-ident
-      remote-user remote-addr request-method server-name server-port
-      server-protocol request-uri path-info client-ip range
-
-      x-request-start x-queue-start x-queue-time x-heroku-queue-wait-time
-      x-application-start x-forwarded-for x-real-ip
+      connection content-length path-info range request-method request-uri
+      server-name server-port server-protocol
     )
 
     def extract_request_headers(%Plug.Conn{req_headers: req_headers}) do

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -97,7 +97,6 @@ defmodule Mix.Tasks.Appsignal.Install do
     IO.puts ~s(  export APPSIGNAL_APP_NAME="#{config[:name]}")
     IO.puts ~s(  export APPSIGNAL_APP_ENV="production")
     IO.puts ~s(  export APPSIGNAL_PUSH_API_KEY="#{config[:push_api_key]}")
-    IO.puts ~s(  export APPSIGNAL_REQUEST_HEADERS="#{Config.single_line_suggested_request_headers()}")
   end
 
   defp write_config_file(config) do
@@ -158,9 +157,6 @@ defmodule Mix.Tasks.Appsignal.Install do
     options = [
       ~s(  name: "#{config[:name]}",),
       ~s(  push_api_key: "#{config[:push_api_key]}",),
-      ~s{  request_headers: ~w(},
-      Config.multiline_suggested_request_headers(),
-      ~s{  ),},
       ~s(  env: Mix.env)
     ]
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -619,7 +619,12 @@ defmodule Appsignal.ConfigTest do
       skip_session_data: false,
       files_world_accessible: true,
       valid: false,
-      log: "file"
+      log: "file",
+      request_headers: ~w(
+        accept accept-charset accept-encoding accept-language cache-control
+        connection content-length path-info range request-method request-uri
+        server-name server-port server-protocol
+      )
     }
   end
 

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -439,11 +439,7 @@ defmodule Appsignal.PlugTest do
         "req_headers.accept-language" => "en-us",
         "req_headers.cache-control" => "no-cache",
         "req_headers.connection" => "keep-alive",
-        "req_headers.user-agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3...",
-        "req_headers.from" => "webmaster@example.org",
-        "req_headers.referer" => "http://localhost:4001/",
-        "req_headers.range" => "bytes=0-1023",
-        "req_headers.x-real-ip" => "179.146.231.170"
+        "req_headers.range" => "bytes=0-1023"
       }
     end
   end

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -155,7 +155,6 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains? output, ~s(APPSIGNAL_APP_NAME="AppSignal test suite app")
       assert String.contains? output, ~s(APPSIGNAL_APP_ENV="production")
       assert String.contains? output, ~s(APPSIGNAL_PUSH_API_KEY="my_push_api_key")
-      assert String.contains? output, ~s(APPSIGNAL_REQUEST_HEADERS="accept,accept-charset,accept-encoding,accept-language,cache-control,connection,content-length,path-info,range,request-method,request-uri,server-name,server-port,server-protocol")
     end
 
     @tag :file_config
@@ -173,12 +172,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(config :appsignal, :config,\n) <>
         ~s(  name: "AppSignal test suite app",\n) <>
         ~s(  push_api_key: "my_push_api_key",\n) <>
-        ~s{  request_headers: ~w(\n} <>
-        ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
-        ~s{    connection content-length path-info range request-method request-uri\n} <>
-        ~s{    server-name server-port server-protocol\n} <>
-        ~s{  ),\n} <>
-        ~s(  env: Mix.env\n)
+        ~s(  env: Mix.env)
 
       # Imports AppSignal config in config.exs file
       app_config = File.read!(Path.join(@test_config_directory, "config.exs"))
@@ -214,12 +208,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
         ~s(  active: true,\n) <>
         ~s(  name: "AppSignal test suite app",\n) <>
         ~s(  push_api_key: "my_push_api_key",\n) <>
-        ~s{  request_headers: ~w(\n} <>
-        ~s{    accept accept-charset accept-encoding accept-language cache-control\n} <>
-        ~s{    connection content-length path-info range request-method request-uri\n} <>
-        ~s{    server-name server-port server-protocol\n} <>
-        ~s{  ),\n} <>
-        ~s(  env: Mix.env\n)
+        ~s(  env: Mix.env)
 
       # Imports AppSignal config in config.exs file
       app_config = File.read!(Path.join(config_directory, "config.exs"))


### PR DESCRIPTION
Instead replace fallback header list with the new default.

Remove the warning that's printed after upgrade and the option is not
set.

Don't add it to the config by default, but allow complete overrides of
the config option.

Conclusion: use saner defaults, don't require users to do anything to
their configuration.

If they miss any headers they can update the configuration after
upgrade. This requires a smaller segment of our users to update their
config manually.

Description copied from https://github.com/appsignal/appsignal-ruby/pull/410