### PR TITLE
Use :logger instead of :error_logger on OTP >= 21

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -31,7 +31,7 @@ defmodule Appsignal do
 
     initialize()
 
-    :error_logger.add_report_handler(Appsignal.ErrorHandler)
+    :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
 
     children = [
       worker(Appsignal.TransactionRegistry, [])

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -30,12 +30,7 @@ defmodule Appsignal do
     import Supervisor.Spec, warn: false
 
     initialize()
-
-    if(Process.whereis(:logger)) do
-      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
-    else
-      :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
-    end
+    add_report_handler()
 
     children = [
       worker(Appsignal.TransactionRegistry, [])
@@ -96,6 +91,24 @@ defmodule Appsignal do
           "Warning: No valid AppSignal configuration found, continuing with " <>
             "AppSignal metrics disabled."
         )
+    end
+  end
+
+  @doc false
+  def add_report_handler do
+    if(Process.whereis(:logger)) do
+      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
+    else
+      :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
+    end
+  end
+
+  @doc false
+  def remove_report_handler do
+    if(Process.whereis(:logger)) do
+      :logger.remove_handler(:appsignal)
+    else
+      :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
     end
   end
 

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -31,7 +31,11 @@ defmodule Appsignal do
 
     initialize()
 
-    :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
+    if(Process.whereis(:logger)) do
+      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
+    else
+      :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
+    end
 
     children = [
       worker(Appsignal.TransactionRegistry, [])

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -94,22 +94,18 @@ defmodule Appsignal do
     end
   end
 
-  @doc false
-  def add_report_handler do
-    if(Process.whereis(:logger)) do
-      Appsignal.LoggerHandler.add()
-    else
-      Appsignal.ErrorLoggerHandler.add()
-    end
-  end
+  if System.otp_release() >= "21" do
+    @doc false
+    def add_report_handler, do: Appsignal.LoggerHandler.add()
 
-  @doc false
-  def remove_report_handler do
-    if(Process.whereis(:logger)) do
-      Appsignal.LoggerHandler.remove()
-    else
-      Appsignal.ErrorLoggerHandler.remove()
-    end
+    @doc false
+    def remove_report_handler, do: Appsignal.LoggerHandler.remove()
+  else
+    @doc false
+    def add_report_handler, do: Appsignal.ErrorLoggerHandler.add()
+
+    @doc false
+    def remove_report_handler, do: Appsignal.ErrorLoggerHandler.remove()
   end
 
   @doc """

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -97,18 +97,18 @@ defmodule Appsignal do
   @doc false
   def add_report_handler do
     if(Process.whereis(:logger)) do
-      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
+      Appsignal.LoggerHandler.add()
     else
-      :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
+      Appsignal.ErrorLoggerHandler.add()
     end
   end
 
   @doc false
   def remove_report_handler do
     if(Process.whereis(:logger)) do
-      :logger.remove_handler(:appsignal)
+      Appsignal.LoggerHandler.remove()
     else
-      :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
+      Appsignal.ErrorLoggerHandler.remove()
     end
   end
 

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -23,6 +23,12 @@ defmodule Appsignal do
                  Appsignal.Transaction
                )
 
+  if System.otp_release() >= "21" do
+    @report_handler Appsignal.LoggerHandler
+  else
+    @report_handler Appsignal.ErrorLoggerHandler
+  end
+
   @doc """
   Application callback function
   """
@@ -94,19 +100,11 @@ defmodule Appsignal do
     end
   end
 
-  if System.otp_release() >= "21" do
-    @doc false
-    def add_report_handler, do: Appsignal.LoggerHandler.add()
+  @doc false
+  def add_report_handler, do: @report_handler.add()
 
-    @doc false
-    def remove_report_handler, do: Appsignal.LoggerHandler.remove()
-  else
-    @doc false
-    def add_report_handler, do: Appsignal.ErrorLoggerHandler.add()
-
-    @doc false
-    def remove_report_handler, do: Appsignal.ErrorLoggerHandler.remove()
-  end
+  @doc false
+  def remove_report_handler, do: @report_handler.remove()
 
   @doc """
   Set a gauge for a measurement of some metric.

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -20,10 +20,6 @@ defmodule Appsignal.ErrorHandler do
                  Appsignal.Transaction
                )
 
-  def init(state) do
-    {:ok, state}
-  end
-
   def handle_event(event, state) do
     case match_event(event) do
       {origin, error, stack, conn} ->
@@ -40,10 +36,6 @@ defmodule Appsignal.ErrorHandler do
         :ok
     end
 
-    {:ok, state}
-  end
-
-  def handle_info(_, state) do
     {:ok, state}
   end
 
@@ -116,6 +108,16 @@ defmodule Appsignal.ErrorHandler do
 
   def match_event(_event) do
     :nomatch
+  end
+
+  @deprecated "Use Appsignal.ErrorLoggerHandler.init/1 instead."
+  def init(state) do
+    Appsignal.ErrorLoggerHandler.init(state)
+  end
+
+  @deprecated "Use Appsignal.ErrorLoggerHandler.handle_info/2 instead."
+  def handle_info(info, state) do
+    Appsignal.ErrorLoggerHandler.handle_info(info, state)
   end
 
   @doc false

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -124,11 +124,13 @@ defmodule Appsignal.ErrorHandler do
     :nomatch
   end
 
+  @doc false
   @deprecated "Use Appsignal.ErrorLoggerHandler.init/1 instead."
   def init(state) do
     Appsignal.ErrorLoggerHandler.init(state)
   end
 
+  @doc false
   @deprecated "Use Appsignal.ErrorLoggerHandler.handle_info/2 instead."
   def handle_info(info, state) do
     Appsignal.ErrorLoggerHandler.handle_info(info, state)

--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -20,25 +20,6 @@ defmodule Appsignal.ErrorHandler do
                  Appsignal.Transaction
                )
 
-  def handle_event(event, state) do
-    case match_event(event) do
-      {origin, error, stack, conn} ->
-        transaction =
-          unless TransactionRegistry.ignored?(origin) do
-            @transaction.lookup_or_create_transaction(origin)
-          end
-
-        if transaction != nil do
-          handle_error(transaction, error, stack, conn)
-        end
-
-      _ ->
-        :ok
-    end
-
-    {:ok, state}
-  end
-
   @spec handle_error(Appsignal.Transaction.t() | pid(), any(), Exception.stacktrace(), map()) ::
           :ok
   def handle_error(pid_or_transaction, error, stack, conn \\ %{})
@@ -128,6 +109,12 @@ defmodule Appsignal.ErrorHandler do
   @deprecated "Use Appsignal.ErrorLoggerHandler.init/1 instead."
   def init(state) do
     Appsignal.ErrorLoggerHandler.init(state)
+  end
+
+  @doc false
+  @deprecated "Use Appsignal.ErrorLoggerHandler.handle_event/2 instead."
+  def handle_event(event, state) do
+    Appsignal.ErrorLoggerHandler.handle_event(event, state)
   end
 
   @doc false

--- a/lib/appsignal/error_logger_handler.ex
+++ b/lib/appsignal/error_logger_handler.ex
@@ -7,12 +7,17 @@ defmodule Appsignal.ErrorLoggerHandler do
   end
 
   def handle_event({:error_report, _gleader, {pid, :crash_report, [report | _]}}, state) do
-    case match_report(report) do
-      {error, stack} ->
-        ErrorHandler.handle_error(pid, error, stack)
-
-      _ ->
-        :ok
+    try do
+      {_kind, error, stack} = report[:error_info]
+      ErrorHandler.handle_error(pid, error, stack)
+    rescue
+      exception ->
+        Logger.warn(fn ->
+          """
+          AppSignal: Failed to match error report: #{Exception.message(exception)}
+          #{inspect(report[:error_info])}
+          """
+        end)
     end
 
     {:ok, state}
@@ -24,22 +29,5 @@ defmodule Appsignal.ErrorLoggerHandler do
 
   def handle_info(_, state) do
     {:ok, state}
-  end
-
-  defp match_report(report) do
-    try do
-      {_kind, error, stack} = report[:error_info]
-      {error, stack}
-    rescue
-      exception ->
-        Logger.warn(fn ->
-          """
-          AppSignal: Failed to match error report: #{Exception.message(exception)}
-          #{inspect(report[:error_info])}
-          """
-        end)
-
-        :nomatch
-    end
   end
 end

--- a/lib/appsignal/error_logger_handler.ex
+++ b/lib/appsignal/error_logger_handler.ex
@@ -10,6 +10,20 @@ defmodule Appsignal.ErrorLoggerHandler do
 
   require Logger
 
+  @doc """
+  Add `Appsignal.ErrorLoggerHandler` as a report handler for `:error_logger`.
+  """
+  def add do
+    :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
+  end
+
+  @doc """
+  Remove `AppSignal.ErrorLoggerHandler` report handler from `:error_logger`.
+  """
+  def remove do
+    :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
+  end
+
   @doc false
   def init(state) do
     {:ok, state}

--- a/lib/appsignal/error_logger_handler.ex
+++ b/lib/appsignal/error_logger_handler.ex
@@ -9,7 +9,6 @@ defmodule Appsignal.ErrorLoggerHandler do
   """
 
   require Logger
-  alias Appsignal.ErrorHandler
 
   @doc false
   def init(state) do
@@ -20,7 +19,7 @@ defmodule Appsignal.ErrorLoggerHandler do
   def handle_event({:error_report, _gleader, {pid, :crash_report, [report | _]}}, state) do
     try do
       {_kind, error, stack} = report[:error_info]
-      ErrorHandler.handle_error(pid, error, stack)
+      Appsignal.ErrorHandler.handle_error(pid, error, stack)
     rescue
       exception ->
         Logger.warn(fn ->

--- a/lib/appsignal/error_logger_handler.ex
+++ b/lib/appsignal/error_logger_handler.ex
@@ -1,15 +1,58 @@
 defmodule Appsignal.ErrorLoggerHandler do
-  alias Appsignal.ErrorHandler
+  require Logger
+  alias Appsignal.{TransactionRegistry, ErrorHandler}
+
+  @transaction Application.get_env(
+                 :appsignal,
+                 :appsignal_transaction,
+                 Appsignal.Transaction
+               )
 
   def init(state) do
-    ErrorHandler.init(state)
+    {:ok, state}
   end
 
-  def handle_event(event, state) do
-    ErrorHandler.handle_event(event, state)
+  def handle_event({:error_report, _gleader, {origin, :crash_report, [report | _]}}, state) do
+    case match_report(report) do
+      {error, stack} ->
+        transaction =
+          unless TransactionRegistry.ignored?(origin) do
+            @transaction.lookup_or_create_transaction(origin)
+          end
+
+        if transaction != nil do
+          ErrorHandler.handle_error(transaction, error, stack, %{})
+        end
+
+      _ ->
+        :ok
+    end
+
+    {:ok, state}
   end
 
-  def handle_info(event, state) do
-    ErrorHandler.handle_info(event, state)
+  def handle_event(_event, state) do
+    {:ok, state}
+  end
+
+  def handle_info(_, state) do
+    {:ok, state}
+  end
+
+  defp match_report(report) do
+    try do
+      {_kind, error, stack} = report[:error_info]
+      {error, stack}
+    rescue
+      exception ->
+        Logger.warn(fn ->
+          """
+          AppSignal: Failed to match error report: #{Exception.message(exception)}
+          #{inspect(report[:error_info])}
+          """
+        end)
+
+        :nomatch
+    end
   end
 end

--- a/lib/appsignal/error_logger_handler.ex
+++ b/lib/appsignal/error_logger_handler.ex
@@ -1,11 +1,22 @@
 defmodule Appsignal.ErrorLoggerHandler do
+  @moduledoc """
+  Error handler to send crash reports to AppSignal.
+
+  AppSignal automatically adds `Appsignal.ErrorLoggerHandler` to Erlang's
+  `:error_logger` as a report handler to receive error reports. It extracts the
+  error and stacktrace from the report and sends it over to
+  `Appsignal.ErrorHandler` to be reported to AppSignal.
+  """
+
   require Logger
   alias Appsignal.ErrorHandler
 
+  @doc false
   def init(state) do
     {:ok, state}
   end
 
+  @doc false
   def handle_event({:error_report, _gleader, {pid, :crash_report, [report | _]}}, state) do
     try do
       {_kind, error, stack} = report[:error_info]
@@ -23,10 +34,12 @@ defmodule Appsignal.ErrorLoggerHandler do
     {:ok, state}
   end
 
+  @doc false
   def handle_event(_event, state) do
     {:ok, state}
   end
 
+  @doc false
   def handle_info(_, state) do
     {:ok, state}
   end

--- a/lib/appsignal/error_logger_handler.ex
+++ b/lib/appsignal/error_logger_handler.ex
@@ -1,0 +1,15 @@
+defmodule Appsignal.ErrorLoggerHandler do
+  alias Appsignal.ErrorHandler
+
+  def init(state) do
+    ErrorHandler.init(state)
+  end
+
+  def handle_event(event, state) do
+    ErrorHandler.handle_event(event, state)
+  end
+
+  def handle_info(event, state) do
+    ErrorHandler.handle_info(event, state)
+  end
+end

--- a/lib/appsignal/logger_handler.ex
+++ b/lib/appsignal/logger_handler.ex
@@ -1,0 +1,29 @@
+defmodule Appsignal.LoggerHandler do
+  require Logger
+
+  @doc false
+  def log(
+        %{
+          meta: %{error_logger: %{tag: :error_report, type: :crash_report}},
+          msg: {:report, %{report: [report | _]}}
+        },
+        _config
+      ) do
+    try do
+      {_kind, error, stack} = report[:error_info]
+      Appsignal.ErrorHandler.handle_error(self(), error, stack)
+    rescue
+      exception ->
+        Logger.warn(fn ->
+          """
+          AppSignal: Failed to match error report: #{Exception.message(exception)}
+          #{inspect(report[:error_info])}
+          """
+        end)
+    end
+  end
+
+  def log(_log, _config) do
+    :ok
+  end
+end

--- a/lib/appsignal/logger_handler.ex
+++ b/lib/appsignal/logger_handler.ex
@@ -1,52 +1,54 @@
-defmodule Appsignal.LoggerHandler do
-  @moduledoc """
-  Error handler to send crash reports to AppSignal.
+if System.otp_release() >= "21" do
+  defmodule Appsignal.LoggerHandler do
+    @moduledoc """
+    Error handler to send crash reports to AppSignal.
 
-  AppSignal automatically adds `Appsignal.LoggerHandler` to Erlang's `:error`
-  as a report handler to receive error reports. It extracts the error and
-  stacktrace from the report and sends it over to `Appsignal.ErrorHandler` to
-  be reported to AppSignal.
-  """
+    AppSignal automatically adds `Appsignal.LoggerHandler` to Erlang's `:error`
+    as a report handler to receive error reports. It extracts the error and
+    stacktrace from the report and sends it over to `Appsignal.ErrorHandler` to
+    be reported to AppSignal.
+    """
 
-  require Logger
+    require Logger
 
-  @doc """
-  Add `Appsignal.LoggerHandler` as a report handler for `:logger`.
-  """
-  def add do
-    :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
-  end
-
-  @doc """
-  Remove AppSignal report handlers from `:logger`.
-  """
-  def remove do
-    :logger.remove_handler(:appsignal)
-  end
-
-  @doc false
-  def log(
-        %{
-          meta: %{error_logger: %{tag: :error_report, type: :crash_report}},
-          msg: {:report, %{report: [report | _]}}
-        },
-        _config
-      ) do
-    try do
-      {_kind, error, stack} = report[:error_info]
-      Appsignal.ErrorHandler.handle_error(self(), error, stack)
-    rescue
-      exception ->
-        Logger.warn(fn ->
-          """
-          AppSignal: Failed to match error report: #{Exception.message(exception)}
-          #{inspect(report[:error_info])}
-          """
-        end)
+    @doc """
+    Add `Appsignal.LoggerHandler` as a report handler for `:logger`.
+    """
+    def add do
+      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
     end
-  end
 
-  def log(_log, _config) do
-    :ok
+    @doc """
+    Remove AppSignal report handlers from `:logger`.
+    """
+    def remove do
+      :logger.remove_handler(:appsignal)
+    end
+
+    @doc false
+    def log(
+          %{
+            meta: %{error_logger: %{tag: :error_report, type: :crash_report}},
+            msg: {:report, %{report: [report | _]}}
+          },
+          _config
+        ) do
+      try do
+        {_kind, error, stack} = report[:error_info]
+        Appsignal.ErrorHandler.handle_error(self(), error, stack)
+      rescue
+        exception ->
+          Logger.warn(fn ->
+            """
+            AppSignal: Failed to match error report: #{Exception.message(exception)}
+            #{inspect(report[:error_info])}
+            """
+          end)
+      end
+    end
+
+    def log(_log, _config) do
+      :ok
+    end
   end
 end

--- a/lib/appsignal/logger_handler.ex
+++ b/lib/appsignal/logger_handler.ex
@@ -10,6 +10,20 @@ defmodule Appsignal.LoggerHandler do
 
   require Logger
 
+  @doc """
+  Add `Appsignal.LoggerHandler` as a report handler for `:logger`.
+  """
+  def add do
+    :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
+  end
+
+  @doc """
+  Remove AppSignal report handlers from `:logger`.
+  """
+  def remove do
+    :logger.remove_handler(:appsignal)
+  end
+
   @doc false
   def log(
         %{

--- a/lib/appsignal/logger_handler.ex
+++ b/lib/appsignal/logger_handler.ex
@@ -1,4 +1,13 @@
 defmodule Appsignal.LoggerHandler do
+  @moduledoc """
+  Error handler to send crash reports to AppSignal.
+
+  AppSignal automatically adds `Appsignal.LoggerHandler` to Erlang's `:error`
+  as a report handler to receive error reports. It extracts the error and
+  stacktrace from the report and sends it over to `Appsignal.ErrorHandler` to
+  be reported to AppSignal.
+  """
+
   require Logger
 
   @doc false

--- a/test/appsignal/error_handler_test.exs
+++ b/test/appsignal/error_handler_test.exs
@@ -12,14 +12,6 @@ defmodule Appsignal.ErrorHandlerTest do
     [fake_transaction: fake_transaction]
   end
 
-  test "whether we can send error reports without current transaction" do
-    :proc_lib.spawn(fn ->
-      :erlang.error(:error_task)
-    end)
-
-    :timer.sleep(100)
-  end
-
   test "whether we can send error reports with a current transaction", %{
     fake_transaction: fake_transaction
   } do
@@ -72,16 +64,6 @@ defmodule Appsignal.ErrorHandlerTest do
     assert ^metadata = FakeTransaction.metadata(fake_transaction)
     assert [^transaction] = FakeTransaction.finished_transactions(fake_transaction)
     assert [^transaction] = FakeTransaction.completed_transactions(fake_transaction)
-  end
-
-  test "does not cause warnings for noise on handle_info" do
-    :error_logger.add_report_handler(ErrorLoggerForwarder, self())
-
-    :error_logger
-    |> Process.whereis()
-    |> send(:noise)
-
-    refute_receive({:warning_msg, _, _})
   end
 
   describe "handle_error/2" do

--- a/test/appsignal/error_logger_handler_test.exs
+++ b/test/appsignal/error_logger_handler_test.exs
@@ -4,10 +4,10 @@ defmodule Appsignal.ErrorLoggerHandlerTest do
 
   setup do
     Appsignal.remove_report_handler()
-    Appsignal.LoggerHandler.add()
+    Appsignal.ErrorLoggerHandler.add()
 
     on_exit(fn ->
-      Appsignal.LoggerHandler.remove()
+      Appsignal.ErrorLoggerHandler.remove()
       Appsignal.add_report_handler()
     end)
 

--- a/test/appsignal/error_logger_handler_test.exs
+++ b/test/appsignal/error_logger_handler_test.exs
@@ -1,0 +1,55 @@
+defmodule Appsignal.ErrorLoggerHandlerTest do
+  use ExUnit.Case, async: false
+  alias Appsignal.{Transaction, FakeTransaction}
+
+  setup do
+    {:ok, fake_transaction} = FakeTransaction.start_link()
+    [fake_transaction: fake_transaction]
+  end
+
+  test "handles an error report", %{fake_transaction: fake_transaction} do
+    pid =
+      :proc_lib.spawn(fn ->
+        self()
+        |> inspect
+        |> FakeTransaction.start(:http_request)
+        |> FakeTransaction.set_action("AppsignalErrorHandlerTest#test")
+
+        :erlang.error(:error_http_request)
+      end)
+
+    :timer.sleep(20)
+
+    [{transaction, reason, _message, _stack}] = FakeTransaction.errors(fake_transaction)
+
+    assert transaction.id == inspect(pid)
+    assert reason == ":error_http_request"
+  end
+
+  test "does not send error reports for ignored processes", %{fake_transaction: fake_transaction} do
+    :proc_lib.spawn(fn ->
+      Appsignal.TransactionRegistry.ignore(self())
+      :timer.sleep(50)
+
+      :erlang.error(:error_ignored)
+    end)
+
+    :timer.sleep(100)
+
+    refute fake_transaction
+           |> FakeTransaction.errors()
+           |> Enum.any?(fn error ->
+             match?({%Transaction{}, ":error_ignored", _, _}, error)
+           end)
+  end
+
+  test "does not cause warnings for noise on handle_info" do
+    :error_logger.add_report_handler(ErrorLoggerForwarder, self())
+
+    :error_logger
+    |> Process.whereis()
+    |> send(:noise)
+
+    refute_receive({:warning_msg, _, _})
+  end
+end

--- a/test/appsignal/error_logger_handler_test.exs
+++ b/test/appsignal/error_logger_handler_test.exs
@@ -3,13 +3,12 @@ defmodule Appsignal.ErrorLoggerHandlerTest do
   alias Appsignal.{Transaction, FakeTransaction}
 
   setup do
-    :logger.remove_handler(:appsignal)
-    :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
+    Appsignal.remove_report_handler()
     :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
 
     on_exit(fn ->
       :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
-      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
+      Appsignal.add_report_handler()
     end)
 
     {:ok, fake_transaction} = FakeTransaction.start_link()

--- a/test/appsignal/error_logger_handler_test.exs
+++ b/test/appsignal/error_logger_handler_test.exs
@@ -4,10 +4,10 @@ defmodule Appsignal.ErrorLoggerHandlerTest do
 
   setup do
     Appsignal.remove_report_handler()
-    :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
+    Appsignal.LoggerHandler.add()
 
     on_exit(fn ->
-      :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
+      Appsignal.LoggerHandler.remove()
       Appsignal.add_report_handler()
     end)
 

--- a/test/appsignal/logger_handler_test.exs
+++ b/test/appsignal/logger_handler_test.exs
@@ -1,16 +1,11 @@
-defmodule Appsignal.ErrorLoggerHandlerTest do
+defmodule Appsignal.LoggerHandlerTest do
   use ExUnit.Case, async: false
   alias Appsignal.{Transaction, FakeTransaction}
 
   setup do
-    :logger.remove_handler(:appsignal)
     :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
-    :error_logger.add_report_handler(Appsignal.ErrorLoggerHandler)
-
-    on_exit(fn ->
-      :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
-      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
-    end)
+    :logger.remove_handler(:appsignal)
+    :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
 
     {:ok, fake_transaction} = FakeTransaction.start_link()
     [fake_transaction: fake_transaction]
@@ -50,15 +45,5 @@ defmodule Appsignal.ErrorLoggerHandlerTest do
            |> Enum.any?(fn error ->
              match?({%Transaction{}, ":error_ignored", _, _}, error)
            end)
-  end
-
-  test "does not cause warnings for noise on handle_info" do
-    :error_logger.add_report_handler(ErrorLoggerForwarder, self())
-
-    :error_logger
-    |> Process.whereis()
-    |> send(:noise)
-
-    refute_receive({:warning_msg, _, _})
   end
 end

--- a/test/appsignal/logger_handler_test.exs
+++ b/test/appsignal/logger_handler_test.exs
@@ -3,9 +3,13 @@ defmodule Appsignal.LoggerHandlerTest do
   alias Appsignal.{Transaction, FakeTransaction}
 
   setup do
-    :error_logger.delete_report_handler(Appsignal.ErrorLoggerHandler)
-    :logger.remove_handler(:appsignal)
+    Appsignal.remove_report_handler()
     :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
+
+    on_exit(fn ->
+      :logger.remove_handler(:appsignal)
+      Appsignal.add_report_handler()
+    end)
 
     {:ok, fake_transaction} = FakeTransaction.start_link()
     [fake_transaction: fake_transaction]

--- a/test/appsignal/logger_handler_test.exs
+++ b/test/appsignal/logger_handler_test.exs
@@ -1,53 +1,57 @@
-defmodule Appsignal.LoggerHandlerTest do
-  use ExUnit.Case, async: false
-  alias Appsignal.{Transaction, FakeTransaction}
+if System.otp_release() >= "21" do
+  defmodule Appsignal.LoggerHandlerTest do
+    use ExUnit.Case, async: false
+    alias Appsignal.{Transaction, FakeTransaction}
 
-  setup do
-    Appsignal.remove_report_handler()
-    :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
+    setup do
+      Appsignal.remove_report_handler()
+      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
 
-    on_exit(fn ->
-      :logger.remove_handler(:appsignal)
-      Appsignal.add_report_handler()
-    end)
-
-    {:ok, fake_transaction} = FakeTransaction.start_link()
-    [fake_transaction: fake_transaction]
-  end
-
-  test "handles an error report", %{fake_transaction: fake_transaction} do
-    pid =
-      :proc_lib.spawn(fn ->
-        self()
-        |> inspect
-        |> FakeTransaction.start(:http_request)
-        |> FakeTransaction.set_action("AppsignalErrorHandlerTest#test")
-
-        :erlang.error(:error_http_request)
+      on_exit(fn ->
+        :logger.remove_handler(:appsignal)
+        Appsignal.add_report_handler()
       end)
 
-    :timer.sleep(20)
+      {:ok, fake_transaction} = FakeTransaction.start_link()
+      [fake_transaction: fake_transaction]
+    end
 
-    [{transaction, reason, _message, _stack}] = FakeTransaction.errors(fake_transaction)
+    test "handles an error report", %{fake_transaction: fake_transaction} do
+      pid =
+        :proc_lib.spawn(fn ->
+          self()
+          |> inspect
+          |> FakeTransaction.start(:http_request)
+          |> FakeTransaction.set_action("AppsignalErrorHandlerTest#test")
 
-    assert transaction.id == inspect(pid)
-    assert reason == ":error_http_request"
-  end
+          :erlang.error(:error_http_request)
+        end)
 
-  test "does not send error reports for ignored processes", %{fake_transaction: fake_transaction} do
-    :proc_lib.spawn(fn ->
-      Appsignal.TransactionRegistry.ignore(self())
-      :timer.sleep(50)
+      :timer.sleep(20)
 
-      :erlang.error(:error_ignored)
-    end)
+      [{transaction, reason, _message, _stack}] = FakeTransaction.errors(fake_transaction)
 
-    :timer.sleep(100)
+      assert transaction.id == inspect(pid)
+      assert reason == ":error_http_request"
+    end
 
-    refute fake_transaction
-           |> FakeTransaction.errors()
-           |> Enum.any?(fn error ->
-             match?({%Transaction{}, ":error_ignored", _, _}, error)
-           end)
+    test "does not send error reports for ignored processes", %{
+      fake_transaction: fake_transaction
+    } do
+      :proc_lib.spawn(fn ->
+        Appsignal.TransactionRegistry.ignore(self())
+        :timer.sleep(50)
+
+        :erlang.error(:error_ignored)
+      end)
+
+      :timer.sleep(100)
+
+      refute fake_transaction
+             |> FakeTransaction.errors()
+             |> Enum.any?(fn error ->
+               match?({%Transaction{}, ":error_ignored", _, _}, error)
+             end)
+    end
   end
 end

--- a/test/appsignal/logger_handler_test.exs
+++ b/test/appsignal/logger_handler_test.exs
@@ -5,10 +5,10 @@ if System.otp_release() >= "21" do
 
     setup do
       Appsignal.remove_report_handler()
-      :logger.add_handler(:appsignal, Appsignal.LoggerHandler, %{})
+      Appsignal.LoggerHandler.add()
 
       on_exit(fn ->
-        :logger.remove_handler(:appsignal)
+        Appsignal.LoggerHandler.remove()
         Appsignal.add_report_handler()
       end)
 


### PR DESCRIPTION
Closes https://github.com/appsignal/appsignal-elixir/issues/442.

Instead of switching to Elixir's `Logger`, which doesn't seem to have a way to extract the error object and stack trace, this pull request uses Erlang's `:logger`, which was introduced in OTP 21, for OTP 21 and up. It falls back to using `:error_logger` for earlier OTP versions.

To do this, the report handling logic was moved from `ErrorHandler` to one module for `:error_logger` and one for `:logger`. The application module [decides](https://github.com/appsignal/appsignal-elixir/blob/c5eed929cec7016d26a43c6f0c9e703e856fd445/lib/appsignal.ex#L26-L30) which to use, based on the OTP version.