### PR TITLE
Minutly Probing for Custom Metrics

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -39,10 +39,18 @@ defmodule Appsignal do
     add_report_handler()
 
     children = [
-      worker(Appsignal.TransactionRegistry, [])
+      worker(Appsignal.TransactionRegistry, []),
+      worker(Appsignal.Probes, [])
     ]
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: Appsignal.Supervisor)
+    result = Supervisor.start_link(children, strategy: :one_for_one, name: Appsignal.Supervisor)
+
+    # Add our default system probes. It's important that this is called after
+    # the Suportvisor has started. Otherwise the GenServer cannot register the
+    # probe.
+    add_default_probes()
+
+    result
   end
 
   def plug? do
@@ -105,6 +113,11 @@ defmodule Appsignal do
 
   @doc false
   def remove_report_handler, do: @report_handler.remove()
+
+  @doc false
+  def add_default_probes do
+    # Stub for adding default probes
+  end
 
   @doc """
   Set a gauge for a measurement of some metric.

--- a/lib/appsignal/probes/probes.ex
+++ b/lib/appsignal/probes/probes.ex
@@ -1,0 +1,79 @@
+defmodule Appsignal.Probes do
+  use GenServer
+
+  require Logger
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def register(name, probe) do
+    if genserver_running?() do
+      if is_function(probe) do
+        GenServer.cast(__MODULE__, {name, probe})
+        :ok
+      else
+        Logger.debug(fn ->
+          "Trying to register probe #{name}. Ignoring probe since it's not a function."
+        end)
+
+        {:error, "Probe is not a function"}
+      end
+    else
+      {:error, "Probe genserver is not running"}
+    end
+  end
+
+  def unregister(name) do
+    GenServer.cast(__MODULE__, name)
+    :ok
+  end
+
+  def init([]) do
+    schedule_probes()
+    {:ok, %{}}
+  end
+
+  def handle_cast({name, probe}, probes) do
+    if Map.has_key?(probes, name) do
+      Logger.debug(fn -> "A probe with name '#{name}' already exists. Overriding that one." end)
+    end
+
+    {:noreply, Map.put(probes, name, probe)}
+  end
+
+  def handle_cast(name, probes) do
+    {:noreply, Map.delete(probes, name)}
+  end
+
+  def handle_info(:run_probes, probes) do
+    Enum.each(probes, fn {name, probe} ->
+      Task.start(fn ->
+        try do
+          probe.()
+        rescue
+          e ->
+            Logger.error("Error while calling probe #{name}: #{e}")
+        end
+      end)
+    end)
+
+    schedule_probes()
+    {:noreply, probes}
+  end
+
+  defp genserver_running? do
+    pid = Process.whereis(__MODULE__)
+    !is_nil(pid) && Process.alive?(pid)
+  end
+
+  if Mix.env() in [:test, :test_phoenix, :test_no_nif] do
+    defp schedule_probes do
+      Process.send_after(self(), :run_probes, 10)
+    end
+  else
+    defp schedule_probes do
+      Process.send_after(self(), :run_probes, (60 - DateTime.utc_now().second) * 1000)
+    end
+  end
+end

--- a/test/appsignal/probes/probes_test.exs
+++ b/test/appsignal/probes/probes_test.exs
@@ -1,0 +1,38 @@
+defmodule Appsignal.Probes.ProbesTest do
+  use ExUnit.Case, async: false
+
+  alias Appsignal.Probes
+  alias FakeProbe
+
+  describe "register/2" do
+    test "registers a probe when given a function as probe" do
+      assert :ok == Probes.register(:some_probe, fn -> nil end)
+    end
+
+    test "returns an error tupple when probe is not a function" do
+      assert {:error, _} = Probes.register(:some_probe, :some_value)
+    end
+  end
+
+  describe "integration test for probing" do
+    setup do
+      {:ok, fake_probe} = FakeProbe.start_link()
+      [fake_probe: fake_probe]
+    end
+
+    test "once a probe is registered, it is called by the probes system", %{
+      fake_probe: fake_probe
+    } do
+      Probes.register(:test_probe, &FakeProbe.call/0)
+
+      refute FakeProbe.get(fake_probe, :probe_called)
+
+      # Sleep for some time to give the Probe system time to do its work
+      :timer.sleep(100)
+
+      assert FakeProbe.get(fake_probe, :probe_called)
+
+      Probes.unregister(:test_probe)
+    end
+  end
+end

--- a/test/support/fake_probe.ex
+++ b/test/support/fake_probe.ex
@@ -1,0 +1,5 @@
+defmodule FakeProbe do
+  use TestAgent
+
+  def call, do: update(__MODULE__, :probe_called, true)
+end


### PR DESCRIPTION
This adds the first setup for the probing system in the Elixir side.

We use a Genserver that holds all the probes, this Genserver will schedule itself every minute, and then create a Task for every Probe.

The Probes Genserver is supervised by appsignal.ex.

@jeffkreeftmeijer I'm not 100% sure if this tests are enough coverage.

Next steps would be:
1. Create a way to allow probes to be their own Genservers (Some form of Init system)
2. Create the Erlang Probe