### PR TITLE
Use `Mix.shell.info` instead of `Logger.info` in mix helpers

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -6,8 +6,6 @@ defmodule Mix.Appsignal.Helper do
   """
   @os Application.get_env(:appsignal, :os, :os)
 
-  require Logger
-
   @max_retries 5
 
   def verify_system_architecture() do
@@ -21,7 +19,7 @@ defmodule Mix.Appsignal.Helper do
     System.put_env("LIB_DIR", priv_dir())
 
     if has_local_release_files?() do
-      IO.puts "AppSignal: Using local agent release."
+      Mix.shell.info "AppSignal: Using local agent release."
       File.mkdir_p!(priv_dir())
       clean_up_extension_files()
       Enum.each(["appsignal.h", "appsignal-agent", "appsignal.version", "libappsignal.a"], fn(file) ->
@@ -94,7 +92,7 @@ defmodule Mix.Appsignal.Helper do
         {:ok, filename}
 
       false ->
-        Logger.info("Downloading agent release from #{url}")
+        Mix.shell.info("Downloading agent release from #{url}")
         :application.ensure_all_started(:hackney)
 
         case do_download_file!(url, filename, @max_retries) do


### PR DESCRIPTION
From [support](https://app.intercom.io/a/apps/yzor8gyw/inbox/inbox/540654/conversations/18349713842) (private Intercom link).  One of our customers had trouble getting AppSignal to compile while using Distillery’s REPLACE_OS_VARS feature.

When the log_level is set to `:"${LOG_LEVEL}"`, it’s replaced by Distillery. Because that hasn’t happened at compile-time, compiling crashes on `Logger.level_to_number/1`, which doesn’t have a clause for `:"${LOG_LEVEL}"`:

```
==> appsignal
** (FunctionClauseError) no function clause matching in Logger.level_to_number/1 

The following arguments were given to Logger.level_to_number/1:

# 1
:"${LOG_LEVEL}"

(logger) lib/logger.ex:465: Logger.level_to_number/1
(logger) lib/logger.ex:463: Logger.compare_levels/2
(logger) lib/logger.ex:578: Logger.bare_log/3
mix_helpers.exs:97: Mix.Appsignal.Helper.download_file/2
mix_helpers.exs:78: Mix.Appsignal.Helper.download_and_extract/3
mix_helpers.exs:47: Mix.Appsignal.Helper.ensure_downloaded/1
/build/deps/appsignal/mix.exs:9: Mix.Tasks.Compile.Appsignal.run/1
(mix) lib/mix/task.ex:301: Mix.Task.run_task/3
```

This patch uses Mix’s `Mix.shell.info` instead of requiring the `Logger` to be required and using `Logger.info` and `IO.puts`, as Mix is available at compile time, to get around this issue.

**Note**: Based on master to be able to release this as 1.8.1, as develop is on track with 1.9.0-alpha.1.