### PR TITLE
Add Appsignal.Ecto.handle_event/4

### DIFF
--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -17,6 +17,10 @@ defmodule Appsignal.Ecto do
 
   @nano_seconds :erlang.convert_time_unit(1, :nano_seconds, :native)
 
+  def handle_event(_event, _latency, metadata, _config) do
+    log(metadata)
+  end
+
   def log(entry) do
     # See if we have a transaction registered for the current process
     case TransactionRegistry.lookup(self()) do


### PR DESCRIPTION
Adds Telemetry support for Ecto 3.0. Instead of adding `Ecto.Appsignal`
to the :loggers configuration, which is deprecated in 3.x, attach to
Telemetry events instead:

    Telemetry.attach("appsignal-ecto", [:appsignal_phoenix_example, :repo, :query], Appsignal.Ecto, :handle_event, nil)

Closes #415.