### PR TITLE
Allow Appsignal.send_error/1-7 to be called without a stack trace

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -148,7 +148,7 @@ defmodule Appsignal do
       end)
   """
   def send_error(reason, message \\ "", stack \\ nil, metadata \\ %{}, conn \\ nil, fun \\ fn(t) -> t end, namespace \\ :http_request) do
-    case stack do
+    stack = case stack do
       nil ->
         IO.warn "Appsignal.send_error/1-7 without passing a stack trace is deprecated, and defaults to passing an empty stacktrace. Please explicitly pass a stack trace or an empty list."
         []


### PR DESCRIPTION
Fixes #396.

Although we don't recommend calling `Appsignal.send_error/1-7` without a stacktrace, and we raise an exception when you do, https://github.com/appsignal/appsignal-elixir/commit/52eee8d84d0f4f23319ea046e53843638bc6e16d introduced a bug which made `send_error/1-7` break when calling it without a stack trace, resulting in the issue described in #396.

