### PR TITLE
Pretty print lists in diagnose output

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -107,9 +107,15 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   defp print_configuration(config) do
     IO.puts "Configuration"
 
-    Enum.each config, fn({key, value}) ->
-      IO.puts "  #{key}: #{value}"
-    end
+    Enum.each config, &print_configuration_option/1
+  end
+
+  defp print_configuration_option({key, value}) when is_list(value) do
+    IO.puts "  #{key}: #{Enum.join(value, ", ")}"
+  end
+
+  defp print_configuration_option({key, value}) do
+    IO.puts "  #{key}: #{value}"
   end
 
   defp print_validation(validation_report) do

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -457,12 +457,25 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     end
   end
 
-  test "outputs configuration" do
-    output = run()
-    assert String.contains? output, "Configuration"
+  describe "configuration" do
+    test "outputs configuration with string values" do
+      output = run()
+      assert String.contains? output, "Configuration"
 
-    Enum.each Application.get_env(:appsignal, :config), fn({key, value}) ->
-      assert String.contains? output, "  #{key}: #{value}"
+      config = Application.get_env(:appsignal, :config)
+               |> Enum.filter(fn({_, value}) -> !is_list(value) end)
+      Enum.each config, fn({key, value}) ->
+        assert String.contains? output, "  #{key}: #{value}"
+      end
+    end
+
+    test "outputs configuration with array values" do
+      output = run()
+      config = Application.get_env(:appsignal, :config)
+               |> Enum.filter(fn({_, value}) -> is_list(value) end)
+      Enum.each config, fn({key, value}) ->
+        assert String.contains? output, "  #{key}: #{Enum.join(value, ", ")}"
+      end
     end
   end
 


### PR DESCRIPTION
By default the list values are printed right after one another, which
makes for unreadable output.

```
request_headers: acceptaccept-charsetaccept-encoding
```

This change joins the list and makes it a comma separated printed list
in the diagnose output.

```
request_headers: accept, accept-charset, accept-encoding
```

Fixes https://github.com/appsignal/appsignal-elixir/issues/379