### PR TITLE
Document how to attach to new telemetry versions.

### DIFF
--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -13,6 +13,18 @@ defmodule Appsignal.Ecto do
   application's start/2 function:
 
   ```
+  :telemetry.attach(
+    "appsignal-ecto",
+    [:my_app, :repo, :query],
+    &Appsignal.Ecto.handle_event/4,
+    :handle_event,
+    nil
+  )
+  ```
+
+  For versions of Telemetry < 0.3.0, you'll need to call it slightly differently:
+
+  ```
   Telemetry.attach(
     "appsignal-ecto",
     [:my_app, :repo, :query],

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -17,7 +17,6 @@ defmodule Appsignal.Ecto do
     "appsignal-ecto",
     [:my_app, :repo, :query],
     &Appsignal.Ecto.handle_event/4,
-    :handle_event,
     nil
   )
   ```


### PR DESCRIPTION
For telemetry >= 0.3.0, there is a new calling convention as it is now implemented in Erlang not Elixir. This updates the docs to reflect this.