### PR TITLE
Remove unused extension send_params option

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -248,7 +248,6 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")
     Nif.env_put("_APPSIGNAL_RUNNING_IN_CONTAINER", to_string(config[:running_in_container]))
-    Nif.env_put("_APPSIGNAL_SEND_PARAMS", to_string(config[:send_params]))
     Nif.env_put("_APPSIGNAL_WORKING_DIR_PATH", to_string(config[:working_dir_path]))
     Nif.env_put("_APPSIGNAL_WORKING_DIRECTORY_PATH", to_string(config[:working_directory_path]))
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -607,7 +607,6 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_PUSH_API_ENDPOINT") == 'https://push.staging.lol'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_KEY") == '00000000-0000-0000-0000-000000000000'
           assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == 'false'
-          assert Nif.env_get("_APPSIGNAL_SEND_PARAMS") == 'true'
           assert Nif.env_get("_APPSIGNAL_WORKING_DIR_PATH") == '/tmp/appsignal-deprecated'
           assert Nif.env_get("_APPSIGNAL_WORKING_DIRECTORY_PATH") == '/tmp/appsignal'
           assert Nif.env_get("_APPSIGNAL_FILES_WORLD_ACCESSIBLE") == 'false'
@@ -659,7 +658,6 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_ENABLE_HOST_METRICS") == 'true'
           assert Nif.env_get("_APPSIGNAL_ENVIRONMENT") == 'prod'
           assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == 'false'
-          assert Nif.env_get("_APPSIGNAL_SEND_PARAMS") == 'true'
           assert Nif.env_get("_APPSIGNAL_FILES_WORLD_ACCESSIBLE") == 'false'
         end
       )


### PR DESCRIPTION
It's not used for the config in the extension, so remove it to avoid
confusion.