### PR TITLE
Allow calling `Transaction.register/1` and `Transaction.complete/1` when the Registry is not alive

### DIFF
--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -81,7 +81,7 @@ defmodule Appsignal.Transaction do
 
   @spec register(Transaction.t) :: Transaction.t
   defp register(transaction) do
-    :ok = TransactionRegistry.register(transaction)
+    TransactionRegistry.register(transaction)
     transaction
   end
 

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -96,10 +96,14 @@ defmodule Appsignal.TransactionRegistry do
   @doc """
   Unregister the current process as the owner of the given transaction.
   """
-  @spec remove_transaction(Transaction.t) :: :ok | {:error, :not_found}
+  @spec remove_transaction(Transaction.t) :: :ok | {:error, :not_found} | {:error, :no_registry}
   def remove_transaction(%Transaction{} = transaction) do
-    GenServer.cast(__MODULE__, {:demonitor, transaction})
-    GenServer.call(__MODULE__, {:remove, transaction})
+    if registry_alive?() do
+      GenServer.cast(__MODULE__, {:demonitor, transaction})
+      GenServer.call(__MODULE__, {:remove, transaction})
+    else
+      {:error, :no_registry}
+    end
   end
 
   ##

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -83,6 +83,14 @@ defmodule Appsignal.Transaction.RegistryTest do
     end
   end
 
+  describe "remove_transaction/1, when the registry is not running" do
+    setup [:register_transaction, :terminate_registry]
+
+    test "returns no registry error", %{transaction: transaction} do
+      assert TransactionRegistry.remove_transaction(transaction) == {:error, :no_registry}
+    end
+  end
+
   defp register_transaction(_) do
     transaction = %Transaction{id: Transaction.generate_id()}
     TransactionRegistry.register(transaction)

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -228,13 +228,25 @@ defmodule AppsignalTransactionTest do
     end
   end
 
-  describe "starting a transaction when the registry is not running" do
+  describe "completing a transaction" do
+    test "removes the transaction from the registry" do
+      transaction = Transaction.start(Transaction.generate_id, :http_request)
+      Transaction.finish(transaction)
+      :ok = Transaction.complete(transaction)
+      {:error, :not_found} = TransactionRegistry.remove_transaction(transaction)
+    end
+  end
+
+  describe "when the registry is not running" do
     setup do
+      transaction = Transaction.start(Transaction.generate_id, :http_request)
       :ok = Supervisor.terminate_child(Appsignal.Supervisor, TransactionRegistry)
 
       on_exit(fn ->
         {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, TransactionRegistry)
       end)
+
+      [transaction: transaction]
     end
 
     test "creates a transaction" do
@@ -243,14 +255,9 @@ defmodule AppsignalTransactionTest do
 
       assert %Transaction{id: id} = transaction
     end
-  end
 
-  describe "completing a transaction" do
-    test "removes the transaction from the registry" do
-      transaction = Transaction.start(Transaction.generate_id, :http_request)
-      Transaction.finish(transaction)
-      :ok = Transaction.complete(transaction)
-      {:error, :not_found} = TransactionRegistry.remove_transaction(transaction)
+    test "does not crash when trying to complete a transaction", %{transaction: transaction} do
+      assert :ok == Transaction.complete(transaction)
     end
   end
 end

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -228,6 +228,23 @@ defmodule AppsignalTransactionTest do
     end
   end
 
+  describe "starting a transaction when the registry is not running" do
+    setup do
+      :ok = Supervisor.terminate_child(Appsignal.Supervisor, TransactionRegistry)
+
+      on_exit(fn ->
+        {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, TransactionRegistry)
+      end)
+    end
+
+    test "creates a transaction" do
+      id = Transaction.generate_id
+      transaction = Transaction.start(id, :http_request)
+
+      assert %Transaction{id: id} = transaction
+    end
+  end
+
   describe "completing a transaction" do
     test "removes the transaction from the registry" do
       transaction = Transaction.start(Transaction.generate_id, :http_request)


### PR DESCRIPTION
Closes #354 by making sure the Registry GenServer is alive before sending messages to it. When the registry is unavailable, a debug message is logged in [`TransactionRegistry.register/1`](https://github.com/appsignal/appsignal-elixir/blob/65385340bd4692fe3a1ae258f2b7b97853bae0fb/lib/appsignal/transaction/registry.ex#L43).

@lukaszsamson could you try this branch locally and let us know if this resolves the issues you've been running into?