### PR TITLE
Fix appsignal.log default path

### DIFF
--- a/lib/appsignal/diagnose/paths.ex
+++ b/lib/appsignal/diagnose/paths.ex
@@ -1,6 +1,6 @@
 defmodule Appsignal.Diagnose.Paths do
-  def info(config) do
-    log_file_path = config[:log_path] || "/tmp/appsignal.log"
+  def info do
+    log_file_path = Appsignal.Config.log_file_path() || "/tmp/appsignal.log"
     log_dir_path = Path.dirname(log_file_path)
 
     install_log_path =

--- a/lib/appsignal/utils/file_system.ex
+++ b/lib/appsignal/utils/file_system.ex
@@ -1,0 +1,35 @@
+defmodule Appsignal.Utils.FileSystem do
+  def system_tmp_dir do
+    {_, os_type} = :os.type()
+    system_tmp_dir_for_os(os_type)
+  end
+
+  @doc false
+  def system_tmp_dir_for_os(os_type) do
+    case os_type do
+      :nt ->
+        System.tmp_dir()
+
+      _ ->
+        path = "/tmp"
+
+        case File.exists?(path) do
+          true ->
+            path
+
+          false ->
+            System.tmp_dir()
+        end
+    end
+  end
+
+  def writable?(path) do
+    case File.stat(path) do
+      {:ok, %{access: access}} when access in [:write, :read_write] ->
+        true
+
+      _ ->
+        false
+    end
+  end
+end

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     print_validation(validation_report)
     empty_line()
 
-    path_report = Diagnose.Paths.info(config)
+    path_report = Diagnose.Paths.info()
     report = Map.put(report, :paths, path_report)
     print_paths(path_report)
     empty_line()

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -5,6 +5,7 @@ defmodule Appsignal.ConfigTest do
 
   use ExUnit.Case
   import AppsignalTest.Utils
+  import ExUnit.CaptureIO
   alias Appsignal.{Config, Nif}
 
   setup do
@@ -21,8 +22,12 @@ defmodule Appsignal.ConfigTest do
     test "stores sources in Application" do
       init_config()
 
+      default =
+        default_configuration()
+        |> Map.delete(:valid)
+
       assert Application.get_env(:appsignal, :config_sources) == %{
-               default: default_configuration() |> Map.delete(:valid),
+               default: default,
                system: %{},
                file: %{},
                env: %{}
@@ -229,8 +234,10 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "log_path" do
-      assert with_config(%{log_path: "log/appsignal.log"}, &init_config/0) ==
-               default_configuration() |> Map.put(:log_path, "log/appsignal.log")
+      log_path = System.cwd()
+
+      assert with_config(%{log_path: log_path}, &init_config/0) ==
+               default_configuration() |> Map.put(:log_path, log_path)
     end
 
     test "name" do
@@ -421,10 +428,12 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "log_path" do
+      log_path = System.cwd()
+
       assert with_env(
-               %{"APPSIGNAL_LOG_PATH" => "log/appsignal.log"},
+               %{"APPSIGNAL_LOG_PATH" => log_path},
                &init_config/0
-             ) == default_configuration() |> Map.put(:log_path, "log/appsignal.log")
+             ) == default_configuration() |> Map.put(:log_path, log_path)
     end
 
     test "name" do
@@ -574,6 +583,46 @@ defmodule Appsignal.ConfigTest do
     end
   end
 
+  describe "log_file_path/0" do
+    test "defaults to /tmp/appsignal.log" do
+      system_tmp_dir = Appsignal.Utils.FileSystem.system_tmp_dir()
+
+      with_config(%{}, fn ->
+        assert Config.log_file_path() == Path.join(system_tmp_dir, "appsignal.log")
+      end)
+    end
+
+    test "overrides user specified filename when set" do
+      output =
+        capture_io(:stderr, fn ->
+          system_tmp_dir = Appsignal.Utils.FileSystem.system_tmp_dir()
+
+          with_config(%{log_path: Path.join(system_tmp_dir, "custom.log")}, fn ->
+            assert Config.log_file_path() == Path.join(system_tmp_dir, "appsignal.log")
+          end)
+        end)
+
+      assert output =~ "Deprecation warning: File names are no longer supported in the 'log_path'"
+    end
+
+    test "falls back on /tmp/appsignal.log when user path is not writable" do
+      log_path = "/non_existent_path"
+      system_tmp_dir = Appsignal.Utils.FileSystem.system_tmp_dir()
+
+      output =
+        capture_io(:stderr, fn ->
+          with_config(%{log_path: log_path}, fn ->
+            assert Config.log_file_path() == Path.join(system_tmp_dir, "appsignal.log")
+          end)
+        end)
+
+      assert output =~
+               "appsignal: Unable to log to '#{log_path}' or the " <>
+                 "'#{system_tmp_dir}' fallback. " <>
+                 "Please check the write permissions for the log directory."
+    end
+  end
+
   describe "reset_environment_config!" do
     test "deletes existing configuration in environment" do
       assert with_env(
@@ -592,6 +641,7 @@ defmodule Appsignal.ConfigTest do
       Appsignal.Config.write_to_environment()
     end
 
+    @tag :skip_env_test_no_nif
     test "empty config options get written to the env" do
       write_to_environment()
       assert Nif.env_get("_APPSIGNAL_APP_NAME") == ''
@@ -599,7 +649,7 @@ defmodule Appsignal.ConfigTest do
       assert Nif.env_get("_APPSIGNAL_IGNORE_ACTIONS") == ''
       assert Nif.env_get("_APPSIGNAL_IGNORE_ERRORS") == ''
       assert Nif.env_get("_APPSIGNAL_IGNORE_NAMESPACES") == ''
-      assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == ''
+      assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == '/tmp/appsignal.log'
       assert Nif.env_get("_APPSIGNAL_WORKING_DIR_PATH") == ''
       assert Nif.env_get("_APPSIGNAL_WORKING_DIRECTORY_PATH") == ''
       assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == ''
@@ -642,7 +692,7 @@ defmodule Appsignal.ConfigTest do
           ignore_errors: ~w(VerySpecificError AnotherError),
           ignore_namespaces: ~w(admin private_namespace),
           log: "stdout",
-          log_path: "log/appsignal.log",
+          log_path: "/tmp",
           name: "AppSignal test suite app",
           running_in_container: false,
           working_dir_path: "/tmp/appsignal-deprecated",
@@ -674,7 +724,7 @@ defmodule Appsignal.ConfigTest do
                    'elixir-' ++ String.to_charlist(Mix.Project.config()[:version])
 
           assert Nif.env_get("_APPSIGNAL_LOG") == 'stdout'
-          assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == 'log/appsignal.log'
+          assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == '/tmp/appsignal.log'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_ENDPOINT") == 'https://push.staging.lol'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_KEY") == '00000000-0000-0000-0000-000000000000'
           assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == 'false'

--- a/test/appsignal/utils/file_system_test.exs
+++ b/test/appsignal/utils/file_system_test.exs
@@ -1,0 +1,19 @@
+defmodule Appsignal.Utils.FileSystemTest do
+  use ExUnit.Case
+  import AppsignalTest.Utils
+  alias Appsignal.Utils.FileSystem
+
+  describe "system_tmp_dir_for_os/1" do
+    test "returns /tmp dir on *nix" do
+      tmp_dir = "/tmp"
+      assert FileSystem.system_tmp_dir_for_os(:unix) == tmp_dir
+    end
+
+    test "returns Windows tmp dir on Microsoft Windows" do
+      windows_tmp_dir = Path.join(System.tmp_dir(), "windows_tmp_dir")
+      File.mkdir(windows_tmp_dir)
+      setup_with_env(%{"TMPDIR" => windows_tmp_dir})
+      assert FileSystem.system_tmp_dir_for_os(:nt) == windows_tmp_dir
+    end
+  end
+end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -16,12 +16,14 @@ defmodule AppsignalTest.Utils do
   def freeze_environment do
     {
       Application.get_env(:appsignal, :config, %{}),
+      Application.get_env(:appsignal, :config_sources, %{}),
       System.get_env()
     }
   end
 
-  def unfreeze_environment({config, env}) do
+  def unfreeze_environment({config, sources, env}) do
     Application.put_env(:appsignal, :config, config)
+    Application.put_env(:appsignal, :config_sources, sources)
     reset_env(env)
   end
 


### PR DESCRIPTION
Set the appsignal.log by default based on the same logic as is present
in Ruby:
https://github.com/appsignal/appsignal-ruby/blob/57b3b7f8a024226c89fb9788a8772047c681ab8f/lib/appsignal/config.rb#L126-L143

With the exception of the preference of the `./log` directory in the
app's directory.

This is not common in Elixir, so instead default to the
`/tmp/appsignal.log` path.

Fixes #391