### PR TITLE
Link gcc to extension .so library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIB_NAME = libappsignal.a
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
 CFLAGS = -g -O3 -pedantic -Wall -Wextra -I"$(ERLANG_PATH)" -I"$(LIB_DIR)"
 ifeq ($(shell uname),Linux)
-	LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive
+	LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive -static-libgcc
 else
 	LDFLAGS = "$(LIB_DIR)"/$(LIB_NAME)
 endif


### PR DESCRIPTION
This fixes the missing `libgcc_s.so` error on AppSignal boot on musl
builds with a two stage deploy.

```
Error loading shared library libgcc_s.so.1: No such file or directory
(needed by /app/lib/appsignal-1.8.1-beta.2/priv/appsignal_extension.so)
```

This was caused by the 1.8 build having more dynamically linked
dependencies than the previous build. This was `libgcc_s`. Since it's
only available as a shared object file (`.so`) we can't specify
`-static` as an option to gcc. Instead, we need to add the
`-static-libgcc` option. Docs:
http://gcc.gnu.org/onlinedocs/gcc/Link-Options.html (search for
`-static-libgcc`).

Fixes:
https://docs.appsignal.com/support/known-issues/compilation-dependencies-required-at-runtime.html

For more information (private issue):
https://github.com/appsignal/appsignal-agent/issues/375

## TODO

- [x] ~Musl only flag for this option~ `libgcc_s` is also required for GNU builds.
- [x] Failing tests seem unrelated, but why are they failing? - Fixed on `develop` according to Jeff - Fix backported to master
- [x] Send this branch to users with this issue so they can test. See https://github.com/appsignal/appsignal-agent/issues/375