### PR TITLE
Recommend "prod" instead of "production" in installer

### DIFF
--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -106,7 +106,7 @@ defmodule Mix.Tasks.Appsignal.Install do
     IO.puts("Configuring with environment variables.")
     IO.puts("Please put the following variables in your environment to configure AppSignal.\n")
     IO.puts(~s(  export APPSIGNAL_APP_NAME="#{config[:name]}"))
-    IO.puts(~s(  export APPSIGNAL_APP_ENV="production"))
+    IO.puts(~s(  export APPSIGNAL_APP_ENV="prod"))
     IO.puts(~s(  export APPSIGNAL_PUSH_API_KEY="#{config[:push_api_key]}"))
   end
 

--- a/test/appsignal/diagnose/report_test.exs
+++ b/test/appsignal/diagnose/report_test.exs
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose.ReportTest do
     setup_with_config(%{
       api_key: "foo",
       name: "AppSignal test suite app",
-      environment: "production",
+      environment: "prod",
       diagnose_endpoint: "http://localhost:#{diagnose_bypass.port}/diag"
     })
 

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -168,7 +168,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
       assert String.contains?(output, "What is your preferred configuration method? (1/2): ")
       assert String.contains?(output, "Configuring with environment variables.")
       assert String.contains?(output, ~s(APPSIGNAL_APP_NAME="AppSignal test suite app"))
-      assert String.contains?(output, ~s(APPSIGNAL_APP_ENV="production"))
+      assert String.contains?(output, ~s(APPSIGNAL_APP_ENV="prod"))
       assert String.contains?(output, ~s(APPSIGNAL_PUSH_API_KEY="my_push_api_key"))
     end
 


### PR DESCRIPTION
Elixir’s default environments are called “dev”, “test” and “prod”, as
opposed to Rails’ “development”, “test” and “production”.

This patch changes the recommended APPSIGNAL_APP_ENV from “production”
to “prod” in the installer, when selecting environment variable
configuration.