### PR TITLE
Group extension and agent tests in diagnose output

### DIFF
--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -24,8 +24,9 @@ defmodule Appsignal.Diagnose.Agent do
     if report["error"] do
       IO.puts "  Error: #{report["error"]}"
     else
-      Enum.each(report_definition(), fn({component, categories}) ->
-        print_component(report[component] || %{}, categories)
+      Enum.each(report_definition(), fn({component, definition}) ->
+        IO.puts "  #{definition[:label]}"
+        print_component(report[component] || %{}, definition[:tests])
       end)
     end
     IO.puts ""
@@ -44,7 +45,7 @@ defmodule Appsignal.Diagnose.Agent do
   end
 
   defp print_test(report, definition) do
-    IO.write "  #{definition[:label]}: "
+    IO.write "    #{definition[:label]}: "
     result = report["result"]
     display_value =
       case Map.has_key?(definition, :values) do
@@ -61,52 +62,58 @@ defmodule Appsignal.Diagnose.Agent do
         value -> value
       end
     IO.puts display_value
-    if report["error"], do: IO.puts "    Error: #{report["error"]}"
-    if report["output"], do: IO.puts "    Output: #{report["output"]}"
+    if report["error"], do: IO.puts "      Error: #{report["error"]}"
+    if report["output"], do: IO.puts "      Output: #{report["output"]}"
   end
 
   defp report_definition do
     %{
       "extension" => %{
-        "config" => %{
-          "valid" => %{
-            :label => "Extension config",
-            :values => %{ true => "valid", false => "invalid" }
+        :label => "Extension tests",
+        :tests => %{
+          "config" => %{
+            "valid" => %{
+              :label => "Configuration",
+              :values => %{ true => "valid", false => "invalid" }
+            }
           }
         }
       },
       "agent" => %{
-        "boot" => %{
-          "started" => %{
-            :label => "Agent started",
-            :values => %{ true => "started", false => "not started" }
-          }
-        },
-        "host" => %{
-          "uid" => %{ :label => "Agent user id" },
-          "gid" => %{ :label => "Agent user group id" }
-        },
-        "config" => %{
-          "valid" => %{
-            :label => "Agent config",
-            :values => %{ true => "valid", false => "invalid" }
-          }
-        },
-        "logger" => %{
-          "started" => %{
-            :label => "Agent logger",
-            :values => %{ true => "started", false => "not started" }
-          }
-        },
-        "working_directory_stat" => %{
-          "uid" => %{ :label => "Agent working directory user id" },
-          "gid" => %{ :label => "Agent working directory user group id" },
-          "mode" => %{ :label => "Agent working directory permissions" }
-        },
-        "lock_path" => %{
-          "created" => %{
-            :label => "Agent lock path",
-            :values => %{ true => "writable", false => "not writable" }
+        :label => "Agent tests",
+        :tests => %{
+          "boot" => %{
+            "started" => %{
+              :label => "Started",
+              :values => %{ true => "started", false => "not started" }
+            }
+          },
+          "host" => %{
+            "uid" => %{ :label => "Process user id" },
+            "gid" => %{ :label => "Process user group id" }
+          },
+          "config" => %{
+            "valid" => %{
+              :label => "Configuration",
+              :values => %{ true => "valid", false => "invalid" }
+            }
+          },
+          "logger" => %{
+            "started" => %{
+              :label => "Logger",
+              :values => %{ true => "started", false => "not started" }
+            }
+          },
+          "working_directory_stat" => %{
+            "uid" => %{ :label => "Working directory user id" },
+            "gid" => %{ :label => "Working directory user group id" },
+            "mode" => %{ :label => "Working directory permissions" }
+          },
+          "lock_path" => %{
+            "created" => %{
+              :label => "Lock path",
+              :values => %{ true => "writable", false => "not writable" }
+            }
           }
         }
       }

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -280,16 +280,17 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     output = run()
     {:ok, working_directory_stat} = File.stat("/tmp/appsignal")
     assert String.contains? output, "Agent diagnostics"
-    assert String.contains? output, "  Extension config: valid"
-    assert String.contains? output, "  Agent started: started"
-    assert String.contains? output, "  Agent user id: #{process_uid()}"
-    assert String.contains? output, "  Agent user group id: #{process_gid()}"
-    assert String.contains? output, "  Agent config: valid"
-    assert String.contains? output, "  Agent logger: started"
-    assert String.contains? output, "  Agent working directory user id: #{working_directory_stat.uid}"
-    assert String.contains? output, "  Agent working directory user group id: #{working_directory_stat.gid}"
-    assert String.contains? output, "  Agent working directory permissions: #{working_directory_stat.mode}"
-    assert String.contains? output, "  Agent lock path: writable"
+    assert String.contains? output, "  Extension tests\n    Configuration: valid"
+    assert String.contains? output, "  Agent tests"
+    assert String.contains? output, "    Started: started\n" <>
+      "    Configuration: valid"
+    assert String.contains? output, "    Process user id: #{process_uid()}"
+    assert String.contains? output, "    Process user group id: #{process_gid()}"
+    assert String.contains? output, "    Logger: started"
+    assert String.contains? output, "    Working directory user id: #{working_directory_stat.uid}"
+    assert String.contains? output, "    Working directory user group id: #{working_directory_stat.gid}"
+    assert String.contains? output, "    Working directory permissions: #{working_directory_stat.mode}"
+    assert String.contains? output, "    Lock path: writable"
   end
 
   @tag :skip_env_test_no_nif
@@ -326,13 +327,20 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       FakeNif.update(fake_nif, :run_diagnose, true)
 
       output = with_config(%{active: false}, &run/0)
+      {:ok, working_directory_stat} = File.stat("/tmp/appsignal")
       assert String.contains? output, "active: false"
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "  Extension config: valid"
-      assert String.contains? output, "  Agent started: started"
-      assert String.contains? output, "  Agent config: valid"
-      assert String.contains? output, "  Agent lock path: writable"
-      assert String.contains? output, "  Agent logger: started"
+      assert String.contains? output, "  Extension tests\n    Configuration: valid"
+      assert String.contains? output, "  Agent tests"
+      assert String.contains? output, "    Started: started\n" <>
+        "    Configuration: valid"
+      assert String.contains? output, "    Process user id: #{process_uid()}"
+      assert String.contains? output, "    Process user group id: #{process_gid()}"
+      assert String.contains? output, "    Logger: started"
+      assert String.contains? output, "    Working directory user id: #{working_directory_stat.uid}"
+      assert String.contains? output, "    Working directory user group id: #{working_directory_stat.gid}"
+      assert String.contains? output, "    Working directory permissions: #{working_directory_stat.mode}"
+      assert String.contains? output, "    Lock path: writable"
     end
 
     @tag :skip_env_test_no_nif
@@ -414,11 +422,17 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "agent diagnostics report prints the tests, but shows a dash `-` for missed results" do
       output = run()
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "  Extension config: valid"
-      assert String.contains? output, "  Agent started: -"
-      assert String.contains? output, "  Agent config: -"
-      assert String.contains? output, "  Agent lock path: -"
-      assert String.contains? output, "  Agent logger: -"
+      assert String.contains? output, "  Extension tests\n    Configuration: valid"
+      assert String.contains? output, "  Agent tests"
+      assert String.contains? output, "    Started: -"
+      assert String.contains? output, "    Configuration: -"
+      assert String.contains? output, "    Process user id: -"
+      assert String.contains? output, "    Process user group id: -"
+      assert String.contains? output, "    Lock path: -"
+      assert String.contains? output, "    Logger: -"
+      assert String.contains? output, "    Working directory user id: -"
+      assert String.contains? output, "    Working directory user group id: -"
+      assert String.contains? output, "    Working directory permissions: -"
     end
 
     test "missings tests are not added to report", %{fake_report: fake_report} do
@@ -462,7 +476,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "prints the error" do
       output = run()
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "  Agent started: not started\n    Error: my error"
+      assert String.contains? output, "  Started: not started\n      Error: my error"
     end
   end
 
@@ -479,7 +493,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "prints the output" do
       output = run()
       assert String.contains? output, "Agent diagnostics"
-      assert String.contains? output, "  Agent started: not started\n    Output: my output"
+      assert String.contains? output, "  Started: not started\n      Output: my output"
     end
   end
 


### PR DESCRIPTION
So we don't have to repeat "Agent|Extension" before every test label.

PR only for build.

Related PR https://github.com/appsignal/appsignal-ruby/pull/437