### PR TITLE
Fail AppSignal extension installation on warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ ifeq ($(shell uname),Darwin)
 	LDFLAGS += -dynamiclib -undefined dynamic_lookup
 endif
 
+LDFLAGS += -Wl,-fatal_warnings
+
 all:
 	@$(CC) $(CFLAGS) $(CFLAGS_ADD) -shared $(LDFLAGS) -o $(OUTPUT) c_src/$(LIB).c
 

--- a/lib/appsignal/diagnose/paths.ex
+++ b/lib/appsignal/diagnose/paths.ex
@@ -3,16 +3,10 @@ defmodule Appsignal.Diagnose.Paths do
     log_file_path = Appsignal.Config.log_file_path() || "/tmp/appsignal.log"
     log_dir_path = Path.dirname(log_file_path)
 
-    install_log_path =
-      :appsignal
-      |> Application.app_dir()
-      |> Path.join("install.log")
-
     %{
       working_dir: path_report(File.cwd!()),
       log_dir_path: path_report(log_dir_path),
-      "appsignal.log": path_report(log_file_path),
-      "install.log": path_report(install_log_path)
+      "appsignal.log": path_report(log_file_path)
     }
   end
 
@@ -20,8 +14,7 @@ defmodule Appsignal.Diagnose.Paths do
     %{
       working_dir: "Working directory",
       log_dir_path: "Log directory",
-      "appsignal.log": "AppSignal log",
-      "install.log": "Extension install log"
+      "appsignal.log": "AppSignal log"
     }
   end
 

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -45,17 +45,11 @@ defmodule Appsignal.Nif do
       {:error, {:load_failed, reason}} ->
         arch = :erlang.system_info(:system_architecture)
 
-        message =
-          "[#{DateTime.utc_now() |> to_string}] Error loading NIF (Is your operating system (#{
-            arch
-          }) supported? Please check http://docs.appsignal.com/support/operating-systems.html):\n#{
+        IO.warn(
+          "Error loading NIF (Is your operating system (#{arch}) supported? Please check http://docs.appsignal.com/support/operating-systems.html):\n#{
             reason
-          }\n\n"
-
-        :appsignal
-        |> Application.app_dir()
-        |> Path.join("install.log")
-        |> File.write(message, [:append])
+          }"
+        )
 
         :ok
     end

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -170,8 +170,7 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp compile(report) do
-    {result, error_code} = System.cmd(make(), make_args(to_string(Mix.env())))
-    IO.binwrite(result)
+    {result, error_code} = System.cmd(make(), make_args(to_string(Mix.env())), [stderr_to_stdout: true])
     report = merge_report(report, %{build: %{agent_version: agent_version()}})
 
     if error_code == 0 do
@@ -180,7 +179,9 @@ defmodule Mix.Appsignal.Helper do
       :ok
     else
       reason = """
-      Could not run `make`. Please check if `make` and either `clang` or `gcc` are installed
+      Build error was encountered while running `make`:
+
+      #{result}
       """
 
       abort_installation(reason, report)


### PR DESCRIPTION
When a warning occurs during the extension installation, fail the
installation. Currently warnings such as linking issues are not cause
for a failed installation, such as #406.

This was replicated by trying to install the linux-gnu build on macOS,
this did not caused the installation to be registered as "failed". This
was unexpected behavior.

Since we don't think the `install.log` will catch any more problems than
the `install.report` now that it also fails on warnings, remove the
`install.log` and instead print the error in the app's STDOUT so the
user can see if anything is wrong.

## TODO

- [x] Test if normal `linux-gnu` and `linux-musl` builds generate any warnings by default, causing the installation to always fail with this change.