### PR TITLE
Block on ignoring pids in TransactionRegistry

### DIFF
--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -113,7 +113,12 @@ defmodule Appsignal.TransactionRegistry do
   """
   @spec ignore(pid()) :: :ok
   def ignore(pid) do
-    GenServer.cast(__MODULE__, {:ignore, pid})
+    if registry_alive?() do
+      :ets.insert(@table, {pid, :ignore})
+      :ok
+    else
+      {:error, :no_registry}
+    end
   end
 
   @doc """
@@ -164,12 +169,6 @@ defmodule Appsignal.TransactionRegistry do
     transaction
     |> pids_and_monitor_references()
     |> demonitor
-
-    {:noreply, state}
-  end
-
-  def handle_cast({:ignore, pid}, state) do
-    :ets.insert(@table, {pid, :ignore})
 
     {:noreply, state}
   end

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -58,7 +58,6 @@ defmodule Appsignal.Transaction.RegistryTest do
     test "ignores a pid" do
       pid = :c.pid(0, 991, 0)
       :ok = TransactionRegistry.ignore(pid)
-      :timer.sleep(1)
       assert TransactionRegistry.ignored?(pid) == true
     end
   end
@@ -68,7 +67,7 @@ defmodule Appsignal.Transaction.RegistryTest do
 
     test "can't ignore a pid" do
       pid = :c.pid(0, 992, 0)
-      :ok = TransactionRegistry.ignore(pid)
+      {:error, :no_registry} = TransactionRegistry.ignore(pid)
       assert TransactionRegistry.ignored?(pid) == false
     end
   end


### PR DESCRIPTION
Closes #440.

Ignoring PIDs in a cast in the TransactionRegistry caused race conditions in some situations, which caused errors reported in Plug apps to be registered again in the error logger. This caused `ErlangError`s wrapped in tuples to appear in AppSignal, in the "web" namespace.

This patch makes sure to block when updating the ets table.

*NOTE*: This is a hotfix to be released as 1.9.1.