### PR TITLE
Don't use fetch_env!/2 in ErlangProbe

### DIFF
--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -48,13 +48,13 @@ defmodule Appsignal.Probes.ErlangProbe do
   end
 
   defp hostname do
-    case Application.fetch_env!(:appsignal, :config)[:hostname] do
-      nil ->
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, %{hostname: hostname}} ->
+        hostname
+
+      _ ->
         {:ok, hostname} = @inet.gethostname()
         List.to_string(hostname)
-
-      hostname ->
-        hostname
     end
   end
 end

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -1,6 +1,6 @@
 defmodule Appsignal.Probes.ErlangProbeTest do
   use ExUnit.Case, async: false
-
+  import AppsignalTest.Utils
   alias Appsignal.{FakeAppsignal, Probes.ErlangProbe}
 
   setup do
@@ -110,6 +110,15 @@ defmodule Appsignal.Probes.ErlangProbeTest do
                  value: _
                }
              ] = FakeAppsignal.get_gauges(fake_appsignal, "erlang_memory")
+    end
+  end
+
+  describe "call/0, with a configured hostname" do
+    test "adds the configured hostname as a tag", %{fake_appsignal: fake_appsignal} do
+      with_config(%{hostname: "Alices-MBP.example.com"}, &ErlangProbe.call/0)
+
+      assert [%{tags: %{hostname: "Alices-MBP.example.com"}} | _] =
+               FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
     end
   end
 end


### PR DESCRIPTION
Fall back to using the :inet hostname when no :appsignal config is
defined. Only use the one from the config when the config exists and has
a :hostname key.