### PR TITLE
Add Erlang Probe

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,6 +11,7 @@ if Mix.env() in [:test, :test_phoenix, :test_no_nif] do
   config :appsignal, appsignal_demo: Appsignal.FakeDemo
   config :appsignal, appsignal_transaction: Appsignal.FakeTransaction
   config :appsignal, appsignal_diagnose_report: Appsignal.Diagnose.FakeReport
+  config :appsignal, appsignal: Appsignal.FakeAppsignal
 
   config :appsignal, :config,
     push_api_key: "00000000-0000-0000-0000-000000000000",

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -116,9 +116,7 @@ defmodule Appsignal do
 
   @doc false
   def add_default_probes do
-    unless Mix.env() in [:test, :test_phoenix, :test_no_nif] do
-      Appsignal.Probes.register(:erlang, &Appsignal.Probes.ErlangProbe.call/0)
-    end
+    Appsignal.Probes.register(:erlang, &Appsignal.Probes.ErlangProbe.call/0)
   end
 
   @doc """

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -116,7 +116,9 @@ defmodule Appsignal do
 
   @doc false
   def add_default_probes do
-    # Stub for adding default probes
+    unless Mix.env() in [:test, :test_phoenix, :test_no_nif] do
+      Appsignal.Probes.register(:erlang, &Appsignal.Probes.ErlangProbe.call/0)
+    end
   end
 
   @doc """

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -1,0 +1,40 @@
+defmodule Appsignal.Probes.ErlangProbe do
+  @appsignal Application.get_env(:appsignal, :appsignal, Appsignal)
+
+  def call do
+    io_metrics()
+    scheduler_metrics()
+    process_metrics()
+    memory_metrics()
+  end
+
+  defp io_metrics do
+    {{:input, input}, {:output, output}} = :erlang.statistics(:io)
+    @appsignal.set_gauge("erlang_io", Kernel.div(input, 1024), %{type: "input"})
+    @appsignal.set_gauge("erlang_io", Kernel.div(output, 1024), %{type: "output"})
+  end
+
+  defp scheduler_metrics do
+    @appsignal.set_gauge("erlang_schedulers", :erlang.system_info(:schedulers), %{type: "total"})
+
+    @appsignal.set_gauge(
+      "erlang_schedulers",
+      :erlang.system_info(:schedulers_online),
+      %{type: "online"}
+    )
+  end
+
+  defp process_metrics do
+    @appsignal.set_gauge("erlang_processes", :erlang.system_info(:process_limit), %{type: "limit"})
+
+    @appsignal.set_gauge("erlang_processes", :erlang.system_info(:process_count), %{type: "count"})
+  end
+
+  defp memory_metrics do
+    memory = :erlang.memory()
+
+    Enum.each(memory, fn {key, value} ->
+      @appsignal.set_gauge("erlang_memory", Kernel.div(value, 1024), %{type: key})
+    end)
+  end
+end

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -34,7 +34,7 @@ defmodule Appsignal.Probes.ErlangProbe do
     memory = :erlang.memory()
 
     Enum.each(memory, fn {key, value} ->
-      @appsignal.set_gauge("erlang_memory", Kernel.div(value, 1024), %{type: key})
+      @appsignal.set_gauge("erlang_memory", Kernel.div(value, 1024), %{type: to_string(key)})
     end)
   end
 end

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -1,5 +1,5 @@
 defmodule Appsignal.Probes.ErlangProbeTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   alias Appsignal.{FakeAppsignal, Probes.ErlangProbe}
 
@@ -15,19 +15,38 @@ defmodule Appsignal.Probes.ErlangProbeTest do
     end
 
     test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do
-      assert length(FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")) == 2
+      assert [
+               %{key: "erlang_io", tags: %{type: "output"}, value: _},
+               %{key: "erlang_io", tags: %{type: "input"}, value: _}
+             ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
     end
 
     test "gathers scheduler metrics", %{fake_appsignal: fake_appsignal} do
-      assert length(FakeAppsignal.get_gauges(fake_appsignal, "erlang_schedulers")) == 2
+      assert [
+               %{key: "erlang_schedulers", tags: %{type: "online"}, value: _},
+               %{key: "erlang_schedulers", tags: %{type: "total"}, value: _}
+             ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_schedulers")
     end
 
     test "gathers process metrics", %{fake_appsignal: fake_appsignal} do
-      assert length(FakeAppsignal.get_gauges(fake_appsignal, "erlang_processes")) == 2
+      assert [
+               %{key: "erlang_processes", tags: %{type: "count"}, value: _},
+               %{key: "erlang_processes", tags: %{type: "limit"}, value: _}
+             ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_processes")
     end
 
     test "gathers memory metrics", %{fake_appsignal: fake_appsignal} do
-      assert length(FakeAppsignal.get_gauges(fake_appsignal, "erlang_memory")) == 9
+      assert [
+               %{key: "erlang_memory", tags: %{type: "ets"}, value: _},
+               %{key: "erlang_memory", tags: %{type: "code"}, value: _},
+               %{key: "erlang_memory", tags: %{type: "binary"}, value: _},
+               %{key: "erlang_memory", tags: %{type: "atom_used"}, value: _},
+               %{key: "erlang_memory", tags: %{type: "atom"}, value: _},
+               %{key: "erlang_memory", tags: %{type: "system"}, value: _},
+               %{key: "erlang_memory", tags: %{type: "processes_used"}, value: _},
+               %{key: "erlang_memory", tags: %{type: "processes"}, value: _},
+               %{key: "erlang_memory", tags: %{type: "total"}, value: _}
+             ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_memory")
     end
   end
 end

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -4,15 +4,17 @@ defmodule Appsignal.Probes.ErlangProbeTest do
   alias Appsignal.{FakeAppsignal, Probes.ErlangProbe}
 
   setup do
-    {:ok, fake_appsignal} = FakeAppsignal.start_link()
+    # Ensure the default probe is unregistered, that way we only record metrics
+    # from this test
+    Appsignal.Probes.unregister(:erlang)
 
+    {:ok, fake_appsignal} = FakeAppsignal.start_link()
     [fake_appsignal: fake_appsignal]
   end
 
   describe "call/0" do
     setup do
       ErlangProbe.call()
-      Appsignal.Probes.unregister(:erlang)
     end
 
     test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -1,0 +1,33 @@
+defmodule Appsignal.Probes.ErlangProbeTest do
+  use ExUnit.Case
+
+  alias Appsignal.{FakeAppsignal, Probes.ErlangProbe}
+
+  setup do
+    {:ok, fake_appsignal} = FakeAppsignal.start_link()
+
+    [fake_appsignal: fake_appsignal]
+  end
+
+  describe "call/0" do
+    setup do
+      ErlangProbe.call()
+    end
+
+    test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do
+      assert FakeAppsignal.get(fake_appsignal, "erlang_io")
+    end
+
+    test "gathers scheduler metrics", %{fake_appsignal: fake_appsignal} do
+      assert FakeAppsignal.get(fake_appsignal, "erlang_schedulers")
+    end
+
+    test "gathers process metrics", %{fake_appsignal: fake_appsignal} do
+      assert FakeAppsignal.get(fake_appsignal, "erlang_processes")
+    end
+
+    test "gathers memory metrics", %{fake_appsignal: fake_appsignal} do
+      assert FakeAppsignal.get(fake_appsignal, "erlang_memory")
+    end
+  end
+end

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -15,19 +15,19 @@ defmodule Appsignal.Probes.ErlangProbeTest do
     end
 
     test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do
-      assert FakeAppsignal.get(fake_appsignal, "erlang_io")
+      assert length(FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")) == 2
     end
 
     test "gathers scheduler metrics", %{fake_appsignal: fake_appsignal} do
-      assert FakeAppsignal.get(fake_appsignal, "erlang_schedulers")
+      assert length(FakeAppsignal.get_gauges(fake_appsignal, "erlang_schedulers")) == 2
     end
 
     test "gathers process metrics", %{fake_appsignal: fake_appsignal} do
-      assert FakeAppsignal.get(fake_appsignal, "erlang_processes")
+      assert length(FakeAppsignal.get_gauges(fake_appsignal, "erlang_processes")) == 2
     end
 
     test "gathers memory metrics", %{fake_appsignal: fake_appsignal} do
-      assert FakeAppsignal.get(fake_appsignal, "erlang_memory")
+      assert length(FakeAppsignal.get_gauges(fake_appsignal, "erlang_memory")) == 9
     end
   end
 end

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -12,6 +12,7 @@ defmodule Appsignal.Probes.ErlangProbeTest do
   describe "call/0" do
     setup do
       ErlangProbe.call()
+      Appsignal.Probes.unregister(:erlang)
     end
 
     test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do

--- a/test/support/appsignal/fake_appsignal.ex
+++ b/test/support/appsignal/fake_appsignal.ex
@@ -2,6 +2,8 @@ defmodule Appsignal.FakeAppsignal do
   use TestAgent
 
   def set_gauge(key, value, _tags \\ %{}) do
-    update(__MODULE__, key, value)
+    if alive? do
+      update(__MODULE__, key, value)
+    end
   end
 end

--- a/test/support/appsignal/fake_appsignal.ex
+++ b/test/support/appsignal/fake_appsignal.ex
@@ -2,7 +2,7 @@ defmodule Appsignal.FakeAppsignal do
   use TestAgent
 
   def set_gauge(key, value, _tags \\ %{}) do
-    if alive? do
+    if alive?() do
       update(__MODULE__, key, value)
     end
   end

--- a/test/support/appsignal/fake_appsignal.ex
+++ b/test/support/appsignal/fake_appsignal.ex
@@ -1,0 +1,7 @@
+defmodule Appsignal.FakeAppsignal do
+  use TestAgent
+
+  def set_gauge(key, value, _tags \\ %{}) do
+    update(__MODULE__, key, value)
+  end
+end

--- a/test/support/appsignal/fake_appsignal.ex
+++ b/test/support/appsignal/fake_appsignal.ex
@@ -1,9 +1,29 @@
 defmodule Appsignal.FakeAppsignal do
-  use TestAgent
+  use TestAgent, %{
+    gauges: []
+  }
 
-  def set_gauge(key, value, _tags \\ %{}) do
+  def set_gauge(key, value, tags \\ %{}) do
     if alive?() do
-      update(__MODULE__, key, value)
+      Agent.update(__MODULE__, fn state ->
+        {_, new_state} =
+          Map.get_and_update(state, :gauges, fn current ->
+            gauge = %{key: key, value: value, tags: tags}
+
+            case current do
+              nil -> {nil, [gauge]}
+              _ -> {current, [gauge | current]}
+            end
+          end)
+
+        new_state
+      end)
     end
+  end
+
+  def get_gauges(pid_or_module, key) do
+    Enum.filter(get(pid_or_module, :gauges), fn element ->
+      match?(%{key: ^key, tags: _, value: _}, element)
+    end)
   end
 end

--- a/test/support/fake_probe.ex
+++ b/test/support/fake_probe.ex
@@ -2,7 +2,7 @@ defmodule FakeProbe do
   use TestAgent
 
   def call do
-    if alive? do
+    if alive?() do
       update(__MODULE__, :probe_called, true)
     end
   end

--- a/test/support/fake_probe.ex
+++ b/test/support/fake_probe.ex
@@ -1,5 +1,9 @@
 defmodule FakeProbe do
   use TestAgent
 
-  def call, do: update(__MODULE__, :probe_called, true)
+  def call do
+    if alive? do
+      update(__MODULE__, :probe_called, true)
+    end
+  end
 end

--- a/test/support/test_agent.ex
+++ b/test/support/test_agent.ex
@@ -30,6 +30,10 @@ defmodule TestAgent do
       def update(pid_or_module, key, value) do
         Agent.update(pid_or_module, &Map.put(&1, key, value))
       end
+
+      def alive?() do
+        !!Process.whereis(__MODULE__)
+      end
     end
   end
 end


### PR DESCRIPTION
Currently we support the following set of data:

* IO, tagged as Input, and Output
* Scheduler Metrics, tagged as Total, and Online
* Process metrics, tagged as Limit, and Count
* Memory, tagged as: total, processes, processes_used, system, atom,
  atom_used, binary, code, ets

In the future we might want to expand this with Scheduler utilization
and maybe more memory allocations.