### PR TITLE
Get tests to pass on Elixir 1.8

### DIFF
--- a/lib/appsignal/diagnose/paths.ex
+++ b/lib/appsignal/diagnose/paths.ex
@@ -9,7 +9,7 @@ defmodule Appsignal.Diagnose.Paths do
       |> Path.join("install.log")
 
     %{
-      working_dir: path_report(System.cwd()),
+      working_dir: path_report(File.cwd!()),
       log_dir_path: path_report(log_dir_path),
       "appsignal.log": path_report(log_file_path),
       "install.log": path_report(install_log_path)

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -234,7 +234,7 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "log_path" do
-      log_path = System.cwd()
+      log_path = File.cwd!()
 
       assert with_config(%{log_path: log_path}, &init_config/0) ==
                default_configuration() |> Map.put(:log_path, log_path)
@@ -428,7 +428,7 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "log_path" do
-      log_path = System.cwd()
+      log_path = File.cwd!()
 
       assert with_env(
                %{"APPSIGNAL_LOG_PATH" => log_path},

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -191,7 +191,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     assert_stacktrace(stacktrace, [
       ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
-      ~r{\(elixir\) lib/task/supervised.ex:\d+: Task.Supervised.do_apply/2},
+      ~r{\(elixir\) lib/(task/)?supervised.ex:\d+: Task.Supervised\.\w+/2},
       ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
     ])
   end

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -153,7 +153,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
   test "Crashing GenServer with function error", %{fake_transaction: fake_transaction} do
     CrashingGenServer.start(:function_error)
 
-    :timer.sleep(20)
+    :timer.sleep(100)
 
     [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
     assert reason == "FunctionClauseError"
@@ -204,7 +204,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
       |> Task.await(1)
     end)
 
-    :timer.sleep(20)
+    :timer.sleep(100)
 
     [{_, reason, message, stacktrace}] = FakeTransaction.errors(fake_transaction)
     assert reason == ":timeout"


### PR DESCRIPTION
Aside from the fixes in #437, there were some tests failing on 1.8.0:

1. `System.cwd/0` is deprecated and throws a warning.
2. Had to increase the sleeps in ErrorMatcherTest to get them to work. Removing sleeps in favor of retries in the test suite is on my list.
3. Made a stacktrace regex more flexible, because code got moved around in 1.8