### PR TITLE
Allow Appsignal.Plug.call/2 to be overridden

### DIFF
--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -28,6 +28,8 @@ if Appsignal.plug?() do
             conn -> Appsignal.Plug.finish_with_conn(transaction, conn)
           end
         end
+
+        defoverridable call: 2
       end
     end
 

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -1,3 +1,15 @@
+defmodule ModuleWithCall do
+  defmacro __using__(_) do
+    quote do
+      def call(%Plug.Conn{} = conn, _opts) do
+        Plug.Conn.assign(conn, :called?, true)
+      end
+
+      defoverridable call: 2
+    end
+  end
+end
+
 defmodule UsingAppsignalPlug do
   def call(%Plug.Conn{private: %{phoenix_action: :exception}}, _opts) do
     raise("Exception!")
@@ -29,13 +41,18 @@ defmodule UsingAppsignalPlug do
     }
   end
 
-  def call(%Plug.Conn{} = conn, _opts) do
-    conn |> Plug.Conn.assign(:called?, true)
-  end
-
-  defoverridable call: 2
-
+  use ModuleWithCall
   use Appsignal.Plug
+end
+
+defmodule OverridingAppSignalPlug do
+  use ModuleWithCall
+  use Appsignal.Plug
+
+  def call(conn, opts) do
+    conn = super(conn, opts)
+    Plug.Conn.assign(conn, :overridden?, true)
+  end
 end
 
 defmodule Appsignal.PlugTest do
@@ -491,6 +508,26 @@ defmodule Appsignal.PlugTest do
         rescue
           UndefinedFunctionError -> :ok
         end
+    end
+  end
+
+  describe "when overriding the AppSignal Plug" do
+    setup do
+      conn = OverridingAppSignalPlug.call(%Plug.Conn{}, %{})
+
+      [conn: conn]
+    end
+
+    test "starts a transaction", %{fake_transaction: fake_transaction} do
+      assert FakeTransaction.started_transaction?(fake_transaction)
+    end
+
+    test "calls super and returns the conn", %{conn: conn} do
+      assert conn.assigns[:called?]
+    end
+
+    test "calls the overridden call/2", %{conn: conn} do
+      assert conn.assigns[:overridden?]
     end
   end
 end


### PR DESCRIPTION
Closes #463. The `defoverridable` call was dropped in a7b434c7c107a40738f4e42395e8c3a34e798739 when splitting the Plug integration from the Phoenix integration.