### PR TITLE
Make sure events are added to transactions started with decorators

### DIFF
--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -49,7 +49,7 @@ defmodule Appsignal.Instrumentation.Decorators do
       Appsignal.Instrumentation.Decorators.in_transaction(
         unquote(namespace),
         unquote("#{context.module}##{context.name}"),
-        unquote(body)
+        fn -> unquote(body) end
       )
     end
   end
@@ -94,7 +94,7 @@ defmodule Appsignal.Instrumentation.Decorators do
       |> @transaction.start(namespace)
       |> @transaction.set_action(action)
 
-    result = body
+    result = body.()
 
     @transaction.finish(transaction)
     :ok = @transaction.complete(transaction)

--- a/test/appsignal/instrumentation/decorator_test.exs
+++ b/test/appsignal/instrumentation/decorator_test.exs
@@ -50,6 +50,17 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
     [fake_transaction: fake_transaction]
   end
 
+  test "instrument transaction with event", %{fake_transaction: fake_transaction} do
+    UsingAppsignalDecorators.transaction()
+
+    assert [{"123", :http_request}] = FakeTransaction.started_transactions(fake_transaction)
+
+    assert [
+             %{title: "Elixir.UsingAppsignalDecorators.bar"},
+             %{title: "Elixir.UsingAppsignalDecorators.nested"}
+           ] = FakeTransaction.finished_events(fake_transaction)
+  end
+
   test "instrument module function", %{fake_transaction: fake_transaction} do
     transaction = FakeTransaction.start("123", :http_request)
     UsingAppsignalDecorators.bar(123)


### PR DESCRIPTION
f319d28d9f4b3f6cd427aae973c7b6caa1d4886b introduced a regression where
functions decorated with the `transaction` decorator were run before
their transaction was started. This caused any nested events to be
dropped and results in empty transactions being reported.

This was caused by unquoting the body in the `transaction/3` without
wrapping it in an anonymous function, causing the function to run
immediately and its return value being added as the body parameter in
the `in_transaction/3` function.

This patch adds a regression test to make a function with the
`transaction` decorator that calls a function with the
`transaction_event` decorator produces a transaction with an event, and
wraps the function body in an anonymous function that's called in the
`in_transaction/3` function after starting and before finishing the
transaction.