### PR TITLE
Add new agent & extension diagnose report keys 

### DIFF
--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "1bd6660"
+  def version, do: "0830491"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "77371d3bc0a2933755ad637d5fad4b5695b7c509335a36d91c367e7de226a9c5",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "e54dc97f43781c0227b2f15640060c7318153564105f48b835956a0a00271d7e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "77371d3bc0a2933755ad637d5fad4b5695b7c509335a36d91c367e7de226a9c5",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "e54dc97f43781c0227b2f15640060c7318153564105f48b835956a0a00271d7e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "f256cda20f7b614d5286645257bf3d6861a106251c9c9ff009aa49582fc59231",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "5d07d9ef6273c02328dd96334d69f8809ea00cd1e2f09b2ffa6765b530029b10",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "f256cda20f7b614d5286645257bf3d6861a106251c9c9ff009aa49582fc59231",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "5d07d9ef6273c02328dd96334d69f8809ea00cd1e2f09b2ffa6765b530029b10",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "f6290a6ccd8a700af66720fa5e99a99265c3f76f64fb841919a7ce061b04e7cc",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "cc30d74b5f80ce334699459e69d38788156633e95343d448f1f16af3d06c4819",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "f6290a6ccd8a700af66720fa5e99a99265c3f76f64fb841919a7ce061b04e7cc",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "cc30d74b5f80ce334699459e69d38788156633e95343d448f1f16af3d06c4819",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "e2e91a85296bd68718e59cc72a27a224b399bd87ca309e562d1b27cc408c6c40",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "dbbf73b16afd49670f7ec4fd574ed17510c1c96d073faee1d496f56b49bc7515",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "dff3eebc7bc3453984e1c58d8f11ae28fbf352561f44946cd1b381387c499a5a",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "e0591c948590b6ef96b243a826dd176ec4466f326eef44b71a2a4322d9b6358d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "27806c713ce7d594cf32bc290cc2aafdbbd604a2ee9b6edee7d19e8adb029792",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "f5e75c689cc25ec37315fb68c0c4d849f1b9987e675272652cb6ce3b3d785257",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "27806c713ce7d594cf32bc290cc2aafdbbd604a2ee9b6edee7d19e8adb029792",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "f5e75c689cc25ec37315fb68c0c4d849f1b9987e675272652cb6ce3b3d785257",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -45,10 +45,22 @@ defmodule Appsignal.Diagnose.Agent do
 
   defp print_test(report, definition) do
     IO.write "  #{definition[:label]}: "
-    case Map.fetch(definition[:values], report["result"]) do
-      {:ok, value} -> IO.puts value
-      :error -> IO.puts "-"
-    end
+    result = report["result"]
+    display_value =
+      case Map.has_key?(definition, :values) do
+        true ->
+          case Map.fetch(definition[:values], report["result"]) do
+            {:ok, value} -> value
+            :error -> nil
+          end
+        false -> result
+      end
+    display_value =
+      case display_value do
+        value when value in [nil, ""] -> "-"
+        value -> value
+      end
+    IO.puts display_value
     if report["error"], do: IO.puts "    Error: #{report["error"]}"
     if report["output"], do: IO.puts "    Output: #{report["output"]}"
   end
@@ -70,6 +82,10 @@ defmodule Appsignal.Diagnose.Agent do
             :values => %{ true => "started", false => "not started" }
           }
         },
+        "host" => %{
+          "uid" => %{ :label => "Agent user id" },
+          "gid" => %{ :label => "Agent user group id" }
+        },
         "config" => %{
           "valid" => %{
             :label => "Agent config",
@@ -81,6 +97,11 @@ defmodule Appsignal.Diagnose.Agent do
             :label => "Agent logger",
             :values => %{ true => "started", false => "not started" }
           }
+        },
+        "working_directory_stat" => %{
+          "uid" => %{ :label => "Agent working directory user id" },
+          "gid" => %{ :label => "Agent working directory user group id" },
+          "mode" => %{ :label => "Agent working directory permissions" }
         },
         "lock_path" => %{
           "created" => %{

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -24,8 +24,9 @@ defmodule Appsignal.Diagnose.Agent do
     if report["error"] do
       IO.puts "  Error: #{report["error"]}"
     else
-      Enum.each(report_definition(), fn({component, categories}) ->
-        print_component(report[component] || %{}, categories)
+      Enum.each(report_definition(), fn({component, definition}) ->
+        IO.puts "  #{definition[:label]}"
+        print_component(report[component] || %{}, definition[:tests])
       end)
     end
     IO.puts ""
@@ -44,7 +45,7 @@ defmodule Appsignal.Diagnose.Agent do
   end
 
   defp print_test(report, definition) do
-    IO.write "  #{definition[:label]}: "
+    IO.write "    #{definition[:label]}: "
     result = report["result"]
     display_value =
       case Map.has_key?(definition, :values) do
@@ -61,52 +62,58 @@ defmodule Appsignal.Diagnose.Agent do
         value -> value
       end
     IO.puts display_value
-    if report["error"], do: IO.puts "    Error: #{report["error"]}"
-    if report["output"], do: IO.puts "    Output: #{report["output"]}"
+    if report["error"], do: IO.puts "      Error: #{report["error"]}"
+    if report["output"], do: IO.puts "      Output: #{report["output"]}"
   end
 
   defp report_definition do
     %{
       "extension" => %{
-        "config" => %{
-          "valid" => %{
-            :label => "Extension config",
-            :values => %{ true => "valid", false => "invalid" }
+        :label => "Extension tests",
+        :tests => %{
+          "config" => %{
+            "valid" => %{
+              :label => "Configuration",
+              :values => %{ true => "valid", false => "invalid" }
+            }
           }
         }
       },
       "agent" => %{
-        "boot" => %{
-          "started" => %{
-            :label => "Agent started",
-            :values => %{ true => "started", false => "not started" }
-          }
-        },
-        "host" => %{
-          "uid" => %{ :label => "Agent user id" },
-          "gid" => %{ :label => "Agent user group id" }
-        },
-        "config" => %{
-          "valid" => %{
-            :label => "Agent config",
-            :values => %{ true => "valid", false => "invalid" }
-          }
-        },
-        "logger" => %{
-          "started" => %{
-            :label => "Agent logger",
-            :values => %{ true => "started", false => "not started" }
-          }
-        },
-        "working_directory_stat" => %{
-          "uid" => %{ :label => "Agent working directory user id" },
-          "gid" => %{ :label => "Agent working directory user group id" },
-          "mode" => %{ :label => "Agent working directory permissions" }
-        },
-        "lock_path" => %{
-          "created" => %{
-            :label => "Agent lock path",
-            :values => %{ true => "writable", false => "not writable" }
+        :label => "Agent tests",
+        :tests => %{
+          "boot" => %{
+            "started" => %{
+              :label => "Started",
+              :values => %{ true => "started", false => "not started" }
+            }
+          },
+          "host" => %{
+            "uid" => %{ :label => "Process user id" },
+            "gid" => %{ :label => "Process user group id" }
+          },
+          "config" => %{
+            "valid" => %{
+              :label => "Configuration",
+              :values => %{ true => "valid", false => "invalid" }
+            }
+          },
+          "logger" => %{
+            "started" => %{
+              :label => "Logger",
+              :values => %{ true => "started", false => "not started" }
+            }
+          },
+          "working_directory_stat" => %{
+            "uid" => %{ :label => "Working directory user id" },
+            "gid" => %{ :label => "Working directory user group id" },
+            "mode" => %{ :label => "Working directory permissions" }
+          },
+          "lock_path" => %{
+            "created" => %{
+              :label => "Lock path",
+              :values => %{ true => "writable", false => "not writable" }
+            }
           }
         }
       }

--- a/lib/appsignal/system.ex
+++ b/lib/appsignal/system.ex
@@ -38,6 +38,4 @@ defmodule Appsignal.System do
       {:error, _} -> nil
     end
   end
-
-
 end

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -280,16 +280,17 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     output = run()
     {:ok, working_directory_stat} = File.stat("/tmp/appsignal")
     assert String.contains? output, "Agent diagnostics"
-    assert String.contains? output, "  Extension config: valid"
-    assert String.contains? output, "  Agent started: started"
-    assert String.contains? output, "  Agent user id: #{process_uid()}"
-    assert String.contains? output, "  Agent user group id: #{process_gid()}"
-    assert String.contains? output, "  Agent config: valid"
-    assert String.contains? output, "  Agent logger: started"
-    assert String.contains? output, "  Agent working directory user id: #{working_directory_stat.uid}"
-    assert String.contains? output, "  Agent working directory user group id: #{working_directory_stat.gid}"
-    assert String.contains? output, "  Agent working directory permissions: #{working_directory_stat.mode}"
-    assert String.contains? output, "  Agent lock path: writable"
+    assert String.contains? output, "  Extension tests\n    Configuration: valid"
+    assert String.contains? output, "  Agent tests"
+    assert String.contains? output, "    Started: started\n" <>
+      "    Configuration: valid"
+    assert String.contains? output, "    Process user id: #{process_uid()}"
+    assert String.contains? output, "    Process user group id: #{process_gid()}"
+    assert String.contains? output, "    Logger: started"
+    assert String.contains? output, "    Working directory user id: #{working_directory_stat.uid}"
+    assert String.contains? output, "    Working directory user group id: #{working_directory_stat.gid}"
+    assert String.contains? output, "    Working directory permissions: #{working_directory_stat.mode}"
+    assert String.contains? output, "    Lock path: writable"
   end
 
   @tag :skip_env_test_no_nif
@@ -326,13 +327,20 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       FakeNif.update(fake_nif, :run_diagnose, true)
 
       output = with_config(%{active: false}, &run/0)
+      {:ok, working_directory_stat} = File.stat("/tmp/appsignal")
       assert String.contains? output, "active: false"
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "  Extension config: valid"
-      assert String.contains? output, "  Agent started: started"
-      assert String.contains? output, "  Agent config: valid"
-      assert String.contains? output, "  Agent lock path: writable"
-      assert String.contains? output, "  Agent logger: started"
+      assert String.contains? output, "  Extension tests\n    Configuration: valid"
+      assert String.contains? output, "  Agent tests"
+      assert String.contains? output, "    Started: started\n" <>
+        "    Configuration: valid"
+      assert String.contains? output, "    Process user id: #{process_uid()}"
+      assert String.contains? output, "    Process user group id: #{process_gid()}"
+      assert String.contains? output, "    Logger: started"
+      assert String.contains? output, "    Working directory user id: #{working_directory_stat.uid}"
+      assert String.contains? output, "    Working directory user group id: #{working_directory_stat.gid}"
+      assert String.contains? output, "    Working directory permissions: #{working_directory_stat.mode}"
+      assert String.contains? output, "    Lock path: writable"
     end
 
     @tag :skip_env_test_no_nif
@@ -414,11 +422,17 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "agent diagnostics report prints the tests, but shows a dash `-` for missed results" do
       output = run()
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "  Extension config: valid"
-      assert String.contains? output, "  Agent started: -"
-      assert String.contains? output, "  Agent config: -"
-      assert String.contains? output, "  Agent lock path: -"
-      assert String.contains? output, "  Agent logger: -"
+      assert String.contains? output, "  Extension tests\n    Configuration: valid"
+      assert String.contains? output, "  Agent tests"
+      assert String.contains? output, "    Started: -"
+      assert String.contains? output, "    Configuration: -"
+      assert String.contains? output, "    Process user id: -"
+      assert String.contains? output, "    Process user group id: -"
+      assert String.contains? output, "    Lock path: -"
+      assert String.contains? output, "    Logger: -"
+      assert String.contains? output, "    Working directory user id: -"
+      assert String.contains? output, "    Working directory user group id: -"
+      assert String.contains? output, "    Working directory permissions: -"
     end
 
     test "missings tests are not added to report", %{fake_report: fake_report} do
@@ -462,7 +476,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "prints the error" do
       output = run()
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "  Agent started: not started\n    Error: my error"
+      assert String.contains? output, "  Started: not started\n      Error: my error"
     end
   end
 
@@ -479,7 +493,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "prints the output" do
       output = run()
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "  Agent started: not started\n    Output: my output"
+      assert String.contains? output, "  Started: not started\n      Output: my output"
     end
   end
 


### PR DESCRIPTION
Support display of new agent & extension diagnose report keys and
values. Drop the requirement of boolean values. If no value display
method is found, show the raw value.

Closes #411 