### PR TITLE
Add appsignal_to_json implementation

### DIFF
--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -732,12 +732,27 @@ static ERL_NIF_TERM _data_to_json(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
   if (argc != 1) {
     return enif_make_badarg(env);
   }
-  if(!enif_get_resource(env, argv[0], appsignal_data_type, (void**) &ptr)) {
+  if (!enif_get_resource(env, argv[0], appsignal_data_type, (void**) &ptr)) {
     return enif_make_badarg(env);
   }
 
   json = appsignal_data_to_json(ptr->data);
   return make_ok_tuple(env, enif_make_string(env, json.buf, ERL_NIF_LATIN1));
+}
+
+static ERL_NIF_TERM _transaction_to_json(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+  transaction_ptr *ptr;
+  appsignal_string_t json;
+
+  if (argc != 1) {
+    return enif_make_badarg(env);
+  }
+  if (!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
+    return enif_make_badarg(env);
+  }
+
+  json = appsignal_transaction_to_json(ptr->transaction);
+  return make_ok_tuple(env, make_elixir_string(env, json));
 }
 #endif
 
@@ -823,6 +838,7 @@ static ErlNifFunc nif_funcs[] =
     {"_data_list_new", 0, _data_list_new, 0},
     {"_running_in_container", 0, _running_in_container, 0},
 #ifdef TEST
+    {"_transaction_to_json", 1, _transaction_to_json, 0},
     {"_data_to_json", 1, _data_to_json, 0},
 #endif
     {"_loaded", 0, _loaded, 0}

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,4 +11,10 @@ if Mix.env in [:test, :test_phoenix, :test_no_nif] do
   config :appsignal, appsignal_demo: Appsignal.FakeDemo
   config :appsignal, appsignal_transaction: Appsignal.FakeTransaction
   config :appsignal, appsignal_diagnose_report: Appsignal.Diagnose.FakeReport
+
+  config :appsignal, :config,
+    push_api_key: "00000000-0000-0000-0000-000000000000",
+    name: "AppSignal test suite app v0",
+    env: "baz",
+    active: true
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,6 @@ if Mix.env in [:test, :test_phoenix, :test_no_nif] do
   config :appsignal, :config,
     push_api_key: "00000000-0000-0000-0000-000000000000",
     name: "AppSignal test suite app v0",
-    env: "baz",
+    env: "test",
     active: true
 end

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -187,12 +187,6 @@ defmodule Appsignal.Nif do
     _data_set_data(resource, value)
   end
 
-  if Mix.env in [:test, :test_phoenix] do
-    def data_to_json(resource) do
-      _data_to_json(resource)
-    end
-  end
-
   def data_list_new do
     _data_list_new()
   end
@@ -203,6 +197,16 @@ defmodule Appsignal.Nif do
 
   def loaded? do
     _loaded()
+  end
+
+  if Mix.env in [:test, :test_phoenix] do
+    def data_to_json(resource) do
+      _data_to_json(resource)
+    end
+
+    def transaction_to_json(resource) do
+      _transaction_to_json(resource)
+    end
   end
 
   def _start do
@@ -351,6 +355,9 @@ defmodule Appsignal.Nif do
     def _data_to_json(resource) do
       resource
     end
-  end
 
+    def _transaction_to_json(resource) do
+      {:ok, resource}
+    end
+  end
 end

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -79,6 +79,14 @@ defmodule Appsignal.Transaction do
     %Transaction{resource: resource, id: transaction_id}
   end
 
+  if Mix.env in [:test, :test_phoenix] do
+    @spec to_map(Appsignal.Transaction.t) :: map()
+    def to_map(transaction) do
+      {:ok, json} =  Nif.transaction_to_json(transaction.resource)
+      Poison.decode!(json)
+    end
+  end
+
   @spec register(Transaction.t) :: Transaction.t
   defp register(transaction) do
     :ok = TransactionRegistry.register(transaction)

--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -5,7 +5,7 @@ defmodule Appsignal.ReleaseUpgradeTest do
   import AppsignalTest.Utils
 
   test "config_change/3" do
-    assert System.get_env("_APPSIGNAL_APP_NAME") == nil
+    assert System.get_env("_APPSIGNAL_APP_NAME") == "AppSignal test suite app v0"
 
     with_config(valid_configuration(), fn ->
       # First start

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -236,4 +236,14 @@ defmodule AppsignalTransactionTest do
       {:error, :not_found} = TransactionRegistry.remove_transaction(transaction)
     end
   end
+
+  describe "setting a transaction's action name" do
+    @tag :skip_env_test_no_nif
+    test "stores the action name on the transaction" do
+      transaction = Transaction.create(Transaction.generate_id, :http_request)
+      Transaction.set_action(transaction, "ActionController#my_action")
+
+      assert Transaction.to_map(transaction)["action"] == "ActionController#my_action"
+    end
+  end
 end


### PR DESCRIPTION
Available as `to_map` on the `Appsignal.Transaction` module. Allows a
view of the transaction object as is currently stored in the extension.

Used for testing purposes only, do not use this function in your own
apps!

To fetch transaction data from the transaction the extension needs to be
started with a valid config, otherwise it returns an empty string. Since
we want to do this more often, start the AppSignal app with a valid
config by default. Use the `with_config` helper function if you want to
test an invalid config.

Implement one test, setting an action name on the transaction, to make
sure it works from end to end.

Related issue #127 