### PR TITLE
Merge instead of ignore Phoenix's :filter_parameters if also configured in AppSignal

### DIFF
--- a/lib/appsignal/utils/params_filter.ex
+++ b/lib/appsignal/utils/params_filter.ex
@@ -5,9 +5,8 @@ defmodule Appsignal.Utils.ParamsFilter do
   """
 
   def get_filter_parameters do
-    Application.get_env(:appsignal, :config)[:filter_parameters]
-    || Application.get_env(:phoenix, :filter_parameters)
-    || []
+    Application.get_env(:phoenix, :filter_parameters, []) ++
+      Application.get_env(:appsignal, :config)[:filter_parameters]
   end
 
   def filter_values(values) do


### PR DESCRIPTION
Backport of #349 on 1.5.x.