### PR TITLE
Support doubles in extension

### DIFF
--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "e41c3c0"
+  def version, do: "7859eb4"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "29137003b8e4fdec8528cf68d800b08cab15cfdcdcb89535b50e2d76641ff9da",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "7297a066ced652e7ec498eee30b9094586b5d0ce221c84bbb851e2de9d11a39f",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "29137003b8e4fdec8528cf68d800b08cab15cfdcdcb89535b50e2d76641ff9da",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "7297a066ced652e7ec498eee30b9094586b5d0ce221c84bbb851e2de9d11a39f",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "ab930cd56bc0337ac34704a42bcd2d86f3c75f3bfdb8e1b41e600a0ba4f53e42",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "002b5d27e368444eae4308e97285faa83f13cb2aa25fde32a39000d354649917",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "ab930cd56bc0337ac34704a42bcd2d86f3c75f3bfdb8e1b41e600a0ba4f53e42",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "002b5d27e368444eae4308e97285faa83f13cb2aa25fde32a39000d354649917",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "18d37d334a0726de0fa39e4f8b657987350b452664c744d24774a960a54511f7",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "038b14bf3f3cad55e3dfc4947a6eccaf90f2cb15574f2cc69b17f78b20f8075e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "18d37d334a0726de0fa39e4f8b657987350b452664c744d24774a960a54511f7",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "038b14bf3f3cad55e3dfc4947a6eccaf90f2cb15574f2cc69b17f78b20f8075e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "bdf586ecaf7c0c311fc41d3f62f3dc6eee8d4334e10306b5cd82d97bc35c3031",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "d968a93822a61d39a62648c2880e52bdb4caba81c567041d27da7a3c848650b7",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "67fbeda8e308e25657bcce32cdfd0fc3bbe4725f62a6661e76450e57a4aed2d9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "669d0876ae3bb5033563c19aed63c298beca3dd4c2d06c3fa27d641c650b8654",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "f841c5eca8e1ce5413845e79ddd1129d0ae7a04df521066f00d849e149f301bd",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "9f02f723ceef3f5ebb68f226bb6f188b8f3e07551684b86f3eb37f918d549148",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "f841c5eca8e1ce5413845e79ddd1129d0ae7a04df521066f00d849e149f301bd",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "9f02f723ceef3f5ebb68f226bb6f188b8f3e07551684b86f3eb37f918d549148",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "64deb96"
+  def version, do: "e41c3c0"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "1ab49acb93615b0c1e2fe9e48c179e0fd3fcadd391523940c322f154bd479a83",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "29137003b8e4fdec8528cf68d800b08cab15cfdcdcb89535b50e2d76641ff9da",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "1ab49acb93615b0c1e2fe9e48c179e0fd3fcadd391523940c322f154bd479a83",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "29137003b8e4fdec8528cf68d800b08cab15cfdcdcb89535b50e2d76641ff9da",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "a27cf9191f70f13263662f6ca2555cada27ebb4384d6c981a534774b5e7def0e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "ab930cd56bc0337ac34704a42bcd2d86f3c75f3bfdb8e1b41e600a0ba4f53e42",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "a27cf9191f70f13263662f6ca2555cada27ebb4384d6c981a534774b5e7def0e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "ab930cd56bc0337ac34704a42bcd2d86f3c75f3bfdb8e1b41e600a0ba4f53e42",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "80fb5c2f36b7e8efcfc6914bb707688e248dd06c58b174d07e8a931f4bbf97ce",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "18d37d334a0726de0fa39e4f8b657987350b452664c744d24774a960a54511f7",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "80fb5c2f36b7e8efcfc6914bb707688e248dd06c58b174d07e8a931f4bbf97ce",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "18d37d334a0726de0fa39e4f8b657987350b452664c744d24774a960a54511f7",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "83befc3bb521d5e055eb92d5a5a0afca929bce8968ca6d0426fac6aeaec3df24",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "bdf586ecaf7c0c311fc41d3f62f3dc6eee8d4334e10306b5cd82d97bc35c3031",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "3cb74695955c7bc809320fa966d7290fe3162926c239bb6a845b82ef7aec266e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "67fbeda8e308e25657bcce32cdfd0fc3bbe4725f62a6661e76450e57a4aed2d9",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "7735718e2789c71f1135100ff4fab13cd85cbebe0ba2b87c5b555b30635bdcdc",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "f841c5eca8e1ce5413845e79ddd1129d0ae7a04df521066f00d849e149f301bd",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "7735718e2789c71f1135100ff4fab13cd85cbebe0ba2b87c5b555b30635bdcdc",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "f841c5eca8e1ce5413845e79ddd1129d0ae7a04df521066f00d849e149f301bd",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e41c3c0/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "e801925"
+  def version, do: "64deb96"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "e567535a3a2aa7760d6e9fffe62ffe36c1d1544a0ace8b04aaac344ccf6f73ed",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "1ab49acb93615b0c1e2fe9e48c179e0fd3fcadd391523940c322f154bd479a83",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "e567535a3a2aa7760d6e9fffe62ffe36c1d1544a0ace8b04aaac344ccf6f73ed",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "1ab49acb93615b0c1e2fe9e48c179e0fd3fcadd391523940c322f154bd479a83",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "17687fb55bf84f5ed219fabd000c101afac5664408babfd4d7b7d5b27ce4008f",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "a27cf9191f70f13263662f6ca2555cada27ebb4384d6c981a534774b5e7def0e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "17687fb55bf84f5ed219fabd000c101afac5664408babfd4d7b7d5b27ce4008f",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "a27cf9191f70f13263662f6ca2555cada27ebb4384d6c981a534774b5e7def0e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "15cfe0fd8f50882cd93b245ffee25d8e9122ee64a29cedbde6a11e9720acf06c",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "80fb5c2f36b7e8efcfc6914bb707688e248dd06c58b174d07e8a931f4bbf97ce",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "15cfe0fd8f50882cd93b245ffee25d8e9122ee64a29cedbde6a11e9720acf06c",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "80fb5c2f36b7e8efcfc6914bb707688e248dd06c58b174d07e8a931f4bbf97ce",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "b5d711f5f93be49295a2b7a568d990b148db1e1e17bbc95f7038dc10037b64c2",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "83befc3bb521d5e055eb92d5a5a0afca929bce8968ca6d0426fac6aeaec3df24",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "b1761ecbba65eefe1e2b168a41692e82f65781e2b3179277733ae9889d766cdb",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "3cb74695955c7bc809320fa966d7290fe3162926c239bb6a845b82ef7aec266e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "0fecd3891dd9d5f152c06bc960c270274a83df8f8cee6f5698256bb78f1eb3e6",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "7735718e2789c71f1135100ff4fab13cd85cbebe0ba2b87c5b555b30635bdcdc",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "0fecd3891dd9d5f152c06bc960c270274a83df8f8cee6f5698256bb78f1eb3e6",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e801925/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "7735718e2789c71f1135100ff4fab13cd85cbebe0ba2b87c5b555b30635bdcdc",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -521,7 +521,7 @@ static ERL_NIF_TERM _set_gauge(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
 static ERL_NIF_TERM _increment_counter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ErlNifBinary key;
-    int count;
+    double count;
     data_ptr *data_ptr;
 
     if (argc != 3) {
@@ -530,7 +530,7 @@ static ERL_NIF_TERM _increment_counter(ErlNifEnv* env, int argc, const ERL_NIF_T
     if(!enif_inspect_iolist_as_binary(env, argv[0], &key)) {
         return enif_make_badarg(env);
     }
-    if(!enif_get_int(env, argv[1], &count)) {
+    if(!enif_get_double(env, argv[1], &count)) {
         return enif_make_badarg(env);
     }
     if(!enif_get_resource(env, argv[2], appsignal_data_type, (void**) &data_ptr)) {

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -107,10 +107,11 @@ defmodule Appsignal do
   @doc """
   Increment a counter of some metric.
   """
-  @spec increment_counter(String.t(), integer, map) :: :ok
-  def increment_counter(key, count \\ 1, %{} = tags \\ %{}) when is_integer(count) do
+  @spec increment_counter(String.t(), number, map) :: :ok
+  def increment_counter(key, count \\ 1, tags \\ %{})
+  def increment_counter(key, count, %{} = tags) when is_number(count) do
     encoded_tags = Appsignal.Utils.DataEncoder.encode(tags)
-    :ok = Appsignal.Nif.increment_counter(key, count, encoded_tags)
+    :ok = Appsignal.Nif.increment_counter(key, count + 0.0, encoded_tags)
   end
 
   @doc """

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -14,6 +14,8 @@ defmodule AppsignalTest do
     Appsignal.increment_counter("counter")
     Appsignal.increment_counter("counter", 5)
     Appsignal.increment_counter("counter", 5, %{:a => "b"})
+    Appsignal.increment_counter("counter", 5.0)
+    Appsignal.increment_counter("counter", 5.0, %{:a => "b"})
   end
 
   test "add distribution value" do


### PR DESCRIPTION
The extension now uses doubles for all values, update the type mapping.

Fixes #377 
Part of https://github.com/appsignal/appsignal-agent/issues/353