### PR TITLE
Begin fixing Dialyzer errors and bump Dialyxir.

### DIFF
--- a/lib/appsignal/error.ex
+++ b/lib/appsignal/error.ex
@@ -8,7 +8,7 @@ defmodule Appsignal.Error do
     {name(exception), Exception.message(exception)}
   end
 
-  @spec normalize(any, Exception.stactrace()) :: {Exception.t(), list(String.t())}
+  @spec normalize(any, Exception.stacktrace()) :: {Exception.t(), list(String.t())}
   if Appsignal.plug?() do
     def normalize(%Plug.Conn.WrapperError{reason: error, stack: _stacktrace}, stacktrace) do
       normalize(error, stacktrace)
@@ -36,7 +36,7 @@ defmodule Appsignal.Error do
 
   def normalize(error, stacktrace), do: do_normalize(error, stacktrace)
 
-  @spec do_normalize(any, Exception.stactrace()) :: {Exception.t(), list(String.t())}
+  @spec do_normalize(any, Exception.stacktrace()) :: {Exception.t(), list(String.t())}
   defp do_normalize(error, stacktrace) do
     exception = Exception.normalize(:error, error, stacktrace)
     {exception, stacktrace}

--- a/mix.exs
+++ b/mix.exs
@@ -127,7 +127,7 @@ defmodule Appsignal.Mixfile do
       {:plug_cowboy, "~> 1.0", only: [:test, :test_phoenix, :test_no_nif]},
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
+      {:dialyxir, "~> 1.0.0-rc4", only: [:dev], runtime: false}
     ]
   end
 end


### PR DESCRIPTION
One thing I saw in the remaining errors:

```
ib/appsignal/diagnose/agent.ex:10:call
The call:
Poison.decode(_report_string :: :error)

will never return since the success typing is:
(
  binary()
  | maybe_improper_list(
      binary() | maybe_improper_list(any(), binary() | []) | byte(),
      binary() | []
    )
) ::
  {:error,
   %{
     :__exception__ => true,
     :__struct__ => Poison.DecodeError | Poison.ParseError,
     :value => _,
     :message => binary(),
     :pos => integer(),
     :rest => _
   }}
  | {:ok, _}

and the contract is
(iodata()) :: {:ok, Poison.Parser.t()} | {:error, Poison.ParseError.t()}
```

Looking through the code, that's exactly what happens.

```elixir
  def report do
    if @nif.loaded? do
      Appsignal.Nif.env_put("_APPSIGNAL_DIAGNOSE", "true")
      report_string = @nif.diagnose

      # snip
      {:error, :nif_not_loaded}
    end
  end

# snip + change file 

  def diagnose do
    _diagnose()
  end

# snip

  def _diagnose do
    :error
  end
```

What is the intention here? It does not appear to be part of the `AppSignal.NifBehaviour` but not overriding it seems to result in Dialyzer failing there. That looks to be contributing to the remaining errors after this PR. 