### PR TITLE
Create separate modules for testing Appsignal.Phoenix.Channel

### DIFF
--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -1,4 +1,4 @@
-defmodule UsingAppsignalPhoenixChannel do
+defmodule DecoratedPhoenixChannel do
   import Appsignal.Phoenix.Channel, only: [channel_action: 5]
   use Appsignal.Instrumentation.Decorators
 
@@ -6,11 +6,11 @@ defmodule UsingAppsignalPhoenixChannel do
   def handle_in("decorated", payload, socket) do
     {:reply, {:ok, payload}, socket}
   end
+end
 
-  @decorate channel_action()
-  def handle_in("decorated_with_unbound_payload", _, socket) do
-    {:reply, :ok, socket}
-  end
+defmodule InstrumentedPhoenixChannel do
+  import Appsignal.Phoenix.Channel, only: [channel_action: 5]
+  use Appsignal.Instrumentation.Decorators
 
   def handle_in("instrumented" = action, payload, socket) do
     channel_action(__MODULE__, action, socket, payload, fn ->
@@ -40,12 +40,15 @@ defmodule Appsignal.Phoenix.ChannelTest do
     ]
   end
 
-  test "instruments a channel action with a decorator", %{socket: socket, fake_transaction: fake_transaction} do
-    UsingAppsignalPhoenixChannel.handle_in("decorated", %{"body" => "Hello, world!"}, socket)
+  test "instruments a channel action with a decorator", %{
+    socket: socket,
+    fake_transaction: fake_transaction
+  } do
+    DecoratedPhoenixChannel.handle_in("decorated", %{"body" => "Hello, world!"}, socket)
 
     assert [{"123", :channel}] == FakeTransaction.started_transactions(fake_transaction)
-    assert "UsingAppsignalPhoenixChannel#decorated"
-      == FakeTransaction.action(fake_transaction)
+    assert "DecoratedPhoenixChannel#decorated" == FakeTransaction.action(fake_transaction)
+
     assert %{
       "environment" => %{
         channel: PhoenixChatExampleWeb.RoomChannel,
@@ -62,11 +65,15 @@ defmodule Appsignal.Phoenix.ChannelTest do
     assert [%Appsignal.Transaction{id: "123"}] = FakeTransaction.completed_transactions(fake_transaction)
   end
 
-  test "instruments a channel action with an instrumentation helper", %{socket: socket, fake_transaction: fake_transaction} do
-    UsingAppsignalPhoenixChannel.handle_in("instrumented", %{"body" => "Hello, world!"}, socket)
+  test "instruments a channel action with an instrumentation helper", %{
+    socket: socket,
+    fake_transaction: fake_transaction
+  } do
+    InstrumentedPhoenixChannel.handle_in("instrumented", %{"body" => "Hello, world!"}, socket)
 
     assert [{"123", :channel}] == FakeTransaction.started_transactions(fake_transaction)
-    assert "UsingAppsignalPhoenixChannel#instrumented" == FakeTransaction.action(fake_transaction)
+    assert "InstrumentedPhoenixChannel#instrumented" == FakeTransaction.action(fake_transaction)
+
     assert %{
       "environment" => %{
         channel: PhoenixChatExampleWeb.RoomChannel,
@@ -84,8 +91,8 @@ defmodule Appsignal.Phoenix.ChannelTest do
   end
 
   test "filters parameters", %{socket: socket, fake_transaction: fake_transaction} do
-    AppsignalTest.Utils.with_config(%{filter_parameters: ["password"]}, fn() ->
-      UsingAppsignalPhoenixChannel.handle_in("instrumented", %{"password" => "secret"}, socket)
+    AppsignalTest.Utils.with_config(%{filter_parameters: ["password"]}, fn ->
+      InstrumentedPhoenixChannel.handle_in("instrumented", %{"password" => "secret"}, socket)
       assert "[FILTERED]" == FakeTransaction.sample_data(fake_transaction)["params"]["password"]
     end)
   end


### PR DESCRIPTION
Fixes test failures on Decorator 1.2.4 on develop.

Co-authored-by: Jeff Kreeftmeijer <jeffkreeftmeijer@gmail.com>

PR only for build.