### PR TITLE
Store action names in registry to set them after the request is done, unless overridden

### DIFF
--- a/lib/appsignal/phoenix/instrumenter.ex
+++ b/lib/appsignal/phoenix/instrumenter.ex
@@ -25,8 +25,7 @@ if Appsignal.phoenix? do
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 
     @doc false
-    def phoenix_controller_call(:start, _, %{conn: conn} = args) do
-      @transaction.set_action(Appsignal.Plug.extract_action(conn))
+    def phoenix_controller_call(:start, _, args) do
       {@transaction.start_event, args}
     end
 

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -36,7 +36,7 @@ defmodule Appsignal.Transaction do
 
   """
 
-  defstruct [:resource, :id]
+  defstruct [:resource, :id, :action]
 
   alias Appsignal.{Nif, Transaction, TransactionRegistry, Backtrace}
 
@@ -257,6 +257,7 @@ defmodule Appsignal.Transaction do
   @spec set_action(Transaction.t | nil, String.t) :: Transaction.t
   def set_action(nil, _action), do: nil
   def set_action(%Transaction{} = transaction, action) do
+    :ok = TransactionRegistry.set_action(transaction, action)
     :ok = Nif.set_action(transaction.resource, action)
     transaction
   end

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -104,7 +104,32 @@ defmodule Appsignal.TransactionRegistry do
     GenServer.call(__MODULE__, {:remove, transaction})
   end
 
-  ##
+  @doc """
+  Set the Transaction's action name
+  """
+  @spec set_action(Transaction.t, String.t) :: :ok | {:error, :not_found}
+  def set_action(%Transaction{id: id}, action) do
+    case :ets.lookup(@index, id) do
+      [{^id, pid}] ->
+        transaction = %{lookup(pid) | action: action}
+
+        true = :ets.insert(@table, {pid, transaction})
+        :ok
+      [] ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Get the Transaction's action name
+  """
+  @spec action(Transaction.t) :: {:ok, String.t | nil} | {:error, :not_found}
+  def action(%Transaction{id: id}) do
+    case :ets.lookup(@index, id) do
+      [{^id, pid}] -> {:ok, lookup(pid).action}
+      [] -> {:error, :not_found}
+    end
+  end
 
   defmodule State do
     @moduledoc false

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -19,7 +19,8 @@ defmodule Appsignal.TransactionRegistry do
 
   require Logger
 
-  @table :'$appsignal_transaction_registry'
+  @table :"$appsignal_transaction_registry"
+  @index :"$appsignal_transaction_index"
 
   alias Appsignal.Transaction
 
@@ -38,6 +39,7 @@ defmodule Appsignal.TransactionRegistry do
     if registry_alive?() do
       monitor_reference = GenServer.call(__MODULE__, {:monitor, pid})
       true = :ets.insert(@table, {pid, transaction, monitor_reference})
+      true = :ets.insert(@index, {transaction.id, pid})
       :ok
     else
       Logger.debug("AppSignal was not started, skipping transaction registration.")
@@ -110,22 +112,19 @@ defmodule Appsignal.TransactionRegistry do
   end
 
   def init([]) do
-    table = :ets.new(@table, [:set, :named_table,
-                              {:keypos, 1}, :public, {:write_concurrency, true}])
+    :ets.new(@index, [:set, :named_table, :public, {:write_concurrency, true}])
+
+    table =
+      :ets.new(@table, [:set, :named_table, {:keypos, 1}, :public, {:write_concurrency, true}])
+
     {:ok, %State{table: table}}
   end
 
-  def handle_call({:remove, transaction}, _from, state) do
+  def handle_call({:remove, %Transaction{id: id}}, _from, state) do
     reply =
-      case pids_and_monitor_references(transaction) do
-        [[_pid, _reference] | _] = pids_and_refs ->
-          delete(pids_and_refs)
-
-        [[_pid] | _] = pids ->
-          delete(pids)
-
-        [] ->
-          {:error, :not_found}
+      case :ets.lookup(@index, id) do
+        [{^id, pid}] when is_pid(pid) -> Process.send(self(), {:delete, pid}, [])
+        _ -> {:error, :not_found}
       end
 
     {:reply, reply, state}
@@ -151,6 +150,11 @@ defmodule Appsignal.TransactionRegistry do
   end
 
   def handle_info({:delete, pid}, state) do
+    case lookup(pid) do
+      %Transaction{id: id} -> :ets.delete(@index, id)
+      _ -> :ok
+    end
+
     :ets.delete(@table, pid)
     {:noreply, state}
   end
@@ -158,16 +162,6 @@ defmodule Appsignal.TransactionRegistry do
   def handle_info(_msg, state) do
     {:noreply, state}
   end
-
-  defp delete([[pid, _] | tail]) do
-    :ets.delete(@table, pid)
-    delete(tail)
-  end
-  defp delete([[pid] | tail]) do
-    :ets.delete(@table, pid)
-    delete(tail)
-  end
-  defp delete([]), do: :ok
 
   defp demonitor([[_, reference] | tail]) do
     Process.demonitor(reference)

--- a/test/appsignal/instrumentation/decorator_test.exs
+++ b/test/appsignal/instrumentation/decorator_test.exs
@@ -48,11 +48,11 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
   alias Appsignal.Transaction
 
   test_with_mock "instrument module function", Appsignal.Transaction, [:passthrough], [] do
-    t = Transaction.start("bar", :http_request)
+    Transaction.start("bar", :http_request)
     UsingAppsignalDecorators.bar(123)
-    assert called Transaction.start_event(t)
-    assert called Transaction.finish_event(t, "bar", "Elixir.UsingAppsignalDecorators.bar", "", 0)
-    assert called Transaction.finish_event(t, "nested", "Elixir.UsingAppsignalDecorators.nested", "", 0)
+    assert called Transaction.start_event(:_)
+    assert called Transaction.finish_event(:_, "bar", "Elixir.UsingAppsignalDecorators.bar", "", 0)
+    assert called Transaction.finish_event(:_, "nested", "Elixir.UsingAppsignalDecorators.nested", "", 0)
   end
 
   test_with_mock "instrument transaction", Appsignal.Transaction, [:passthrough], [] do
@@ -82,11 +82,11 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
 
 
   test_with_mock "instrument module function with category", Appsignal.Transaction, [:passthrough], [] do
-    t = Transaction.start("bar", :http_request)
+    Transaction.start("bar", :http_request)
     UsingAppsignalDecoratorsWithCustomNamespaces.bar(123)
-    assert called Transaction.start_event(t)
-    assert called Transaction.finish_event(t, "bar.http", "Elixir.UsingAppsignalDecoratorsWithCustomNamespaces.bar", "", 0)
-    assert called Transaction.finish_event(t, "nested.db", "Elixir.UsingAppsignalDecoratorsWithCustomNamespaces.nested", "", 0)
+    assert called Transaction.start_event(:_)
+    assert called Transaction.finish_event(:_, "bar.http", "Elixir.UsingAppsignalDecoratorsWithCustomNamespaces.bar", "", 0)
+    assert called Transaction.finish_event(:_, "nested.db", "Elixir.UsingAppsignalDecoratorsWithCustomNamespaces.nested", "", 0)
   end
 
 end

--- a/test/appsignal/instrumentation/helpers_test.exs
+++ b/test/appsignal/instrumentation/helpers_test.exs
@@ -13,10 +13,10 @@ defmodule AppsignalHelpersTest do
   end
 
   test_with_mock "instrument with pid", Appsignal.Transaction, [:passthrough], [] do
-    t = Transaction.start("bar", :http_request)
+    Transaction.start("bar", :http_request)
     call_instrument(self())
-    assert called Transaction.start_event(t)
-    assert called Transaction.finish_event(t, "name", "title", "", 0)
+    assert called Transaction.start_event(:_)
+    assert called Transaction.finish_event(:_, "name", "title", "", 0)
   end
 
   test "instrument with nil" do

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -4,16 +4,18 @@ defmodule Appsignal.Transaction.RegistryTest do
   alias Appsignal.{Transaction, TransactionRegistry}
 
   test "lookup/1 returns nil after process has ended" do
-    transaction = %Transaction{id: Transaction.generate_id()}
+    id = Transaction.generate_id()
+    transaction = %Transaction{id: id}
 
-    pid = spawn(fn() ->
-      TransactionRegistry.register(transaction)
-      assert transaction == TransactionRegistry.lookup(self())
-    end)
+    pid =
+      spawn(fn ->
+        TransactionRegistry.register(transaction)
+        assert %Transaction{id: ^id} = TransactionRegistry.lookup(self())
+      end)
 
     :ok = wait_for_process_to_exit(pid)
 
-    assert transaction == TransactionRegistry.lookup(pid)
+    assert %Transaction{id: ^id} = TransactionRegistry.lookup(pid)
 
     :ok = TransactionRegistry.remove_transaction(transaction)
 
@@ -30,8 +32,8 @@ defmodule Appsignal.Transaction.RegistryTest do
   describe "register/1 and lookup/1, with an existing transaction" do
     setup :register_transaction
 
-    test "finds an existing transaction by pid", %{transaction: transaction} do
-      assert TransactionRegistry.lookup(self()) == transaction
+    test "finds an existing transaction by pid", %{transaction: %{id: id}} do
+      assert %Transaction{id: ^id} = TransactionRegistry.lookup(self())
     end
 
     test "finds the transaction ID from the index", %{transaction: %{id: id} = transaction} do

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -90,6 +90,48 @@ defmodule Appsignal.Transaction.RegistryTest do
     end
   end
 
+  describe "action/1, without an action set" do
+    setup :register_transaction
+
+    test "fails to get an unregistered transaction's action" do
+      assert TransactionRegistry.action(%Transaction{}) == {:error, :not_found}
+    end
+
+    test "get a registered transaction's action", %{transaction: transaction} do
+      assert TransactionRegistry.action(transaction) == {:ok, nil}
+    end
+  end
+
+  describe "action/1, with an action set" do
+    setup :register_transaction_with_action_name
+
+    test "get the action", %{transaction: transaction} do
+      assert TransactionRegistry.action(transaction) == {:ok, "action"}
+    end
+  end
+
+  describe "set_action/1" do
+    setup :register_transaction
+
+    test "fails to set an unregistered transaction's action" do
+      assert TransactionRegistry.set_action(%Transaction{}, "custom") == {:error, :not_found}
+    end
+
+    test "set a registered transaction's action", %{transaction: transaction} do
+      assert TransactionRegistry.set_action(transaction, "custom") ==  :ok
+      assert TransactionRegistry.action(transaction) == {:ok, "custom"}
+    end
+  end
+
+  describe "set_action/1, with an action set" do
+    setup :register_transaction_with_action_name
+
+    test "overwrite the action", %{transaction: transaction} do
+      assert TransactionRegistry.set_action(transaction, "custom") == :ok
+      assert TransactionRegistry.action(transaction) == {:ok, "custom"}
+    end
+  end
+
   defp register_transaction(_) do
     transaction = %Transaction{id: Transaction.generate_id()}
     TransactionRegistry.register(transaction)
@@ -102,6 +144,13 @@ defmodule Appsignal.Transaction.RegistryTest do
     transaction = %Transaction{id: id}
     true = :ets.insert(:"$appsignal_transaction_registry", {self(), transaction})
     true = :ets.insert(:"$appsignal_transaction_index", {id, self()})
+
+    [transaction: transaction]
+  end
+
+  defp register_transaction_with_action_name(_) do
+    transaction = %Transaction{id: Transaction.generate_id(), action: "action"}
+    TransactionRegistry.register(transaction)
 
     [transaction: transaction]
   end

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -22,21 +22,33 @@ defmodule AppsignalTransactionTest do
   end
 
   test "use default transaction in Transaction calls" do
+    id = Transaction.generate_id()
+    transaction = Transaction.start(id, :http_request)
+    assert %Transaction{id: ^id} = transaction
 
-    transaction = Transaction.start("test2", :http_request)
-    assert %Transaction{} = transaction
+    assert %Transaction{id: ^id} = Transaction.start_event()
 
-    assert ^transaction = Transaction.start_event()
-    assert ^transaction = Transaction.finish_event("sql.query", "Model load", "SELECT * FROM table;", 1)
-    assert ^transaction = Transaction.record_event("sql.query", "Model load", "SELECT * FROM table;", 1000 * 1000 * 3, 1)
-    assert ^transaction = Transaction.set_error("Error", "error message", System.stacktrace)
-    assert ^transaction = Transaction.set_sample_data("key", %{user_id: 1})
-    assert ^transaction = Transaction.set_action("GET:/")
-    assert ^transaction = Transaction.set_queue_start(1000)
-    assert ^transaction = Transaction.set_meta_data("email", "info@info.com")
+    assert %Transaction{id: ^id} =
+             Transaction.finish_event("sql.query", "Model load", "SELECT * FROM table;", 1)
+
+    assert %Transaction{id: ^id} =
+             Transaction.record_event(
+               "sql.query",
+               "Model load",
+               "SELECT * FROM table;",
+               1000 * 1000 * 3,
+               1
+             )
+
+    assert %Transaction{id: ^id} =
+             Transaction.set_error("Error", "error message", System.stacktrace())
+
+    assert %Transaction{id: ^id} = Transaction.set_sample_data("key", %{user_id: 1})
+    assert %Transaction{id: ^id} = Transaction.set_action("GET:/")
+    assert %Transaction{id: ^id} = Transaction.set_queue_start(1000)
+    assert %Transaction{id: ^id} = Transaction.set_meta_data("email", "info@info.com")
     assert [:sample, :no_sample] |> Enum.member?(Transaction.finish())
     assert :ok = Transaction.complete()
-
   end
 
 
@@ -75,16 +87,18 @@ defmodule AppsignalTransactionTest do
   end
 
   test "data encoding" do
-    transaction = Transaction.start("test3", :http_request)
+    id = Transaction.generate_id()
+    Transaction.start(id, :http_request)
 
     # Map
-    assert ^transaction = Transaction.set_sample_data("key", %{"user_id" => 1})
+    assert %Transaction{id: ^id} = Transaction.set_sample_data("key", %{"user_id" => 1})
 
     # Atom
-    assert ^transaction = Transaction.set_sample_data("key", %{user_id: 1})
+    assert %Transaction{id: ^id} = Transaction.set_sample_data("key", %{user_id: 1})
 
     # complex
-    assert ^transaction = Transaction.set_sample_data("key", %{values: %{1 => 2, 3 => 4}})
+    assert %Transaction{id: ^id} =
+             Transaction.set_sample_data("key", %{values: %{1 => 2, 3 => 4}})
   end
 
   test "finishing an event with a non-string body" do

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -48,6 +48,7 @@ defmodule AppsignalTransactionTest do
     assert %Transaction{id: ^id} = Transaction.set_queue_start(1000)
     assert %Transaction{id: ^id} = Transaction.set_meta_data("email", "info@info.com")
     assert [:sample, :no_sample] |> Enum.member?(Transaction.finish())
+    assert TransactionRegistry.action(transaction) == {:ok, "GET:/"}
     assert :ok = Transaction.complete()
   end
 

--- a/test/phoenix/instrumenter_test.exs
+++ b/test/phoenix/instrumenter_test.exs
@@ -20,13 +20,6 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
       Instrumenter.phoenix_controller_call(:start, nil, arguments)
   end
 
-  test "sets the action name in phoenix_controller_call", %{transaction: transaction, conn: conn, fake_transaction: fake_transaction} do
-    arguments = %{conn: conn, transaction: transaction}
-
-    Instrumenter.phoenix_controller_call(:start, nil, arguments)
-    assert "foo#bar" == FakeTransaction.action(fake_transaction)
-  end
-
   test "starts an event in phoenix_controller_render", context do
     arguments = %{foo: "bar"}
     assert {context[:transaction], arguments} ==


### PR DESCRIPTION
By storing the actions in the TransactionRegistry, we can revert back to setting the action name after the request is done. This will fix issues we're seeing where the action names for umbrella apps aren't properly set. 