### PR TITLE
Add enable_minutely_probes config option

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -9,6 +9,7 @@ defmodule Appsignal.Config do
     debug: false,
     dns_servers: [],
     enable_host_metrics: true,
+    enable_minutely_probes: true,
     endpoint: "https://push.appsignal.com",
     diagnose_endpoint: "https://appsignal.com/diag",
     env: :dev,
@@ -101,6 +102,13 @@ defmodule Appsignal.Config do
     Application.fetch_env!(:appsignal, :config)[:ca_file_path]
   end
 
+  def minutely_probes_enabled? do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, value} -> !!value[:enable_minutely_probes]
+      _ -> false
+    end
+  end
+
   defp default_ca_file_path do
     Path.join(:code.priv_dir(:appsignal), "cacert.pem")
   end
@@ -157,6 +165,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_WORKING_DIR_PATH" => :working_dir_path,
     "APPSIGNAL_WORKING_DIRECTORY_PATH" => :working_directory_path,
     "APPSIGNAL_ENABLE_HOST_METRICS" => :enable_host_metrics,
+    "APPSIGNAL_ENABLE_MINUTELY_PROBES" => :enable_minutely_probes,
     "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data,
     "APPSIGNAL_FILES_WORLD_ACCESSIBLE" => :files_world_accessible,
     "APPSIGNAL_REQUEST_HEADERS" => :request_headers,
@@ -172,7 +181,7 @@ defmodule Appsignal.Config do
     APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING
     APPSIGNAL_ENABLE_ALLOCATION_TRACKING APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER
     APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA APPSIGNAL_FILES_WORLD_ACCESSIBLE
-    APPSIGNAL_SEND_PARAMS
+    APPSIGNAL_SEND_PARAMS APPSIGNAL_ENABLE_MINUTELY_PROBES
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV)
   @string_list_keys ~w(

--- a/lib/appsignal/probes/probes.ex
+++ b/lib/appsignal/probes/probes.ex
@@ -47,16 +47,18 @@ defmodule Appsignal.Probes do
   end
 
   def handle_info(:run_probes, probes) do
-    Enum.each(probes, fn {name, probe} ->
-      Task.start(fn ->
-        try do
-          probe.()
-        rescue
-          e ->
-            Logger.error("Error while calling probe #{name}: #{e}")
-        end
+    if Appsignal.Config.minutely_probes_enabled?() do
+      Enum.each(probes, fn {name, probe} ->
+        Task.start(fn ->
+          try do
+            probe.()
+          rescue
+            e ->
+              Logger.error("Error while calling probe #{name}: #{e}")
+          end
+        end)
       end)
-    end)
+    end
 
     schedule_probes()
     {:noreply, probes}

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -165,6 +165,11 @@ defmodule Appsignal.ConfigTest do
                default_configuration() |> Map.put(:enable_host_metrics, false)
     end
 
+    test "enable_minutely_probes" do
+      assert with_config(%{enable_minutely_probes: false}, &init_config/0) ==
+               default_configuration() |> Map.put(:enable_minutely_probes, false)
+    end
+
     test "endpoint" do
       assert with_config(%{endpoint: "https://push.staging.lol"}, &init_config/0) ==
                default_configuration() |> Map.put(:endpoint, "https://push.staging.lol")
@@ -337,6 +342,13 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_ENABLE_HOST_METRICS" => "false"},
                &init_config/0
              ) == default_configuration() |> Map.put(:enable_host_metrics, false)
+    end
+
+    test "enable_minutely_probes" do
+      assert with_env(
+               %{"APPSIGNAL_ENABLE_MINUTELY_PROBES" => "false"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:enable_minutely_probes, false)
     end
 
     test "endpoint" do
@@ -809,6 +821,7 @@ defmodule Appsignal.ConfigTest do
       debug: false,
       dns_servers: [],
       enable_host_metrics: true,
+      enable_minutely_probes: true,
       endpoint: "https://push.appsignal.com",
       diagnose_endpoint: "https://appsignal.com/diag",
       env: :dev,

--- a/test/appsignal/probes/probes_test.exs
+++ b/test/appsignal/probes/probes_test.exs
@@ -34,5 +34,22 @@ defmodule Appsignal.Probes.ProbesTest do
 
       Probes.unregister(:test_probe)
     end
+
+    test "a probe does not get called by the probes system if it's disabled", %{
+      fake_probe: fake_probe
+    } do
+      AppsignalTest.Utils.with_config(%{enable_minutely_probes: false}, fn ->
+        Probes.register(:test_probe, &FakeProbe.call/0)
+
+        refute FakeProbe.get(fake_probe, :probe_called)
+
+        # Sleep for some time to give the Probe system time to do its work
+        :timer.sleep(100)
+
+        refute FakeProbe.get(fake_probe, :probe_called)
+
+        Probes.unregister(:test_probe)
+      end)
+    end
   end
 end


### PR DESCRIPTION
Allow users to completely disable the minutely probes feature in case of
an issue or if they don't want the metrics to be collected by default.