### PR TITLE
On FreeBSD use gmake (GNU Make)

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -148,7 +148,11 @@ defmodule Mix.Appsignal.Helper do
   end
 
   def compile do
-    {result, error_code} = System.cmd("make", make_args(to_string(Mix.env)))
+    {result, error_code} = if Mix.Appsignal.Helper.agent_platform() == "freebsd" do
+      System.cmd("gmake", make_args(to_string(Mix.env)))
+    else
+      System.cmd("make", make_args(to_string(Mix.env)))
+    end
     IO.binwrite(result)
 
     if error_code != 0 do


### PR DESCRIPTION
appsignal fails to compile in FreeBSD because of different syntax in BSD make and GNU make
Here is current output on master
```
kirillvr@tsugaike:~/appsignal-elixir % mix compile
==> httpoison
Compiling 2 files (.ex)
Generated httpoison app
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 4: Missing dependency operator
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 6: Need an operator
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 8: Need an operator
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 13: Missing dependency operator
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 15: Need an operator
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 17: Missing dependency operator
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 18: warning: duplicate script for target "ifeq" ignored
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 5: warning: using previous script for "ifeq" defined here
make: "/usr/home/kirillvr/appsignal-elixir/Makefile" line 19: Need an operator
make: Fatal errors encountered -- cannot continue
make: stopped in /usr/home/kirillvr/appsignal-elixir
==> appsignal
** (Mix) Could not run `make`. Please check if `make` and either `clang` or `gcc` are installed
```

This pull request make appsignal to use gmake on FreeBSD.
Feel free to change implementation if you know how to detect platform better,

Cheers,
K