### PR TITLE
Set extra tags erlang

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,6 +12,7 @@ if Mix.env() in [:test, :test_phoenix, :test_no_nif] do
   config :appsignal, appsignal_transaction: Appsignal.FakeTransaction
   config :appsignal, appsignal_diagnose_report: Appsignal.Diagnose.FakeReport
   config :appsignal, appsignal: Appsignal.FakeAppsignal
+  config :appsignal, inet: FakeInet
 
   config :appsignal, :config,
     push_api_key: "00000000-0000-0000-0000-000000000000",

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -38,7 +38,17 @@ defmodule Appsignal.Probes.ErlangProbe do
     end)
   end
 
-  defp set_gauge(name, value, extra_tags \\ %{}) do
-    @appsignal.set_gauge(name, value, Map.merge(extra_tags, %{host_metric: ""}))
+  defp set_gauge(name, value, tags) do
+    @appsignal.set_gauge(
+      name,
+      value,
+      Map.merge(tags, %{host_metric: "", hostname: hostname()})
+    )
+  end
+
+  defp hostname do
+    {:ok, hostname} = :inet.gethostname()
+    config = Application.get_env(:appsignal, :config)
+    config[:hostname] || hostname
   end
 end

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -42,13 +42,18 @@ defmodule Appsignal.Probes.ErlangProbe do
     @appsignal.set_gauge(
       name,
       value,
-      Map.merge(tags, %{host_metric: "", hostname: hostname()})
+      Map.merge(tags, %{hostname: hostname()})
     )
   end
 
   defp hostname do
-    {:ok, hostname} = :inet.gethostname()
-    config = Application.get_env(:appsignal, :config)
-    config[:hostname] || hostname
+    case Application.fetch_env!(:appsignal, :config)[:hostname] do
+      nil ->
+        {:ok, hostname} = :inet.gethostname()
+        hostname
+
+      hostname ->
+        hostname
+    end
   end
 end

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -1,5 +1,6 @@
 defmodule Appsignal.Probes.ErlangProbe do
   @appsignal Application.get_env(:appsignal, :appsignal, Appsignal)
+  @inet Application.get_env(:appsignal, :inet, :inet)
 
   def call do
     io_metrics()
@@ -49,8 +50,8 @@ defmodule Appsignal.Probes.ErlangProbe do
   defp hostname do
     case Application.fetch_env!(:appsignal, :config)[:hostname] do
       nil ->
-        {:ok, hostname} = :inet.gethostname()
-        hostname
+        {:ok, hostname} = @inet.gethostname()
+        List.to_string(hostname)
 
       hostname ->
         hostname

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -10,14 +10,14 @@ defmodule Appsignal.Probes.ErlangProbe do
 
   defp io_metrics do
     {{:input, input}, {:output, output}} = :erlang.statistics(:io)
-    @appsignal.set_gauge("erlang_io", Kernel.div(input, 1024), %{type: "input"})
-    @appsignal.set_gauge("erlang_io", Kernel.div(output, 1024), %{type: "output"})
+    set_gauge("erlang_io", Kernel.div(input, 1024), %{type: "input"})
+    set_gauge("erlang_io", Kernel.div(output, 1024), %{type: "output"})
   end
 
   defp scheduler_metrics do
-    @appsignal.set_gauge("erlang_schedulers", :erlang.system_info(:schedulers), %{type: "total"})
+    set_gauge("erlang_schedulers", :erlang.system_info(:schedulers), %{type: "total"})
 
-    @appsignal.set_gauge(
+    set_gauge(
       "erlang_schedulers",
       :erlang.system_info(:schedulers_online),
       %{type: "online"}
@@ -25,16 +25,20 @@ defmodule Appsignal.Probes.ErlangProbe do
   end
 
   defp process_metrics do
-    @appsignal.set_gauge("erlang_processes", :erlang.system_info(:process_limit), %{type: "limit"})
+    set_gauge("erlang_processes", :erlang.system_info(:process_limit), %{type: "limit"})
 
-    @appsignal.set_gauge("erlang_processes", :erlang.system_info(:process_count), %{type: "count"})
+    set_gauge("erlang_processes", :erlang.system_info(:process_count), %{type: "count"})
   end
 
   defp memory_metrics do
     memory = :erlang.memory()
 
     Enum.each(memory, fn {key, value} ->
-      @appsignal.set_gauge("erlang_memory", Kernel.div(value, 1024), %{type: to_string(key)})
+      set_gauge("erlang_memory", Kernel.div(value, 1024), %{type: to_string(key)})
     end)
+  end
+
+  defp set_gauge(name, value, extra_tags \\ %{}) do
+    @appsignal.set_gauge(name, value, Map.merge(extra_tags, %{host_metric: ""}))
   end
 end

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -19,36 +19,96 @@ defmodule Appsignal.Probes.ErlangProbeTest do
 
     test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: "erlang_io", tags: %{type: "output"}, value: _},
-               %{key: "erlang_io", tags: %{type: "input"}, value: _}
+               %{
+                 key: "erlang_io",
+                 tags: %{type: "output", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_io",
+                 tags: %{type: "input", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               }
              ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
     end
 
     test "gathers scheduler metrics", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: "erlang_schedulers", tags: %{type: "online"}, value: _},
-               %{key: "erlang_schedulers", tags: %{type: "total"}, value: _}
+               %{
+                 key: "erlang_schedulers",
+                 tags: %{type: "online", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_schedulers",
+                 tags: %{type: "total", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               }
              ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_schedulers")
     end
 
     test "gathers process metrics", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: "erlang_processes", tags: %{type: "count"}, value: _},
-               %{key: "erlang_processes", tags: %{type: "limit"}, value: _}
+               %{
+                 key: "erlang_processes",
+                 tags: %{type: "count", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_processes",
+                 tags: %{type: "limit", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               }
              ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_processes")
     end
 
     test "gathers memory metrics", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: "erlang_memory", tags: %{type: "ets"}, value: _},
-               %{key: "erlang_memory", tags: %{type: "code"}, value: _},
-               %{key: "erlang_memory", tags: %{type: "binary"}, value: _},
-               %{key: "erlang_memory", tags: %{type: "atom_used"}, value: _},
-               %{key: "erlang_memory", tags: %{type: "atom"}, value: _},
-               %{key: "erlang_memory", tags: %{type: "system"}, value: _},
-               %{key: "erlang_memory", tags: %{type: "processes_used"}, value: _},
-               %{key: "erlang_memory", tags: %{type: "processes"}, value: _},
-               %{key: "erlang_memory", tags: %{type: "total"}, value: _}
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "ets", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "code", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "binary", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "atom_used", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "atom", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "system", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "processes_used", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "processes", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               },
+               %{
+                 key: "erlang_memory",
+                 tags: %{type: "total", hostname: "Bobs-MBP.example.com"},
+                 value: _
+               }
              ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_memory")
     end
   end

--- a/test/support/fake_inet.ex
+++ b/test/support/fake_inet.ex
@@ -1,5 +1,5 @@
 defmodule FakeInet do
-  def gethostname() do
+  def gethostname do
     {:ok, 'Bobs-MBP.example.com'}
   end
 end

--- a/test/support/fake_inet.ex
+++ b/test/support/fake_inet.ex
@@ -1,0 +1,5 @@
+defmodule FakeInet do
+  def gethostname() do
+    {:ok, 'Bobs-MBP.example.com'}
+  end
+end


### PR DESCRIPTION
Make sure we set the Hostname and HostMetric tag for all the gauges in the Erlang Probe.