### PR TITLE
Support container memory host metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.9.0 (unreleased)
+* Support memory host metrics collection for containers. PR #395
+
 # 1.8.0
 * Add working_directory_path config option. PR #363
 * Use doubles values in custom metrics functions. PR #384

--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "7859eb4"
+  def version, do: "01362a4"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "7297a066ced652e7ec498eee30b9094586b5d0ce221c84bbb851e2de9d11a39f",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "a33aa14ae9b8c58c379667e7f79807bdc843354baf635abc334a14c3b984114d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "7297a066ced652e7ec498eee30b9094586b5d0ce221c84bbb851e2de9d11a39f",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "a33aa14ae9b8c58c379667e7f79807bdc843354baf635abc334a14c3b984114d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "002b5d27e368444eae4308e97285faa83f13cb2aa25fde32a39000d354649917",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "44d729dd8b3c6bf3041ee32dee1c155bfd19b5309cbf6ef95959fc026819915c",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "002b5d27e368444eae4308e97285faa83f13cb2aa25fde32a39000d354649917",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "44d729dd8b3c6bf3041ee32dee1c155bfd19b5309cbf6ef95959fc026819915c",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "038b14bf3f3cad55e3dfc4947a6eccaf90f2cb15574f2cc69b17f78b20f8075e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "0bb69e60781db9bd0867ccece63a029706cf0d5a26d34d70668bc2264b531ce4",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "038b14bf3f3cad55e3dfc4947a6eccaf90f2cb15574f2cc69b17f78b20f8075e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "0bb69e60781db9bd0867ccece63a029706cf0d5a26d34d70668bc2264b531ce4",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "d968a93822a61d39a62648c2880e52bdb4caba81c567041d27da7a3c848650b7",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "92b3662722978b39176c9d2e986fb8cc527772470dd0d9d7a8ea808cd4780b70",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "669d0876ae3bb5033563c19aed63c298beca3dd4c2d06c3fa27d641c650b8654",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "41624a50b603eeb4f875ee19dde41bb0877a0a039f6f2f560a9efc3d6b73a195",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "9f02f723ceef3f5ebb68f226bb6f188b8f3e07551684b86f3eb37f918d549148",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "14cdca07045a53b2c69647f1255cbc2f9fe322ddf6040c2e1a6ba36aa482cdf2",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "9f02f723ceef3f5ebb68f226bb6f188b8f3e07551684b86f3eb37f918d549148",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "14cdca07045a53b2c69647f1255cbc2f9fe322ddf6040c2e1a6ba36aa482cdf2",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Appsignal.Mixfile do
   def project do
     [
       app: :appsignal,
-      version: "1.8.0",
+      version: "1.9.0-alpha.1",
       name: "AppSignal",
       description: description(),
       package: package(),


### PR DESCRIPTION
## Bump agent to 01362a4

- Support memory host metrics collection for containers. When
  `running_in_container` is set to `true` or detected as such it will
  collect container runtime metrics rather than the container's parent
  host metrics.

PR will be used for the 1.9.0 alpha series to test it out.