### PR TITLE
Ensure ca_file_path is written to agent env

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -38,6 +38,7 @@ defmodule Appsignal.Config do
 
     config =
       @default_config
+      |> Map.merge(runtime_config())
       |> Map.merge(system_config)
       |> Map.merge(app_config)
       |> Map.merge(env_config)
@@ -83,12 +84,7 @@ defmodule Appsignal.Config do
   end
 
   def ca_file_path do
-    config = Application.fetch_env!(:appsignal, :config)
-    if Map.has_key?(config, :ca_file_path) do
-      config[:ca_file_path]
-    else
-      default_ca_file_path()
-    end
+    Application.fetch_env!(:appsignal, :config)[:ca_file_path]
   end
 
   defp default_ca_file_path do
@@ -139,6 +135,10 @@ defmodule Appsignal.Config do
         cfg
       end
     end)
+  end
+
+  defp runtime_config do
+    %{ca_file_path: default_ca_file_path()}
   end
 
   defp load_from_system() do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -621,6 +621,24 @@ defmodule Appsignal.ConfigTest do
         assert Nif.env_get("_APPSIGNAL_FILES_WORLD_ACCESSIBLE") == 'false'
       end)
     end
+
+    @tag :skip_env_test_no_nif
+    test "writes default ca_file_path to env if not user configured" do
+      with_config(%{}, fn() ->
+        write_to_environment()
+
+        assert Nif.env_get("_APPSIGNAL_CA_FILE_PATH") == to_charlist(default_configuration()[:ca_file_path])
+      end)
+    end
+
+    @tag :skip_env_test_no_nif
+    test "writes empty strint ca_file_path to env if user configured to nil" do
+      with_config(%{ca_file_path: nil}, fn() ->
+        write_to_environment()
+
+        assert Nif.env_get("_APPSIGNAL_CA_FILE_PATH") == ''
+      end)
+    end
   end
 
   defp default_configuration() do
@@ -646,7 +664,8 @@ defmodule Appsignal.ConfigTest do
         accept accept-charset accept-encoding accept-language cache-control
         connection content-length path-info range request-method request-uri
         server-name server-port server-protocol
-      )
+      ),
+      ca_file_path: Path.join(:code.priv_dir(:appsignal), "cacert.pem")
     }
   end
 


### PR DESCRIPTION
PR #380 fixed the ca_file_path option for the integration, but not the
agent config. The default path was not written to the config, only the
user config.

This fix ensures that the ca_file_path config option is part of the
config hash. It now uses the same logic as the rest of the config.

Add more tests to ensure the logic we expect is working.

Fix bug reported in https://github.com/appsignal/appsignal-elixir/issues/378#issuecomment-405202369