### PR TITLE
Use FakeTransaction in ErrorHandler tests

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -17,6 +17,12 @@ defmodule Appsignal do
 
   require Logger
 
+  @transaction Application.get_env(
+                 :appsignal,
+                 :appsignal_transaction,
+                 Appsignal.Transaction
+               )
+
   @doc """
   Application callback function
   """
@@ -170,8 +176,7 @@ defmodule Appsignal do
           stack
       end
 
-    transaction =
-      Appsignal.Transaction.create("_" <> Appsignal.Transaction.generate_id(), namespace)
+    transaction = @transaction.create("_" <> @transaction.generate_id(), namespace)
 
     fun.(transaction)
     {reason, message, backtrace} = Appsignal.Error.metadata(reason, stack)

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -1,5 +1,5 @@
 defmodule AppsignalTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import AppsignalTest.Utils
   import ExUnit.CaptureIO
 

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -4,7 +4,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
   """
 
   use ExUnit.Case
-  alias Appsignal.{ErrorHandler, FakeTransaction}
+  alias Appsignal.FakeTransaction
 
   defmodule CrashingGenServer do
     use GenServer
@@ -33,158 +33,134 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end
   end
 
-  defmodule CustomErrorHandler do
-    def init(_) do
-      {:ok, nil}
-    end
-
-    def handle_event(event, _state) do
-      {:ok, ErrorHandler.match_event(event)}
-    end
-
-    def handle_call(:get_matched_crash, state) do
-      {:remove_handler, state}
-    end
-  end
-
-  @error_handler ErrorHandler.ErrorMatcherTest.CustomErrorHandler
-
-  defp get_last_crash do
-    :timer.sleep(20)
-    :gen_event.call(:error_logger, @error_handler, :get_matched_crash)
-  end
-
-  defp assert_crash_caught({:ok, pid}) when is_pid(pid) do
-    assert_crash_caught(pid)
-  end
-
-  defp assert_crash_caught(crasher) when is_pid(crasher) do
-    assert {^crasher, reason, message, stacktrace, conn} = get_last_crash()
-    assert is_list(stacktrace)
-    assert is_binary(reason)
-    assert is_binary(message)
-    assert is_nil(conn)
-
-    for s <- stacktrace do
-      assert is_binary(s)
-    end
-
-    {reason, message, stacktrace}
-  end
-
   setup do
-    :error_logger.add_report_handler(@error_handler)
     {:ok, fake_transaction} = FakeTransaction.start_link()
-
-    on_exit(fn ->
-      :error_logger.delete_report_handler(@error_handler)
-    end)
-
-    :timer.sleep(100)
+    [fake_transaction: fake_transaction]
   end
 
-  test "proc_lib.spawn + exit" do
+  test "proc_lib.spawn + exit", %{fake_transaction: fake_transaction} do
     :proc_lib.spawn(fn ->
       exit(:crash_proc_lib_spawn)
     end)
-    |> assert_crash_caught
-    |> reason(":crash_proc_lib_spawn")
-    |> message(~r{^(E|e)rlang error: :crash_proc_lib_spawn$})
-    |> stacktrace([
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == ":crash_proc_lib_spawn"
+    assert message =~ ~r{^(E|e)rlang error: :crash_proc_lib_spawn$}
+
+    assert_stacktrace(stacktrace, [
       ~r{test\/appsignal\/error_handler\/error_matcher_test.exs:\d+: anonymous fn\/0 in Appsignal.ErrorHandler.ErrorMatcherTest."?test proc_lib.spawn \+ exit"?/1},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
-  test "proc_lib.spawn + erlang.error" do
+  test "proc_lib.spawn + erlang.error", %{fake_transaction: fake_transaction} do
     :proc_lib.spawn(fn ->
       :erlang.error(:crash_proc_lib_error)
     end)
-    |> assert_crash_caught
-    |> reason(":crash_proc_lib_error")
-    |> message(~r{^(E|e)rlang error: :crash_proc_lib_error$})
-    |> stacktrace([
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == ":crash_proc_lib_error"
+    assert message =~ ~r{^(E|e)rlang error: :crash_proc_lib_error$}
+
+    assert_stacktrace(stacktrace, [
       ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest."?test proc_lib.spawn \+ erlang.error"?/1},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
-  test "proc_lib.spawn + function error" do
+  test "proc_lib.spawn + function error", %{fake_transaction: fake_transaction} do
     :proc_lib.spawn(fn ->
       Float.ceil(1)
     end)
-    |> assert_crash_caught
-    |> reason("FunctionClauseError")
-    |> message("no function clause matching in Float.ceil/2")
-    |> stacktrace([
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == "FunctionClauseError"
+    assert message == "no function clause matching in Float.ceil/2"
+
+    assert_stacktrace(stacktrace, [
       ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
-  test "proc_lib.spawn + badmatch error" do
+  test "proc_lib.spawn + badmatch error", %{fake_transaction: fake_transaction} do
     :proc_lib.spawn(fn -> throw({:badmatch, [1, 2, 3]}) end)
-    |> assert_crash_caught
-    |> reason("MatchError")
-    |> message("no match of right hand side value: [1, 2, 3]")
-    |> stacktrace([
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == "MatchError"
+    assert message == "no match of right hand side value: [1, 2, 3]"
+
+    assert_stacktrace(stacktrace, [
       ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest."?test proc_lib.spawn \+ badmatch error"?/1},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
-  test "Crashing GenServer with throw" do
-    result =
-      CrashingGenServer.start(:throw)
-      |> assert_crash_caught
-      # http://erlang.org/pipermail/erlang-bugs/2012-April/002862.html
-      |> reason(":bad_return_value")
-      |> message(~r{^(E|e)rlang error: {:bad_return_valu...})
+  test "Crashing GenServer with throw", %{fake_transaction: fake_transaction} do
+    CrashingGenServer.start(:throw)
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == ":bad_return_value"
+    assert message =~ ~r{^(E|e)rlang error: {:bad_return_valu...}
 
     if System.otp_release() >= "20" do
-      stacktrace(result, [
+      assert_stacktrace(stacktrace, [
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.handle_common_reply/8},
         ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
       ])
     else
-      stacktrace(result, [
+      assert_stacktrace(stacktrace, [
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.terminate/7},
         ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
       ])
     end
   end
 
-  test "Crashing GenServer with exit" do
-    result =
-      CrashingGenServer.start(:exit)
-      |> assert_crash_caught
-      |> reason(":crashed_gen_server_exit")
-      |> message(~r{^(E|e)rlang error: :crashed_gen_server_exit$})
+  test "Crashing GenServer with exit", %{fake_transaction: fake_transaction} do
+    CrashingGenServer.start(:exit)
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == ":crashed_gen_server_exit"
+    assert message =~ ~r{^(E|e)rlang error: :crashed_gen_server_exit$}
 
     if System.otp_release() >= "20" do
-      stacktrace(result, [
+      assert_stacktrace(stacktrace, [
         ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2},
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.handle_msg/6},
         ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
       ])
     else
-      stacktrace(result, [
+      assert_stacktrace(stacktrace, [
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.terminate/7},
         ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
       ])
     end
   end
 
-  test "Crashing GenServer with function error" do
-    result =
-      CrashingGenServer.start(:function_error)
-      |> assert_crash_caught
-      |> reason("FunctionClauseError")
-      |> message("no function clause matching in Float.ceil/2")
+  test "Crashing GenServer with function error", %{fake_transaction: fake_transaction} do
+    CrashingGenServer.start(:function_error)
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == "FunctionClauseError"
+    assert message == "no function clause matching in Float.ceil/2"
 
     if System.otp_release() >= "20" do
-      stacktrace(result, [
+      assert_stacktrace(stacktrace, [
         ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
         ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2},
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
@@ -192,7 +168,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
         ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
       ])
     else
-      stacktrace(result, [
+      assert_stacktrace(stacktrace, [
         ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
         ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2},
         ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
@@ -202,39 +178,45 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end
   end
 
-  test "Task" do
-    result =
-      Task.start(fn ->
-        Float.ceil(1)
-      end)
-      |> assert_crash_caught
-      |> reason("FunctionClauseError")
-      |> stacktrace([
-        ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
-        ~r{\(elixir\) lib/task/supervised.ex:\d+: Task.Supervised.do_apply/2},
-        ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
-      ])
+  test "Task", %{fake_transaction: fake_transaction} do
+    Task.start(fn ->
+      Float.ceil(1)
+    end)
 
-    message(result, "no function clause matching in Float.ceil/2")
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == "FunctionClauseError"
+    assert message == "no function clause matching in Float.ceil/2"
+
+    assert_stacktrace(stacktrace, [
+      ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
+      ~r{\(elixir\) lib/task/supervised.ex:\d+: Task.Supervised.do_apply/2},
+      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
+    ])
   end
 
-  test "Task await" do
+  test "Task await", %{fake_transaction: fake_transaction} do
     :proc_lib.spawn(fn ->
       Task.async(fn ->
         Process.sleep(2)
       end)
       |> Task.await(1)
     end)
-    |> assert_crash_caught
-    |> reason(":timeout")
-    |> message(~r{^(E|e)rlang error: {:timeout, {Task, :await, \[%Tas...})
-    |> stacktrace([
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == ":timeout"
+    assert message =~ ~r{^(E|e)rlang error: {:timeout, {Task, :await, \[%Tas...}
+
+    assert_stacktrace(stacktrace, [
       ~r{\(elixir\) lib/task.ex:\d+: Task.await/2},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
-  test "Plug.Conn.WrapperError" do
+  test "Plug.Conn.WrapperError", %{fake_transaction: fake_transaction} do
     :proc_lib.spawn(fn ->
       try do
         raise %UndefinedFunctionError{}
@@ -243,33 +225,17 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
           raise(%Plug.Conn.WrapperError{reason: reason, kind: kind, stack: System.stacktrace()})
       end
     end)
-    |> assert_crash_caught
-    |> reason("UndefinedFunctionError")
-    |> message(~r{^undefined function$})
-    |> stacktrace([
+
+    :timer.sleep(20)
+
+    [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
+    assert reason == "UndefinedFunctionError"
+    assert message == "undefined function"
+
+    assert_stacktrace(stacktrace, [
       ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest."?test Plug.Conn.WrapperError"?/1},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
-  end
-
-  defp reason({reason, _message, _stacktrace} = data, expected) do
-    assert expected == reason
-    data
-  end
-
-  defp message({_reason, message, _stacktrace} = data, expected) when is_binary(expected) do
-    assert message == expected
-    data
-  end
-
-  defp message({_reason, message, _stacktrace} = data, expected) do
-    assert message =~ expected
-    data
-  end
-
-  defp stacktrace({_reason, _message, stacktrace} = data, expected) do
-    assert_stacktrace(stacktrace, expected)
-    data
   end
 
   defp assert_stacktrace([line | tail], [expected | expected_tail]) do

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -4,6 +4,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
   """
 
   use ExUnit.Case
+  alias Appsignal.{ErrorHandler, FakeTransaction}
 
   defmodule CrashingGenServer do
     use GenServer
@@ -38,7 +39,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end
 
     def handle_event(event, _state) do
-      {:ok, Appsignal.ErrorHandler.match_event(event)}
+      {:ok, ErrorHandler.match_event(event)}
     end
 
     def handle_call(:get_matched_crash, state) do
@@ -46,7 +47,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end
   end
 
-  @error_handler Appsignal.ErrorHandler.ErrorMatcherTest.CustomErrorHandler
+  @error_handler ErrorHandler.ErrorMatcherTest.CustomErrorHandler
 
   defp get_last_crash do
     :timer.sleep(20)
@@ -73,6 +74,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
   setup do
     :error_logger.add_report_handler(@error_handler)
+    {:ok, fake_transaction} = FakeTransaction.start_link()
 
     on_exit(fn ->
       :error_logger.delete_report_handler(@error_handler)

--- a/test/appsignal/error_handler_test.exs
+++ b/test/appsignal/error_handler_test.exs
@@ -47,12 +47,14 @@ defmodule Appsignal.ErrorHandlerTest do
     :proc_lib.spawn(fn ->
       Transaction.start(id, :http_request)
 
+      :timer.sleep(50)
+
       Appsignal.TransactionRegistry.ignore(self())
 
       :erlang.error(:error_http_request)
     end)
 
-    :timer.sleep(50)
+    :timer.sleep(100)
 
     assert FakeTransaction.errors(fake_transaction) == []
   end

--- a/test/appsignal/error_handler_test.exs
+++ b/test/appsignal/error_handler_test.exs
@@ -3,7 +3,7 @@ defmodule Appsignal.ErrorHandlerTest do
   Test the actual Appsignal.ErrorHandler
   """
 
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Appsignal.{Transaction, ErrorHandler, FakeTransaction}
 

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -58,6 +58,10 @@ defmodule Appsignal.FakeTransaction do
     Agent.get(__MODULE__, &Map.get(&1, :finish, :sample))
   end
 
+  def set_meta_data(_transaction, conn) do
+    Agent.update(__MODULE__, &Map.put(&1, :metadata, conn))
+  end
+
   def set_request_metadata(_transaction, conn) do
     Agent.update(__MODULE__, &Map.put(&1, :request_metadata, conn))
   end
@@ -94,6 +98,10 @@ defmodule Appsignal.FakeTransaction do
     end)
 
     :ok
+  end
+
+  def lookup_or_create_transaction(pid) do
+    start(inspect(pid), :background_job)
   end
 
   def start(id, namespace) do
@@ -156,6 +164,10 @@ defmodule Appsignal.FakeTransaction do
 
   def completed_transactions(pid_or_module) do
     get(pid_or_module, :completed_transactions)
+  end
+
+  def metadata(pid_or_module) do
+    get(pid_or_module, :metadata)
   end
 
   def request_metadata(pid_or_module) do

--- a/test/support/fake_transaction.ex
+++ b/test/support/fake_transaction.ex
@@ -104,6 +104,22 @@ defmodule Appsignal.FakeTransaction do
     start(inspect(pid), :background_job)
   end
 
+  def create(id, namespace) do
+    Agent.update(__MODULE__, fn state ->
+      {_, new_state} =
+        Map.get_and_update(state, :created_transactions, fn current ->
+          case current do
+            nil -> {nil, [{id, namespace}]}
+            _ -> {current, [{id, namespace} | current]}
+          end
+        end)
+
+      new_state
+    end)
+
+    Appsignal.Transaction.create(id, namespace)
+  end
+
   def start(id, namespace) do
     Agent.update(__MODULE__, fn state ->
       {_, new_state} =
@@ -148,6 +164,10 @@ defmodule Appsignal.FakeTransaction do
 
   def action(pid_or_module) do
     get(pid_or_module, :action)
+  end
+
+  def created_transactions(pid_or_module) do
+    get(pid_or_module, :created_transactions)
   end
 
   def started_transactions(pid_or_module) do


### PR DESCRIPTION
As a prerequisite of https://github.com/appsignal/appsignal-elixir/pull/425, this patch switches to using `FakeTransaction` to test if errors are correctly added to the transaction by the `ErrorHandler` instead of relying on its internal state. This is based on https://github.com/appsignal/appsignal-elixir/pull/423, and should be merged after.