### PR TITLE
Remove unused alias, resolves warning.

### DIFF
--- a/lib/appsignal/diagnose/config.ex
+++ b/lib/appsignal/diagnose/config.ex
@@ -1,6 +1,4 @@
 defmodule Appsignal.Diagnose.Config do
-  alias Appsignal.Config
-
   def config() do
     sources = Application.get_env(:appsignal, :config_sources, %{})
 


### PR DESCRIPTION
```
==> appsignal
Compiling 37 files (.ex)
warning: unused alias Config
  lib/appsignal/diagnose/config.ex:2
```