### PR TITLE
Link back to AppSignal diagnose report page

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -184,9 +184,9 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("  Do you want to send this diagnostics report to AppSignal?")
 
     IO.puts(
-      "  If you share this diagnostics report you will be given\n" <>
-        "  a support token you can use to refer to your diagnotics \n" <>
-        "  report when you contact us at support@appsignal.com\n"
+      "  If you share this report you will be given a link to \n" <>
+        "  AppSignal.com to validate the report.\n" <>
+        "  You can also contact us at support@appsignal.com\n  with your support token.\n\n"
     )
 
     answer =
@@ -216,8 +216,8 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   def send_report_to_appsignal(config, report) do
     case @report.send(config, report) do
       {:ok, support_token} ->
-        IO.puts("  Your diagnostics report has been sent to AppSignal.")
         IO.puts("  Your support token: #{support_token}")
+        IO.puts("  View this report:   https://appsignal.com/diagnose/#{support_token}")
 
       {:error, %{status_code: 200, body: body}} ->
         IO.puts("  Error: Couldn't decode server response.")

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -353,7 +353,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       assert String.contains?(output, "Agent diagnostics")
       assert String.contains?(output, "  Extension tests\n    Configuration: valid")
       assert String.contains?(output, "  Agent tests")
-      assert String.contains?(output, "    Started: started\n" <> "    Configuration: valid")
+      assert String.contains?(output, "    Started: started\n    Configuration: valid")
       assert String.contains?(output, "    Process user id: #{process_uid()}")
       assert String.contains?(output, "    Process user group id: #{process_gid()}")
       assert String.contains?(output, "    Logger: started")
@@ -786,13 +786,18 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "sends diagnostics report to AppSignal and outputs a support token", %{
       fake_report: fake_report
     } do
-      assert FakeReport.update(fake_report, :response, {:ok, "0123456789abcdef"})
+      token = "0123456789abcdef"
+      assert FakeReport.update(fake_report, :response, {:ok, token})
       output = run()
       assert String.contains?(output, "Diagnostics report")
       assert String.contains?(output, "Send diagnostics report to AppSignal? (Y/n):")
       assert String.contains?(output, "Transmitting diagnostics report")
-      assert String.contains?(output, "Your diagnostics report has been sent to AppSignal.")
-      assert String.contains?(output, "Your support token: 0123456789abcdef")
+      assert String.contains?(output, "Your support token: #{token}")
+
+      assert String.contains?(
+               output,
+               "View this report:   https://appsignal.com/diagnose/#{token}"
+             )
 
       assert FakeReport.get(fake_report, :report_sent?)
       assert received_report(fake_report)
@@ -817,7 +822,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
       assert String.contains?(
                output,
-               "Error: Something went wrong while submitting the report " <> "to AppSignal."
+               "Error: Something went wrong while submitting the report to AppSignal."
              )
 
       assert String.contains?(output, "Response code: 500")
@@ -833,7 +838,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
       assert String.contains?(
                output,
-               "Error: Something went wrong while submitting the report " <> "to AppSignal.\nfoo"
+               "Error: Something went wrong while submitting the report to AppSignal.\nfoo"
              )
     end
   end
@@ -859,13 +864,18 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "sends diagnostics report to AppSignal and outputs a support token", %{
       fake_report: fake_report
     } do
-      assert FakeReport.update(fake_report, :response, {:ok, "0123456789abcdef"})
+      token = "0123456789abcdef"
+      assert FakeReport.update(fake_report, :response, {:ok, token})
       output = run(["--send-report"])
       assert String.contains?(output, "Diagnostics report")
       assert String.contains?(output, "Confirmed sending report using --send-report option.")
       assert String.contains?(output, "Transmitting diagnostics report")
-      assert String.contains?(output, "Your diagnostics report has been sent to AppSignal.")
-      assert String.contains?(output, "Your support token: 0123456789abcdef")
+      assert String.contains?(output, "Your support token: #{token}")
+
+      assert String.contains?(
+               output,
+               "View this report:   https://appsignal.com/diagnose/#{token}"
+             )
 
       assert FakeReport.get(fake_report, :report_sent?)
       assert received_report(fake_report)


### PR DESCRIPTION
When a user sends a report our way we link back to the AppSignal
diagnose report view page. Initially users will be able to "claim" their
report, so we know who to contact.

Step 2 is making our report validator public so users can see any
validation failures and start debugging themselves, but already keep the
message as such for now so we don't have to ship a new release with an
updated message.

Diagnose CLI updated to match the Ruby gem's output.
https://github.com/appsignal/appsignal-ruby/pull/445

Part of https://github.com/appsignal/appsignal-server/issues/3601