### PR TITLE
Fix tests for test_no_nif test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ script:
   - MIX_ENV=test scripts/check_warnings
   - MIX_ENV=test mix test
   - MIX_ENV=test_phoenix mix test
-  - rm -r priv/*appsignal* && MIX_ENV=test_no_nif mix test
+  - (cd priv && rm -r *appsignal* *.report) && MIX_ENV=test_no_nif mix test

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -139,20 +139,15 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     download_parsing_error = Map.has_key?(report, "download_parsing_error")
     install_parsing_error = Map.has_key?(report, "installation_parsing_error")
 
-    cond do
-      download_parsing_error ->
-        do_print_parsing_error("download", report)
-
-      install_parsing_error ->
-        do_print_download_report(report)
-
-      true ->
-        nil
+    if download_parsing_error && install_parsing_error do
+      do_print_parsing_error("download", report)
+      do_print_parsing_error("installation", report)
     end
 
-    if install_parsing_error, do: do_print_parsing_error("installation", report)
-
-    if !download_parsing_error && !install_parsing_error do
+    if install_parsing_error do
+      do_print_download_report(report)
+      do_print_parsing_error("installation", report)
+    else
       do_print_installation_report(report)
     end
   end
@@ -198,6 +193,10 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("  Host details")
     IO.puts("    Root user: #{format_value(host_report["root_user"])}")
     IO.puts("    Dependencies: #{format_value(host_report["dependencies"])}")
+  end
+
+  defp do_print_download_report(%{"download_parsing_error" => %{}} = installation_report) do
+    do_print_parsing_error("download", installation_report)
   end
 
   defp do_print_download_report(installation_report) do


### PR DESCRIPTION
This environment broke (more noticeably) after PR #433 added more files to
the `priv/` directory that weren't cleaned properly before running the
test suite. The other test environments left artifacts in the `priv/`
dir that were reused by the `test_no_nif` test suite while they
shouldn't have been.

Clean up the `priv/` dir properly and fix the tests to test it properly.