### PR TITLE
Format values printed in the diagnose

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -136,12 +136,8 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     )
   end
 
-  defp configuration_option_label({key, value}) when is_list(value) do
-    "  #{key}: #{Enum.join(value, ", ")}"
-  end
-
   defp configuration_option_label({key, value}) do
-    "  #{key}: #{value}"
+    "  #{key}: #{format_value(value)}"
   end
 
   defp configuration_option_source_label(_, [], _), do: ""
@@ -169,7 +165,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
       sources
       |> Enum.map(fn source ->
         label = String.pad_trailing("#{source}:", max_source_label_length)
-        "      #{label} #{option_sources[source][key]}"
+        "      #{label} #{format_value(option_sources[source][key])}"
       end)
       |> Enum.join("\n")
 
@@ -184,6 +180,10 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
       end
     end)
     |> Enum.reject(fn value -> value == nil end)
+  end
+
+  defp format_value(value) do
+    inspect(value)
   end
 
   defp print_validation(validation_report) do

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -549,28 +549,16 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   end
 
   describe "configuration" do
-    test "outputs configuration with string values" do
+    test "outputs inspected configuration option values" do
       output = run()
       assert String.contains?(output, "Configuration")
 
-      config =
-        Application.get_env(:appsignal, :config)
-        |> Enum.filter(fn {_, value} -> !is_list(value) end)
+      config = Application.get_env(:appsignal, :config)
+
+      refute Enum.empty?(config)
 
       Enum.each(config, fn {key, value} ->
-        assert String.contains?(output, "  #{key}: #{value}")
-      end)
-    end
-
-    test "outputs configuration with array values" do
-      output = run()
-
-      config =
-        Application.get_env(:appsignal, :config)
-        |> Enum.filter(fn {_, value} -> is_list(value) end)
-
-      Enum.each(config, fn {key, value} ->
-        assert String.contains?(output, "  #{key}: #{Enum.join(value, ", ")}")
+        assert String.contains?(output, "  #{key}: #{inspect(value)}")
       end)
     end
 
@@ -583,7 +571,10 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "outputs the source when there is only one source (not default)" do
       output = run()
 
-      assert String.contains?(output, "  name: AppSignal test suite app v0 (Loaded from file)\n")
+      assert String.contains?(
+               output,
+               "  name: \"AppSignal test suite app v0\" (Loaded from file)\n"
+             )
     end
 
     test "outputs sources for option with multiple sources" do
@@ -606,7 +597,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
       assert String.contains?(
                output,
-               "  push_api_key: bar\n    Sources:\n      file: foo\n      env:  bar"
+               "  push_api_key: \"bar\"\n    Sources:\n      file: \"foo\"\n      env:  \"bar\""
              )
 
       assert String.contains?(


### PR DESCRIPTION
Based on #422 
Rebase on develop and change the PRs base branch before merging, after #422 is merged.

If a value was nil or an empty list it wouldn't print anything, as if
was broken.

Now print the config option values to the following rules:

- String: surround with quotes, e.g.: `"foo"`
- Boolean: print raw value, e.g.: `true`
- Atom: print raw value, e.g.: `:foo`
- Lists: print inspect value, e.g.: `["foo", "bar"]`
- Empty lists: print empty list representation, e.g.: `[]`
- Nil values: print nil representation, e.g. `nil`