### PR TITLE
Add response status codes to Plug samples

### DIFF
--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -141,7 +141,7 @@ if Appsignal.plug?() do
       |> Enum.into(%{})
     end
 
-    def extract_meta_data(%Plug.Conn{method: method, request_path: path} = conn) do
+    def extract_meta_data(%Plug.Conn{method: method, request_path: path, status: status} = conn) do
       request_id =
         conn
         |> Plug.Conn.get_resp_header("x-request-id")
@@ -150,7 +150,8 @@ if Appsignal.plug?() do
       %{
         "method" => method,
         "path" => path,
-        "request_id" => request_id
+        "request_id" => request_id,
+        "status" => status
       }
     end
 

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -324,11 +324,13 @@ defmodule Appsignal.PlugTest do
       assert Appsignal.Plug.extract_meta_data(%Plug.Conn{
                method: "GET",
                request_path: "/foo",
-               resp_headers: [{"x-request-id", "kk4hk5sis7c3b56t683nnmdig632c9ot"}]
+               resp_headers: [{"x-request-id", "kk4hk5sis7c3b56t683nnmdig632c9ot"}],
+               status: 200
              }) == %{
                "method" => "GET",
                "path" => "/foo",
-               "request_id" => "kk4hk5sis7c3b56t683nnmdig632c9ot"
+               "request_id" => "kk4hk5sis7c3b56t683nnmdig632c9ot",
+               "status" => 200
              }
     end
   end


### PR DESCRIPTION
Like https://github.com/appsignal/appsignal-ruby/issues/183, but for Elixir. As requested via [support](https://app.intercom.io/a/apps/yzor8gyw/inbox/inbox/540654/conversations/20586098866) (private Intercom link). Opening this pull request instead of an issue since the implementation was mostly done answering their question.

I recommend tagging samples manually until we merge this. That would look something like this;

```elixir
defmodule AppsignalPhoenixExampleWeb.PageController do
  use AppsignalPhoenixExampleWeb, :controller

  def index(conn, _params) do
    conn = render(conn, "index.html")
    Appsignal.Transaction.set_sample_data("tags", %{status: to_string(conn.status)})
    conn
  end
end
```

When using the temporary solution: Some things to note is to update the conn with the result of your render/2 call to make sure the response code is set. Also; don’t forget to return the conn from your action, as Appsignal.Transaction.set_sample_data/2 returns the Appsignal.Transaction struct.