### PR TITLE
Add config option sources to diagnose report

### DIFF
--- a/lib/appsignal/diagnose/config.ex
+++ b/lib/appsignal/diagnose/config.ex
@@ -1,0 +1,12 @@
+defmodule Appsignal.Diagnose.Config do
+  alias Appsignal.Config
+
+  def config() do
+    sources = Application.get_env(:appsignal, :config_sources, %{})
+
+    %{
+      options: Application.get_env(:appsignal, :config),
+      sources: sources
+    }
+  end
+end

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -153,10 +153,23 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   end
 
   defp configuration_option_source_label(key, sources, option_sources) do
+    max_source_label_length =
+      sources
+      |> Enum.map(fn source ->
+        source
+        |> to_string
+        |> String.length()
+      end)
+      |> Enum.max()
+
+    # + 1 to account for the : symbol
+    max_source_label_length = max_source_label_length + 1
+
     sources_label =
       sources
       |> Enum.map(fn source ->
-        "      #{source}: #{option_sources[source][key]}"
+        label = String.pad_trailing("#{source}:", max_source_label_length)
+        "      #{label} #{option_sources[source][key]}"
       end)
       |> Enum.join("\n")
 

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -20,7 +20,10 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     Application.load(:appsignal)
     report = %{process: %{uid: @system.uid}}
     configure_appsignal()
-    config = Application.get_env(:appsignal, :config)
+    config_report = Diagnose.Config.config()
+    config = config_report[:options]
+    report = Map.put(report, :config, config_report)
+
     header()
     empty_line()
 
@@ -52,8 +55,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
           Map.put(report, :agent, %{output: raw_report})
       end
 
-    report = Map.put(report, :config, config)
-    print_configuration(config)
+    print_configuration(config_report)
     empty_line()
 
     validation_report = Diagnose.Validation.validate(config)
@@ -120,15 +122,55 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   defp print_configuration(config) do
     IO.puts("Configuration")
 
-    Enum.each(config, &print_configuration_option/1)
+    Enum.each(config[:options], fn {key, _} = option ->
+      config_label = configuration_option_label(option)
+      option_sources = config[:sources]
+      sources = sources_for_option(key, option_sources)
+      sources_label = configuration_option_source_label(key, sources, option_sources)
+      IO.puts("#{config_label}#{sources_label}")
+    end)
+
+    IO.puts(
+      "\nRead more about how the diagnose config output is rendered\n" <>
+        "https://docs.appsignal.com/elixir/command-line/diagnose.html"
+    )
   end
 
-  defp print_configuration_option({key, value}) when is_list(value) do
-    IO.puts("  #{key}: #{Enum.join(value, ", ")}")
+  defp configuration_option_label({key, value}) when is_list(value) do
+    "  #{key}: #{Enum.join(value, ", ")}"
   end
 
-  defp print_configuration_option({key, value}) do
-    IO.puts("  #{key}: #{value}")
+  defp configuration_option_label({key, value}) do
+    "  #{key}: #{value}"
+  end
+
+  defp configuration_option_source_label(_, [], _), do: ""
+
+  defp configuration_option_source_label(_, [:default], _), do: ""
+
+  defp configuration_option_source_label(_, sources, _) when length(sources) == 1 do
+    " (Loaded from #{Enum.join(sources, ", ")})"
+  end
+
+  defp configuration_option_source_label(key, sources, option_sources) do
+    sources_label =
+      sources
+      |> Enum.map(fn source ->
+        "      #{source}: #{option_sources[source][key]}"
+      end)
+      |> Enum.join("\n")
+
+    "\n    Sources:\n#{sources_label}"
+  end
+
+  defp sources_for_option(key, sources) do
+    [:default, :system, :file, :env]
+    |> Enum.map(fn source ->
+      if Map.has_key?(sources[source], key) do
+        source
+      end
+    end)
+    |> Enum.reject(fn value -> value == nil end)
   end
 
   defp print_validation(validation_report) do

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -591,7 +591,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
       assert String.contains?(
                output,
-               "  active: true\n    Sources:\n      default: false\n      file: true"
+               "  active: true\n    Sources:\n      default: false\n      file:    true"
              )
     end
 
@@ -606,12 +606,12 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
       assert String.contains?(
                output,
-               "  push_api_key: bar\n    Sources:\n      file: foo\n      env: bar"
+               "  push_api_key: bar\n    Sources:\n      file: foo\n      env:  bar"
              )
 
       assert String.contains?(
                output,
-               "  running_in_container: false\n    Sources:\n      system: true\n      file: false"
+               "  running_in_container: false\n    Sources:\n      system: true\n      file:   false"
              )
     end
   end


### PR DESCRIPTION
Based on #421 

This change print config option sources in diagnose report.
This allows users to track back on their own, based on the output, where
the config options are coming from.
Helps with debugging where a particular option gets set.

It also adds the config options sources to the config report as
described in the format in the PR for the Ruby gem:
appsignal/appsignal-ruby#444

New format:

```
Configuration
  # Option with only the default source
  diagnose_endpoint: https://appsignal.com/diag

  # Option with one source, not default
  name: appsignal-plug-example (Loaded from file)

  # Option with multiple sources
  active: true
    Sources:
      default: false
      file: true
```

## TODO

- [x] Test the diagnose report changes