### PR TITLE
Add missing host OS field to diagnose report

### DIFF
--- a/lib/appsignal/diagnose/host.ex
+++ b/lib/appsignal/diagnose/host.ex
@@ -3,10 +3,13 @@ defmodule Appsignal.Diagnose.Host do
   @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   def info do
+    {_, os} = :os.type()
+
     %{
       architecture: to_string(:erlang.system_info(:system_architecture)),
       language_version: System.version(),
       otp_version: System.otp_release(),
+      os: os,
       heroku: @system.heroku?,
       root: @system.root?,
       running_in_container: @nif.running_in_container?

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -97,6 +97,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("  Architecture: #{host_report[:architecture]}")
     IO.puts("  Elixir version: #{host_report[:language_version]}")
     IO.puts("  OTP version: #{host_report[:otp_version]}")
+    IO.puts("  Operating System: #{host_report[:os]}")
     root_user = if host_report[:root], do: "yes (not recommended)", else: "no"
     IO.puts("  root user: #{root_user}")
 

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -126,6 +126,8 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert String.contains?(output, "Architecture: #{:erlang.system_info(:system_architecture)}")
     assert String.contains?(output, "Elixir version: #{System.version()}")
     assert String.contains?(output, "OTP version: #{System.otp_release()}")
+    {_, os} = :os.type()
+    assert String.contains?(output, "Operating System: #{os}")
   end
 
   test "adds host information to report", %{fake_report: fake_report} do
@@ -135,10 +137,13 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       received_report(fake_report)[:host]
       |> Map.drop([:root, :running_in_container])
 
+    {_, os} = :os.type()
+
     assert report == %{
              architecture: to_string(:erlang.system_info(:system_architecture)),
              language_version: System.version(),
              otp_version: System.otp_release(),
+             os: os,
              heroku: false
            }
   end


### PR DESCRIPTION
This field was missing from the report. Add it to the Elixir diagnose
report as well.