### PR TITLE
Add Appsignal.Transaction.set_namespace/1-2

### DIFF
--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -309,6 +309,29 @@ static ERL_NIF_TERM _set_action(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
     return enif_make_atom(env, "ok");
 }
 
+static ERL_NIF_TERM _set_namespace(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    transaction_ptr *ptr;
+    ErlNifBinary namespace;
+
+    if (argc != 2) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_inspect_iolist_as_binary(env, argv[1], &namespace)) {
+        return enif_make_badarg(env);
+    }
+
+    appsignal_set_transaction_namespace(
+        ptr->transaction,
+        make_appsignal_string(namespace)
+    );
+
+    return enif_make_atom(env, "ok");
+}
+
 static ERL_NIF_TERM _set_queue_start(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     transaction_ptr *ptr;
@@ -815,6 +838,7 @@ static ErlNifFunc nif_funcs[] =
     {"_set_error", 4, _set_error, 0},
     {"_set_sample_data", 3, _set_sample_data, 0},
     {"_set_action", 2, _set_action, 0},
+    {"_set_namespace", 2, _set_namespace, 0},
     {"_set_queue_start", 2, _set_queue_start, 0},
     {"_set_meta_data", 3, _set_meta_data, 0},
     {"_finish", 1, _finish, 0},

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -107,6 +107,10 @@ defmodule Appsignal.Nif do
     _set_action(transaction_resource, action)
   end
 
+  def set_namespace(transaction_resource, namespace) do
+    _set_namespace(transaction_resource, namespace)
+  end
+
   def set_queue_start(transaction_resource, start) do
     _set_queue_start(transaction_resource, start)
   end
@@ -254,6 +258,10 @@ defmodule Appsignal.Nif do
   end
 
   def _set_action(_transaction_resource, _action) do
+    :ok
+  end
+
+  def _set_namespace(_transaction_resource, _action) do
     :ok
   end
 

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -285,11 +285,15 @@ defmodule Appsignal.Transaction do
   - `transaction`: The pointer to the transaction this event occurred in
   - `namespace`: This transaction's action (`:`)
   """
-  @spec set_namespace(Transaction.t() | nil, atom()) :: Transaction.t()
+  @spec set_namespace(Transaction.t() | nil, String.t() | atom()) :: Transaction.t()
   def set_namespace(nil, _namespace), do: nil
 
-  def set_namespace(%Transaction{} = transaction, namespace) do
-    :ok = Nif.set_namespace(transaction.resource, Atom.to_string(namespace))
+  def set_namespace(%Transaction{} = transaction, namespace) when is_atom(namespace) do
+    set_namespace(transaction, Atom.to_string(namespace))
+  end
+
+  def set_namespace(%Transaction{} = transaction, namespace) when is_binary(namespace) do
+    :ok = Nif.set_namespace(transaction.resource, namespace)
     transaction
   end
 

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -270,6 +270,30 @@ defmodule Appsignal.Transaction do
   end
 
   @doc """
+  Set namespace of the current transaction. See `set_namespace/1`.
+  """
+  @spec set_namespace(atom()) :: Transaction.t()
+  def set_namespace(namespace) do
+    set_namespace(lookup(), namespace)
+  end
+
+  @doc """
+  Set namespace of a transaction
+
+  Call this to override the transaction's namespace.
+
+  - `transaction`: The pointer to the transaction this event occurred in
+  - `namespace`: This transaction's action (`:`)
+  """
+  @spec set_namespace(Transaction.t() | nil, atom()) :: Transaction.t()
+  def set_namespace(nil, _namespace), do: nil
+
+  def set_namespace(%Transaction{} = transaction, namespace) do
+    :ok = Nif.set_namespace(transaction.resource, Atom.to_string(namespace))
+    transaction
+  end
+
+  @doc """
   Set queue start time of the current transaction. See `set_queue_start/2`.
   """
   @spec set_queue_start(integer) :: Transaction.t

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -270,4 +270,14 @@ defmodule AppsignalTransactionTest do
       assert :ok == Transaction.complete(transaction)
     end
   end
+
+  describe "setting a transaction's namespace" do
+    @tag :skip_env_test_no_nif
+    test "overwrites the transaction's namespace" do
+      transaction = Transaction.create(Transaction.generate_id(), :http_request)
+      Transaction.set_namespace(transaction, :background)
+
+      assert Transaction.to_map(transaction)["namespace"] == "background"
+    end
+  end
 end

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -273,9 +273,17 @@ defmodule AppsignalTransactionTest do
 
   describe "setting a transaction's namespace" do
     @tag :skip_env_test_no_nif
-    test "overwrites the transaction's namespace" do
+    test "overwrites the transaction's namespace with an atom" do
       transaction = Transaction.create(Transaction.generate_id(), :http_request)
       Transaction.set_namespace(transaction, :background)
+
+      assert Transaction.to_map(transaction)["namespace"] == "background"
+    end
+
+    @tag :skip_env_test_no_nif
+    test "overwrites the transaction's namespace with a string" do
+      transaction = Transaction.create(Transaction.generate_id(), :http_request)
+      Transaction.set_namespace(transaction, "background")
 
       assert Transaction.to_map(transaction)["namespace"] == "background"
     end


### PR DESCRIPTION
Closes #348. Allows overwriting the namespace for an existing Transaction.