### PR TITLE
Store extension installation details in report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ mix.lock
 /c_src/libappsignal.a
 /c_src/libappsignal.dylib
 /priv/*appsignal*
+/priv/*.report

--- a/lib/appsignal/diagnose/library.ex
+++ b/lib/appsignal/diagnose/library.ex
@@ -7,7 +7,6 @@ defmodule Appsignal.Diagnose.Library do
     %{
       language: "elixir",
       agent_version: @agent_version,
-      agent_architecture: Appsignal.System.installed_agent_architecture(),
       package_version: @appsignal_version,
       extension_loaded: @nif.loaded?
     }

--- a/lib/appsignal/system.ex
+++ b/lib/appsignal/system.ex
@@ -27,17 +27,4 @@ defmodule Appsignal.System do
         nil
     end
   end
-
-  # Returns the platform for which the agent was installed.
-  #
-  # This value is saved when the package is installed.
-  # We use this value to build the diagnose report with the installed
-  # platform, rather than the detected platform in .agent_platform during
-  # the diagnose run.
-  def installed_agent_architecture do
-    case File.read(Path.join([:code.priv_dir(:appsignal), "appsignal.architecture"])) do
-      {:ok, arch} -> arch
-      {:error, _} -> nil
-    end
-  end
 end

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -5,6 +5,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
 
   @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
   @report Application.get_env(:appsignal, :appsignal_diagnose_report, Appsignal.Diagnose.Report)
+  @env Mix.env()
 
   @shortdoc "Starts and tests AppSignal while validating the configuration."
 
@@ -18,7 +19,9 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
       end
 
     Application.load(:appsignal)
+
     report = %{process: %{uid: @system.uid}}
+
     configure_appsignal()
     config_report = Diagnose.Config.config()
     config = config_report[:options]
@@ -30,6 +33,11 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     library_report = Diagnose.Library.info()
     report = Map.put(report, :library, library_report)
     print_library_info(library_report)
+    empty_line()
+
+    installation_report = fetch_installation_report()
+    report = Map.put(report, :installation, installation_report)
+    print_installation_report(installation_report)
     empty_line()
 
     host_report = Diagnose.Host.info()
@@ -86,8 +94,105 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("  Language: Elixir")
     IO.puts("  Package version: #{library_report[:package_version]}")
     IO.puts("  Agent version: #{library_report[:agent_version]}")
-    IO.puts("  Agent architecture: #{library_report[:agent_architecture]}")
     IO.puts("  Nif loaded: #{yes_or_no(library_report[:extension_loaded])}")
+  end
+
+  defp fetch_installation_report do
+    download_report =
+      case do_fetch_installation_report("download") do
+        %{"parsing_error" => parsing_report} ->
+          %{"download_parsing_error" => parsing_report}
+
+        report ->
+          report
+      end
+
+    install_report =
+      case do_fetch_installation_report("install_#{@env}") do
+        %{"parsing_error" => parsing_report} ->
+          %{"installation_parsing_error" => parsing_report}
+
+        report ->
+          report
+      end
+
+    Map.merge(install_report, download_report)
+  end
+
+  defp do_fetch_installation_report(file) do
+    case File.read(Path.join([:code.priv_dir(:appsignal), "#{file}.report"])) do
+      {:ok, raw_report} ->
+        case Poison.decode(raw_report) do
+          {:ok, report} -> report
+          {:error, reason} -> %{"parsing_error" => %{"error" => reason, "raw" => raw_report}}
+        end
+
+      {:error, reason} ->
+        %{"parsing_error" => %{"error" => reason}}
+    end
+  end
+
+  defp print_installation_report(report) do
+    IO.puts("Extension installation report")
+    download_parsing_error = Map.has_key?(report, "download_parsing_error")
+    install_parsing_error = Map.has_key?(report, "installation_parsing_error")
+    if download_parsing_error, do: do_print_parsing_error("download", report)
+    if install_parsing_error, do: do_print_parsing_error("installation", report)
+
+    if !download_parsing_error && !install_parsing_error do
+      do_print_installation_report(report)
+    end
+  end
+
+  defp do_print_parsing_error(key, report) do
+    parsing_report = report["#{key}_parsing_error"]
+    IO.puts("  Error found while parsing the #{key} report.")
+    IO.puts("  Error: #{format_value(parsing_report["error"])}")
+
+    if Map.has_key?(parsing_report, "raw") do
+      IO.puts("  Raw report:\n#{format_value(parsing_report["raw"])}")
+    end
+  end
+
+  defp do_print_installation_report(installation_report) do
+    result_report = installation_report["result"]
+    IO.puts("  Installation result")
+    IO.puts("    Status: #{format_value(result_report["status"])}")
+
+    if Map.has_key?(result_report, "message") do
+      IO.puts("    Message: #{format_value(result_report["message"])}")
+    end
+
+    if Map.has_key?(result_report, "error") do
+      IO.puts("    Error: #{format_value(result_report["error"])}")
+    end
+
+    language_report = installation_report["language"]
+    IO.puts("  Language details")
+    IO.puts("    Elixir version: #{format_value(language_report["version"])}")
+    IO.puts("    OTP version: #{format_value(language_report["otp_version"])}")
+    download_report = installation_report["download"]
+    IO.puts("  Download details")
+    IO.puts("    Download time: #{format_value(download_report["time"])}")
+    IO.puts("    Download URL: #{format_value(download_report["download_url"])}")
+    IO.puts("    Architecture: #{format_value(download_report["architecture"])}")
+    IO.puts("    Target: #{format_value(download_report["target"])}")
+    IO.puts("    Musl override: #{format_value(download_report["musl_override"])}")
+    IO.puts("    Library type: #{format_value(download_report["library_type"])}")
+    IO.puts("    Checksum: #{format_value(download_report["checksum"])}")
+    build_report = installation_report["build"]
+    IO.puts("  Build details")
+    IO.puts("    Install time: #{format_value(build_report["time"])}")
+    IO.puts("    Source: #{format_value(build_report["source"])}")
+    IO.puts("    Agent version: #{format_value(build_report["agent_version"])}")
+    IO.puts("    Architecture: #{format_value(build_report["architecture"])}")
+    IO.puts("    Target: #{format_value(build_report["target"])}")
+    IO.puts("    Musl override: #{format_value(build_report["musl_override"])}")
+    IO.puts("    Library type: #{format_value(build_report["library_type"])}")
+    host_report = installation_report["host"]
+    IO.puts("  Host details")
+    IO.puts("    Root user: #{format_value(host_report["root_user"])}")
+    IO.puts("    Dependencies: #{format_value(host_report["dependencies"])}")
   end
 
   defp print_host_information(host_report) do

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -136,7 +136,11 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("Extension installation report")
     download_parsing_error = Map.has_key?(report, "download_parsing_error")
     install_parsing_error = Map.has_key?(report, "installation_parsing_error")
-    if download_parsing_error, do: do_print_parsing_error("download", report)
+    if download_parsing_error do
+      do_print_parsing_error("download", report)
+    else
+      do_print_download_report(report)
+    end
     if install_parsing_error, do: do_print_parsing_error("installation", report)
 
     if !download_parsing_error && !install_parsing_error do
@@ -171,15 +175,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("  Language details")
     IO.puts("    Elixir version: #{format_value(language_report["version"])}")
     IO.puts("    OTP version: #{format_value(language_report["otp_version"])}")
-    download_report = installation_report["download"]
-    IO.puts("  Download details")
-    IO.puts("    Download time: #{format_value(download_report["time"])}")
-    IO.puts("    Download URL: #{format_value(download_report["download_url"])}")
-    IO.puts("    Architecture: #{format_value(download_report["architecture"])}")
-    IO.puts("    Target: #{format_value(download_report["target"])}")
-    IO.puts("    Musl override: #{format_value(download_report["musl_override"])}")
-    IO.puts("    Library type: #{format_value(download_report["library_type"])}")
-    IO.puts("    Checksum: #{format_value(download_report["checksum"])}")
+    do_print_download_report(installation_report)
     build_report = installation_report["build"]
     IO.puts("  Build details")
     IO.puts("    Install time: #{format_value(build_report["time"])}")
@@ -193,6 +189,18 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("  Host details")
     IO.puts("    Root user: #{format_value(host_report["root_user"])}")
     IO.puts("    Dependencies: #{format_value(host_report["dependencies"])}")
+  end
+
+  defp do_print_download_report(installation_report) do
+    download_report = installation_report["download"]
+    IO.puts("  Download details")
+    IO.puts("    Download time: #{format_value(download_report["time"])}")
+    IO.puts("    Download URL: #{format_value(download_report["download_url"])}")
+    IO.puts("    Architecture: #{format_value(download_report["architecture"])}")
+    IO.puts("    Target: #{format_value(download_report["target"])}")
+    IO.puts("    Musl override: #{format_value(download_report["musl_override"])}")
+    IO.puts("    Library type: #{format_value(download_report["library_type"])}")
+    IO.puts("    Checksum: #{format_value(download_report["checksum"])}")
   end
 
   defp print_host_information(host_report) do

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -100,20 +100,20 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   defp fetch_installation_report do
     download_report =
       case do_fetch_installation_report("download") do
-        %{"parsing_error" => parsing_report} ->
-          %{"download_parsing_error" => parsing_report}
-
-        report ->
+        {:ok, report} ->
           report
+
+        {:error, %{"parsing_error" => parsing_report}} ->
+          %{"download_parsing_error" => parsing_report}
       end
 
     install_report =
       case do_fetch_installation_report("install_#{@env}") do
-        %{"parsing_error" => parsing_report} ->
-          %{"installation_parsing_error" => parsing_report}
-
-        report ->
+        {:ok, report} ->
           report
+
+        {:error, %{"parsing_error" => parsing_report}} ->
+          %{"installation_parsing_error" => parsing_report}
       end
 
     Map.merge(install_report, download_report)
@@ -123,12 +123,12 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     case File.read(Path.join([:code.priv_dir(:appsignal), "#{file}.report"])) do
       {:ok, raw_report} ->
         case Poison.decode(raw_report) do
-          {:ok, report} -> report
-          {:error, reason} -> %{"parsing_error" => %{"error" => reason, "raw" => raw_report}}
+          {:ok, report} -> {:ok, report}
+          {:error, reason} -> {:error, %{"parsing_error" => %{"error" => reason, "raw" => raw_report}}}
         end
 
       {:error, reason} ->
-        %{"parsing_error" => %{"error" => reason}}
+        {:error, %{"parsing_error" => %{"error" => reason}}}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,38 +3,7 @@ defmodule Mix.Tasks.Compile.Appsignal do
 
   def run(_args) do
     {_, _} = Code.eval_file("mix_helpers.exs")
-
-    case Mix.Appsignal.Helper.verify_system_architecture() do
-      {:ok, arch} ->
-        case Mix.Appsignal.Helper.ensure_downloaded(arch) do
-          :ok ->
-            :ok = Mix.Appsignal.Helper.compile()
-            :ok = Mix.Appsignal.Helper.store_architecture(arch)
-
-          {:error, _reason} ->
-            Mix.Shell.IO.error(
-              "Failed to download AppSignal agent. AppSignal integration disabled!"
-            )
-        end
-
-      {:error, {:unsupported, arch}} ->
-        Mix.Shell.IO.error(
-          "Unsupported target platform #{arch}, AppSignal integration " <>
-            "disabled!\nPlease check " <>
-            "http://docs.appsignal.com/support/operating-systems.html"
-        )
-
-        :ok = Mix.Appsignal.Helper.store_architecture(arch)
-
-      {:error, {:unknown, {arch, platform}}} ->
-        Mix.Shell.IO.error(
-          "Unknown target platform #{arch} - #{platform}, AppSignal " <>
-            "integration disabled!\nPlease check " <>
-            "http://docs.appsignal.com/support/operating-systems.html"
-        )
-
-        :ok = Mix.Appsignal.Helper.store_architecture(arch)
-    end
+    Mix.Appsignal.Helper.install()
   end
 end
 

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -8,7 +8,6 @@ defmodule Mix.Appsignal.Helper do
   @system Application.get_env(:appsignal, :mix_system, System)
 
   @max_retries 5
-  @env Mix.env
 
   def install() do
     report = initial_report()
@@ -374,7 +373,6 @@ defmodule Mix.Appsignal.Helper do
         otp_version: System.otp_release()
       },
       build: %{
-        env: @env,
         time: DateTime.to_iso8601(DateTime.utc_now()),
         package_path: priv_dir(),
         architecture: nil,
@@ -391,7 +389,7 @@ defmodule Mix.Appsignal.Helper do
 
   defp write_report(report) do
     write_download_report(report)
-    write_report_file("install_#{@env}", report)
+    write_report_file("install", report)
   end
 
   defp write_download_report(%{download: %{}} = report) do

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -8,108 +8,129 @@ defmodule Mix.Appsignal.Helper do
   @system Application.get_env(:appsignal, :mix_system, System)
 
   @max_retries 5
+  @env Mix.env
 
-  def verify_system_architecture() do
-    input_arch = :erlang.system_info(:system_architecture)
-    map_arch(input_arch, agent_platform())
+  def install() do
+    report = initial_report()
+
+    case verify_system_architecture(report) do
+      {:ok, {arch, report}} ->
+        case find_package_source(arch, report) do
+          {:ok, {arch_config, %{build: %{source: "remote"}} = report}} ->
+            download_and_compile(arch_config, report)
+
+          {:ok, report} ->
+            # Installation using already downloaded package of the extension
+            compile(report)
+
+          {:error, {reason, report}} ->
+            abort_installation(reason, report)
+        end
+
+      {:error, {reason, report}} ->
+        abort_installation(reason, report)
+    end
   end
 
-  def ensure_downloaded(arch) do
-    arch_config = Appsignal.Agent.triples()[arch]
-
+  defp find_package_source(arch, report) do
+    architecture_key = arch_key(arch)
+    arch_config = Appsignal.Agent.triples()[architecture_key]
     System.put_env("LIB_DIR", priv_dir())
 
-    if has_local_release_files?() do
-      Mix.shell().info("AppSignal: Using local agent release.")
-      File.mkdir_p!(priv_dir())
-      clean_up_extension_files()
-
-      Enum.each(
-        ["appsignal.h", "appsignal-agent", "appsignal.version", "libappsignal.a"],
-        fn file ->
-          File.cp(project_ext_path(file), priv_path(file))
-        end
-      )
-    else
-      if has_files?() and has_correct_agent_version?() do
-        :ok
-      else
-        if is_nil(arch_config) do
-          raise Mix.Error,
-            message: """
-            No config found for architecture '#{arch}'.
-            Please check http://docs.appsignal.com/support/operating-systems.html
-            And inform us about this error at support@appsignal.com
-            """
-        end
-
-        version = Appsignal.Agent.version()
+    cond do
+      has_local_release_files?() ->
+        Mix.shell().info("AppSignal: Using local agent release.")
         File.mkdir_p!(priv_dir())
         clean_up_extension_files()
 
-        try do
-          download_and_extract(arch_config[:download_url], version, arch_config[:checksum])
-        catch
-          {:checksum_mismatch, filename, _, _} ->
-            File.rm!(filename)
+        Enum.each(
+          ["appsignal.h", "appsignal-agent", "appsignal.version", "libappsignal.a"],
+          fn file ->
+            File.cp(project_ext_path(file), priv_path(file))
+          end
+        )
 
-            try do
-              download_and_extract(arch_config[:download_url], version, arch_config[:checksum])
-            catch
-              {:checksum_mismatch, filename, calculated, expected} ->
-                raise Mix.Error,
-                  message: """
-                  Checksum verification of #{filename} failed!
-                  Calculated: #{calculated}
-                  Expected: #{expected}
-                  """
+        {:ok, merge_report(report, %{build: %{source: "local"}})}
+
+      has_files?() and has_correct_agent_version?() ->
+        {:ok, merge_report(report, %{build: %{source: "cached_in_priv_dir"}})}
+
+      is_nil(arch_config) ->
+        {:error,
+         {"No architecture build found for '#{architecture_key}'.",
+          merge_report(report, %{build: %{source: "remote"}})}}
+
+      true ->
+        {:ok, {arch_config, merge_report(report, %{build: %{source: "remote"}})}}
+    end
+  end
+
+  defp download_and_compile(arch_config, report) do
+    report = merge_report(report, %{download: %{checksum: "unverified"}})
+    case download_package(arch_config, report) do
+      {:ok, {filename, report}} ->
+        case verify_download_package(filename, arch_config[:checksum], report) do
+          {:ok, {filename, report}} ->
+            case extract_package(filename) do
+              :ok ->
+                compile(report)
+
+              {:error, reason} ->
+                abort_installation(reason, report)
             end
+
+          {:error, {reason, report}} ->
+            abort_installation(reason, report)
         end
-      end
+
+      {:error, {reason, report}} ->
+        abort_installation(reason, report)
     end
   end
 
-  def store_architecture(arch) do
+  defp download_package(arch_config, report) do
+    version = Appsignal.Agent.version()
     File.mkdir_p!(priv_dir())
+    clean_up_extension_files()
+    url = arch_config[:download_url]
+    report = merge_report(report, %{download: %{download_url: url}})
 
-    case File.open(priv_path("appsignal.architecture"), [:write]) do
-      {:ok, file} ->
-        result = IO.binwrite(file, arch)
-        File.close(file)
-        result
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp download_and_extract(url, version, checksum) do
-    case download_file(url, version) do
-      {:ok, filename} ->
-        filename
-        |> verify_checksum(checksum)
-        |> extract
-
-      error ->
-        error
-    end
-  end
-
-  defp download_file(url, version) do
     filename = Path.join(tmp_dir(), "appsignal-agent-#{version}.tar.gz")
 
     case File.exists?(filename) do
       true ->
-        {:ok, filename}
+        {:ok, {filename, merge_report(report, %{build: %{source: "cached_in_tmp_dir"}})}}
 
       false ->
         Mix.shell().info("Downloading agent release from #{url}")
         :application.ensure_all_started(:hackney)
 
         case do_download_file!(url, filename, @max_retries) do
-          :ok -> {:ok, filename}
-          error -> error
+          :ok ->
+            {:ok, {filename, report}}
+
+          error ->
+            {:error, {error, report}}
         end
+    end
+  end
+
+  defp verify_download_package(filename, expected_checksum, report) do
+    data = File.read!(filename)
+    calculated_checksum = :crypto.hash(:sha256, data) |> Base.encode16(case: :lower)
+
+    if calculated_checksum == expected_checksum do
+      {:ok, {filename, merge_report(report, %{download: %{checksum: "verified"}})}}
+    else
+      sub_report = %{download: %{checksum: "invalid"}}
+
+      reason = """
+      Checksum verification of #{filename} failed!
+      Calculated: #{calculated_checksum}
+      Expected: #{expected_checksum}
+      """
+
+      {:error, {reason, merge_report(report, sub_report)}}
     end
   end
 
@@ -135,18 +156,7 @@ defmodule Mix.Appsignal.Helper do
     end
   end
 
-  defp verify_checksum(filename, expected) do
-    data = File.read!(filename)
-    calculated = :crypto.hash(:sha256, data) |> Base.encode16(case: :lower)
-
-    if calculated != expected do
-      throw({:checksum_mismatch, filename, calculated, expected})
-    end
-
-    filename
-  end
-
-  defp extract(filename) do
+  defp extract_package(filename) do
     case System.cmd("tar", ["zxf", filename, "--no-same-owner"],
            stderr_to_stdout: true,
            cd: priv_dir()
@@ -156,30 +166,60 @@ defmodule Mix.Appsignal.Helper do
 
       {result, _exitcode} ->
         IO.binwrite(result)
-
-        raise Mix.Error,
-          message: """
-          Extracting of #{filename} failed!
-          """
+        {:error, "Extracting of #{filename} failed!"}
     end
   end
 
-  def compile do
+  defp compile(report) do
     {result, error_code} = System.cmd(make(), make_args(to_string(Mix.env())))
     IO.binwrite(result)
+    report = merge_report(report, %{build: %{agent_version: agent_version()}})
 
-    if error_code != 0 do
-      raise Mix.Error,
-        message: """
-        Could not run `make`. Please check if `make` and either `clang` or `gcc` are installed
-        """
+    if error_code == 0 do
+      Mix.shell().info("AppSignal extension installation successful")
+      write_report(merge_report(report, %{result: %{status: :success}}))
+      :ok
+    else
+      reason = """
+      Could not run `make`. Please check if `make` and either `clang` or `gcc` are installed
+      """
+
+      abort_installation(reason, report)
     end
-
-    :ok
   end
 
   defp make_args("test" <> _), do: ["-e", "CFLAGS_ADD=-DTEST"]
   defp make_args(_), do: []
+
+  defp verify_system_architecture(report) do
+    input_arch = :erlang.system_info(:system_architecture)
+
+    case map_arch(input_arch, agent_platform()) do
+      {:ok, {arch, target} = architecture} ->
+        sub_report = %{build: %{architecture: arch, target: target}}
+        {:ok, {architecture, merge_report(report, sub_report)}}
+
+      {:error, {:unsupported, {arch, target}}} ->
+        sub_report = %{build: %{architecture: arch, target: target}}
+
+        reason =
+          "Unsupported target platform #{arch} - #{target}, AppSignal " <>
+            "integration disabled!\nPlease check " <>
+            "http://docs.appsignal.com/support/operating-systems.html"
+
+        {:error, {reason, merge_report(report, sub_report)}}
+
+      {:error, {:unknown, {arch, target}}} ->
+        sub_report = %{build: %{architecture: arch, target: target}}
+
+        reason =
+          "Unknown target platform #{arch} - #{target}, AppSignal " <>
+            "integration disabled!\nPlease check " <>
+            "http://docs.appsignal.com/support/operating-systems.html"
+
+        {:error, {reason, merge_report(report, sub_report)}}
+    end
+  end
 
   if Mix.env() != :test_no_nif do
     defp map_arch('i386-' ++ _, platform), do: build_for("i686", platform)
@@ -192,12 +232,16 @@ defmodule Mix.Appsignal.Helper do
   defp map_arch(arch, platform), do: {:error, {:unknown, {arch, platform}}}
 
   defp build_for(bit, platform) do
-    arch = "#{bit}-#{platform}"
+    arch = {bit, platform}
 
-    case Map.has_key?(Appsignal.Agent.triples(), arch) do
+    case Map.has_key?(Appsignal.Agent.triples(), arch_key(arch)) do
       true -> {:ok, arch}
       false -> {:error, {:unsupported, arch}}
     end
+  end
+
+  defp arch_key({arch, target}) do
+    "#{arch}-#{target}"
   end
 
   defp tmp_dir do
@@ -227,20 +271,22 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp has_files? do
-    has_file("appsignal-agent") and
-      has_file("appsignal.h") and
-      has_file("appsignal_extension.so")
+    has_file("appsignal-agent") and has_file("appsignal.h") and has_file("appsignal_extension.so")
   end
 
   defp has_local_release_files? do
-    has_local_ext_file("appsignal-agent") and
-      has_local_ext_file("appsignal.h") and
+    has_local_ext_file("appsignal-agent") and has_local_ext_file("appsignal.h") and
       has_local_ext_file("libappsignal.a")
   end
 
   defp has_correct_agent_version? do
+    agent_version() == Appsignal.Agent.version()
+  end
+
+  defp agent_version do
     path = priv_path("appsignal.version")
-    File.read(path) == {:ok, "#{Appsignal.Agent.version()}\n"}
+    {:ok, agent_version} = File.read(path)
+    String.trim(agent_version)
   end
 
   defp clean_up_extension_files do
@@ -248,6 +294,17 @@ defmodule Mix.Appsignal.Helper do
     |> Path.join("*appsignal*")
     |> Path.wildcard()
     |> Enum.each(&File.rm_rf!/1)
+  end
+
+  defp library_dependencies do
+    ldd_version_output = ldd_version_output()
+    case extract_ldd_version(ldd_version_output) do
+      nil ->
+        %{}
+
+      ldd_version ->
+        %{libc: ldd_version}
+    end
   end
 
   def agent_platform do
@@ -266,7 +323,164 @@ defmodule Mix.Appsignal.Helper do
     end
   end
 
-  def priv_dir() do
+  defp agent_platform_by_ldd_version do
+    case ldd_version_output() do
+      nil ->
+        "linux"
+
+      output ->
+        case String.contains?(output, "musl") do
+          true ->
+            "linux-musl"
+
+          false ->
+            ldd_version = extract_ldd_version(output)
+
+            case Version.compare("#{ldd_version}.0", "2.15.0") do
+              :lt -> "linux-musl"
+              _ -> "linux"
+            end
+        end
+    end
+  rescue
+    _ -> "linux"
+  end
+
+  # Fetches the libc version number from the `ldd` command
+  # If `ldd` is not found it returns `nil`
+  defp ldd_version_output do
+    {output, _} = @system.cmd("ldd", ["--version"], stderr_to_stdout: true)
+    output
+  rescue
+    _ -> nil
+  end
+
+  defp extract_ldd_version(nil), do: nil
+
+  defp extract_ldd_version(ldd_output) do
+    List.first(Regex.run(~r/\d+\.\d+/, ldd_output))
+  end
+
+  defp initial_report do
+    {_, os} = :os.type()
+
+    %{
+      result: %{
+        status: :incomplete
+      },
+      language: %{
+        name: "elixir",
+        version: System.version(),
+        otp_version: System.otp_release()
+      },
+      build: %{
+        env: @env,
+        time: DateTime.to_iso8601(DateTime.utc_now()),
+        package_path: priv_dir(),
+        architecture: nil,
+        target: os,
+        musl_override: force_musl_build?(),
+        library_type: "static"
+      },
+      host: %{
+        root_user: root?(),
+        dependencies: library_dependencies()
+      }
+    }
+  end
+
+  defp write_report(report) do
+    write_download_report(report)
+    write_report_file("install_#{@env}", report)
+  end
+
+  defp write_download_report(%{download: %{}} = report) do
+    %{
+      build: %{
+        time: time,
+        architecture: architecture,
+        target: target,
+        musl_override: musl_override,
+        library_type: library_type
+      }
+    } = report
+    %{
+      download: %{
+        download_url: download_url,
+        checksum: checksum
+      }
+    } = report
+
+    download_report = %{
+      download: %{
+        time: time,
+        architecture: architecture,
+        target: target,
+        musl_override: musl_override,
+        library_type: library_type,
+        download_url: download_url,
+        checksum: checksum || "unverified"
+      }
+    }
+    write_report_file("download", download_report)
+  end
+
+  defp write_download_report(_) do
+    # Write nothing if no download details are recorded in the report
+  end
+
+  defp write_report_file(file, report) do
+    case Poison.encode(report) do
+      {:ok, body} ->
+        File.mkdir_p!(priv_dir())
+
+        filename = "#{file}.report"
+        case File.open(priv_path(filename), [:write]) do
+          {:ok, file} ->
+            result = IO.binwrite(file, body)
+            File.close(file)
+            result
+
+          {:error, reason} ->
+            Mix.Shell.IO.error("Error: Could not write AppSignal report file '#{file}'.\n#{reason}")
+            {:error, reason}
+        end
+
+      {:error, error} ->
+        Mix.Shell.IO.error("Error: Could not encode AppSignal report file '#{file}'.\n#{error}")
+    end
+  end
+
+  defp merge_report(report, %{download: _download_report} = sub_report) do
+    key = :download
+    {download_report, sub_report} = Map.pop(sub_report, key)
+    report = Map.put(report, key, Map.merge(report[key] || %{}, download_report))
+    merge_report(report, sub_report)
+  end
+
+  defp merge_report(report, %{build: _build_report} = sub_report) do
+    key = :build
+    {build_report, sub_report} = Map.pop(sub_report, key)
+    report = Map.put(report, key, Map.merge(report[key], build_report))
+    merge_report(report, sub_report)
+  end
+
+  defp merge_report(report, %{result: _installation_report} = sub_report) do
+    key = :result
+    {installation_report, sub_report} = Map.pop(sub_report, key)
+    report = Map.put(report, key, installation_report)
+    merge_report(report, sub_report)
+  end
+
+  defp merge_report(report, %{}), do: report
+
+  defp abort_installation(reason, report) do
+    report = merge_report(report, %{result: %{status: :failed, message: reason}})
+    write_report(report)
+    Mix.Shell.IO.error("AppSignal installation failed: #{reason}")
+  end
+
+  defp priv_dir() do
     case :code.priv_dir(:appsignal) do
       {:error, :bad_name} ->
         # This happens on initial compilation
@@ -282,32 +496,28 @@ defmodule Mix.Appsignal.Helper do
     end
   end
 
-  defp agent_platform_by_ldd_version do
-    try do
-      {output, _} = @system.cmd("ldd", ["--version"], stderr_to_stdout: true)
-
-      case String.contains?(output, "musl") do
-        true ->
-          "linux-musl"
-
-        false ->
-          ldd_version = List.first(Regex.run(~r/\d+\.\d+/, output))
-
-          case Version.compare("#{ldd_version}.0", "2.15.0") do
-            :lt -> "linux-musl"
-            _ -> "linux"
-          end
-      end
-    rescue
-      _ -> "linux"
-    end
-  end
-
   defp force_musl_build? do
     !is_nil(System.get_env("APPSIGNAL_BUILD_FOR_MUSL"))
   end
 
   defp make do
     if System.find_executable("gmake"), do: "gmake", else: "make"
+  end
+
+  def root? do
+    uid() == 0
+  end
+
+  def uid do
+    case System.cmd("id", ["-u"]) do
+      {id, 0} ->
+        case Integer.parse(List.first(String.split(id, "\n"))) do
+          {int, _} -> int
+          :error -> nil
+        end
+
+      {_, _} ->
+        nil
+    end
   end
 end

--- a/test/appsignal/system_test.exs
+++ b/test/appsignal/system_test.exs
@@ -15,22 +15,4 @@ defmodule Appsignal.SystemTest do
       assert Appsignal.System.heroku?()
     end
   end
-
-  describe ".installed_agent_architecture" do
-    test "returns nil if the architecture doesn't exist" do
-      File.rm(agent_architecture_path())
-      assert Appsignal.System.installed_agent_architecture() == nil
-    end
-
-    test "returns the architecure if appsignal.architecure exists" do
-      File.write(agent_architecture_path(), "x86_64-linux")
-      assert Appsignal.System.installed_agent_architecture() == "x86_64-linux"
-    end
-  end
-
-  defp agent_architecture_path do
-    :appsignal
-    |> Application.app_dir()
-    |> Path.join("priv/appsignal.architecture")
-  end
 end

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   import AppsignalTest.Utils
   alias Appsignal.{Diagnose.FakeReport, FakeSystem, FakeNif}
 
+  @env Mix.env()
   @appsignal_version Mix.Project.config()[:version]
   @agent_version Appsignal.Nif.agent_version()
 
@@ -69,6 +70,188 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert String.contains?(output, "support@appsignal.com")
   end
 
+  @tag :skip_env_test_no_nif
+  test "adds extension install report to report", %{fake_report: fake_report} do
+    run()
+    report = received_report(fake_report)
+
+    install_report = report[:installation]
+    assert Map.keys(install_report) == ["build", "download", "host", "language", "result"]
+    assert install_report["result"] == %{"status" => "success"}
+
+    assert install_report["language"] == %{
+             "name" => "elixir",
+             "version" => System.version(),
+             "otp_version" => System.otp_release()
+           }
+
+    host_report = install_report["host"]
+    assert host_report["root_user"] == false
+    assert is_map(host_report["dependencies"])
+
+    # Incomplete list for common test values
+    valid_architectures = ["x86", "x86_64"]
+    valid_targets = ["darwin", "linux", "linux-gnu"]
+    valid_sources = ["remote", "cached_in_priv_dir", "cached_in_tmp_dir"]
+
+    download_report = install_report["download"]
+    assert is_binary(download_report["time"])
+    assert String.starts_with?(download_report["download_url"], "https://")
+    assert Enum.member?(valid_architectures, download_report["architecture"])
+    assert Enum.member?(valid_targets, download_report["target"])
+    assert download_report["musl_override"] == false
+    assert download_report["library_type"] == "static"
+    assert download_report["checksum"] == "verified"
+
+    build_report = install_report["build"]
+    assert is_binary(build_report["time"])
+    assert is_binary(build_report["package_path"])
+    assert build_report["agent_version"] == @agent_version
+    assert build_report["env"] == Atom.to_string(@env)
+    assert Enum.member?(valid_sources, build_report["source"])
+    assert Enum.member?(valid_architectures, build_report["architecture"])
+    assert Enum.member?(valid_targets, build_report["target"])
+    assert download_report["musl_override"] == false
+    assert build_report["library_type"] == "static"
+  end
+
+  @tag :skip_env_test_no_nif
+  test "prints the extension installation report" do
+    output = run()
+    assert String.contains?(output, "Extension installation report")
+    assert String.contains?(output, "Language details")
+    assert String.contains?(output, "  Elixir version: #{System.version()}")
+    assert String.contains?(output, "  OTP version: #{System.otp_release()}")
+
+    assert String.contains?(output, "Download details")
+    assert String.contains?(output, "  Download time: \"20")
+    assert String.contains?(output, "  Download URL: \"https://")
+    assert output =~ ~r{Architecture: "x86(_64)?"}
+    assert output =~ ~r{Target: "[\w-]+"}
+    assert String.contains?(output, "  Musl override: false")
+    assert String.contains?(output, "  Library type: \"static\"")
+    assert output =~ ~r{Checksum: "(verified|unverified)"}
+
+    assert String.contains?(output, "Build details")
+    assert String.contains?(output, "  Install time: \"20")
+    assert output =~ ~r{Source: "[\w]+"}
+    assert String.contains?(output, "  Agent version: \"#{@agent_version}\"")
+
+    assert String.contains?(output, "Host details")
+    assert output =~ ~r{Root user: (true|false)}
+    assert String.contains?(output, "  Dependencies: %{")
+  end
+
+  describe "when the extension installation failed" do
+    @tag :skip_env_test
+    @tag :skip_env_test_phoenix
+    test "adds an error to the installation report", %{fake_report: fake_report} do
+      run()
+      report = received_report(fake_report)
+
+      install_report = report[:installation]["result"]
+      assert install_report["status"] == "failed"
+      assert String.starts_with?(install_report["message"], "Unknown target platform")
+    end
+
+    @tag :skip_env_test
+    @tag :skip_env_test_phoenix
+    test "prints the report" do
+      output = run()
+      assert String.contains?(output, "Extension installation report")
+      assert String.contains?(output, "  Installation result")
+      assert String.contains?(output, "  Status: \"failed\"")
+      assert String.contains?(output, "  Message: \"Unknown target platform")
+      assert output =~ ~r{Checksum: "(verified|unverified)"}
+      assert String.contains?(output, "  Source: nil")
+    end
+  end
+
+  describe "when the report file is not readable" do
+    setup do
+      download_report = Path.join([:code.priv_dir(:appsignal), "download.report"])
+      install_report = Path.join([:code.priv_dir(:appsignal), "install_#{@env}.report"])
+      File.chmod(download_report, 0o000)
+      File.chmod(install_report, 0o000)
+
+      on_exit(:reset, fn ->
+        File.chmod(download_report, 0o644)
+        File.chmod(install_report, 0o644)
+      end)
+    end
+
+    test "adds an error to the installation report", %{fake_report: fake_report} do
+      run()
+      report = received_report(fake_report)
+
+      assert report[:installation] == %{
+               "download_parsing_error" => %{"error" => :eacces},
+               "installation_parsing_error" => %{"error" => :eacces}
+             }
+    end
+
+    test "prints a parsing error" do
+      output = run()
+      assert String.contains?(output, "Extension installation report")
+
+      assert String.contains?(
+               output,
+               "  Error found while parsing the download report.\n  Error: :eacces"
+             )
+
+      assert String.contains?(
+               output,
+               "  Error found while parsing the installation report.\n  Error: :eacces"
+             )
+    end
+  end
+
+  describe "when the report file is not valid JSON" do
+    setup do
+      download_report = Path.join([:code.priv_dir(:appsignal), "download.report"])
+      install_report = Path.join([:code.priv_dir(:appsignal), "install_#{@env}.report"])
+      download_contents = File.read!(download_report)
+      install_contents = File.read!(install_report)
+      File.write(download_report, "download report")
+      File.write(install_report, "install report")
+
+      on_exit(:reset, fn ->
+        File.write!(download_report, download_contents)
+        File.write!(install_report, install_contents)
+      end)
+    end
+
+    test "adds an error to the installation report with the raw report", %{
+      fake_report: fake_report
+    } do
+      run()
+      report = received_report(fake_report)
+
+      install_report = report[:installation]
+      assert Map.keys(install_report) == ["download_parsing_error", "installation_parsing_error"]
+
+      download_report = install_report["download_parsing_error"]
+      assert Map.keys(download_report) == ["error", "raw"]
+      refute download_report["error"] == nil
+      assert download_report["raw"] == "download report"
+
+      installation_report = install_report["installation_parsing_error"]
+      assert Map.keys(installation_report) == ["error", "raw"]
+      refute installation_report["error"] == nil
+      assert installation_report["raw"] == "install report"
+    end
+
+    test "prints a parsing error" do
+      output = run()
+
+      assert output =~
+               ~r{  Error found while parsing the download report.\n  Error: .+\n  Raw report:\n"download report"}
+
+      assert output =~
+               ~r{  Error found while parsing the installation report.\n  Error: .+\n  Raw report:\n"install report"}
+    end
+  end
+
   test "outputs library information" do
     output = run()
     assert String.contains?(output, "AppSignal agent")
@@ -83,7 +266,6 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
     assert report[:library] == %{
              agent_version: @agent_version,
-             agent_architecture: Appsignal.System.installed_agent_architecture(),
              extension_loaded: Appsignal.Nif.loaded?(),
              language: "elixir",
              package_version: @appsignal_version

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -4,7 +4,6 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   import AppsignalTest.Utils
   alias Appsignal.{Diagnose.FakeReport, FakeSystem, FakeNif}
 
-  @env Mix.env()
   @appsignal_version Mix.Project.config()[:version]
   @agent_version Appsignal.Nif.agent_version()
 
@@ -107,7 +106,6 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert is_binary(build_report["time"])
     assert is_binary(build_report["package_path"])
     assert build_report["agent_version"] == @agent_version
-    assert build_report["env"] == Atom.to_string(@env)
     assert Enum.member?(valid_sources, build_report["source"])
     assert Enum.member?(valid_architectures, build_report["architecture"])
     assert Enum.member?(valid_targets, build_report["target"])
@@ -163,7 +161,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   describe "when the report file is not readable" do
     setup do
       download_report = Path.join([:code.priv_dir(:appsignal), "download.report"])
-      install_report = Path.join([:code.priv_dir(:appsignal), "install_#{@env}.report"])
+      install_report = Path.join([:code.priv_dir(:appsignal), "install.report"])
       File.chmod(download_report, 0o000)
       File.chmod(install_report, 0o000)
 
@@ -201,7 +199,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
   describe "when the install report file is not readable" do
     setup do
-      install_report = Path.join([:code.priv_dir(:appsignal), "install_#{@env}.report"])
+      install_report = Path.join([:code.priv_dir(:appsignal), "install.report"])
       File.chmod(install_report, 0o000)
 
       on_exit(:reset, fn ->
@@ -222,6 +220,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       assert String.contains?(output, "Extension installation report")
       refute String.contains?(output, "Error found while parsing the download report.")
       assert_output_contains_download_report(output)
+
       assert String.contains?(
                output,
                "  Error found while parsing the installation report.\n  Error: :eacces"
@@ -232,7 +231,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   describe "when the report file is not valid JSON" do
     setup do
       download_report = Path.join([:code.priv_dir(:appsignal), "download.report"])
-      install_report = Path.join([:code.priv_dir(:appsignal), "install_#{@env}.report"])
+      install_report = Path.join([:code.priv_dir(:appsignal), "install.report"])
       download_contents = File.read!(download_report)
       install_contents = File.read!(install_report)
       File.write(download_report, "download report")


### PR DESCRIPTION
Ruby counterpart: https://github.com/appsignal/appsignal-ruby/pull/450
Server PR: https://github.com/appsignal/appsignal-server/pull/3917

---

This report allows us to see what the environment was when the AppSignal
extension was installed, so we can compare it to the diagnose report
generated by `mix appsignal.diagnose` afterwards.

Basic information, such as information about Elixir, the chosen agent
and extension build.

Combine the information from the `install.log` and
`appsignal.architecture` files in one file that stores more easily
parseable metadata.

## Screenshots

Extension installation subreport section
![image](https://user-images.githubusercontent.com/282402/51399653-bf245200-1b46-11e9-8ae0-b03b56bf018c.png)

