### PR TITLE
Read ca_file_path at runtime

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -18,7 +18,6 @@ defmodule Appsignal.Config do
     skip_session_data: false,
     files_world_accessible: true,
     log: "file",
-    ca_file_path: Path.join(:code.priv_dir(:appsignal), "cacert.pem"),
     request_headers: ~w(
       accept accept-charset accept-encoding accept-language cache-control
       connection content-length path-info range request-method request-uri
@@ -84,7 +83,16 @@ defmodule Appsignal.Config do
   end
 
   def ca_file_path do
-    Application.fetch_env!(:appsignal, :config)[:ca_file_path]
+    config = Application.fetch_env!(:appsignal, :config)
+    if Map.has_key?(config, :ca_file_path) do
+      config[:ca_file_path]
+    else
+      default_ca_file_path()
+    end
+  end
+
+  defp default_ca_file_path do
+    Path.join(:code.priv_dir(:appsignal), "cacert.pem")
   end
 
   @env_to_key_mapping %{

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -88,6 +88,25 @@ defmodule Appsignal.ConfigTest do
     end
   end
 
+  describe "ca_file_path" do
+    setup do
+      Config.initialize()
+      :ok
+    end
+
+    test "uses the priv path by default" do
+      assert with_config(%{}, &Config.ca_file_path/0) == Path.join(:code.priv_dir(:appsignal), "cacert.pem")
+    end
+
+    test "returns user override when set" do
+      assert with_config(%{ca_file_path: "/foo/bar/bat.ca"}, &Config.ca_file_path/0) == "/foo/bar/bat.ca"
+    end
+
+    test "returns nil when set to nil" do
+      assert with_config(%{ca_file_path: nil}, &Config.ca_file_path/0) == nil
+    end
+  end
+
   describe "using the application environment" do
     test "active" do
       assert with_config(%{active: true}, &init_config/0)
@@ -627,8 +646,7 @@ defmodule Appsignal.ConfigTest do
         accept accept-charset accept-encoding accept-language cache-control
         connection content-length path-info range request-method request-uri
         server-name server-port server-protocol
-      ),
-      ca_file_path: Path.expand("_build/#{Mix.env}/lib/appsignal/priv/cacert.pem")
+      )
     }
   end
 


### PR DESCRIPTION
Fixes apps that get compiled in another directory than they're run. At
compile time the app paths are different on platforms like Heroku, which
sets the ca_file_path config option to a path that no longer exists at
runtime (assuming the compile dir was cleaned).

Instead, read the path at runtime so we're sure that it points to an
existing ca_file_path path.

With an invalid ca_file_path the AppSignal agent will start reporting
SSL connection errors, because the ca_file_path option points to
no existing file.

Fixes #378 