### PR TITLE
Remove sleeps from tests

### DIFF
--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -45,7 +45,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -64,7 +64,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -83,7 +83,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -100,7 +100,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     :proc_lib.spawn(fn -> throw({:badmatch, [1, 2, 3]}) end)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -117,7 +117,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     CrashingGenServer.start(:throw)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -141,7 +141,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     CrashingGenServer.start(:exit)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -167,7 +167,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     CrashingGenServer.start(:function_error)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -199,7 +199,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -222,7 +222,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 
@@ -246,7 +246,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     end)
 
     [{_, reason, message, stacktrace}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 

--- a/test/appsignal/error_handler_test.exs
+++ b/test/appsignal/error_handler_test.exs
@@ -26,7 +26,7 @@ defmodule Appsignal.ErrorHandlerTest do
       end)
 
     [{transaction, reason, _message, _stack}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 

--- a/test/appsignal/error_handler_test.exs
+++ b/test/appsignal/error_handler_test.exs
@@ -42,13 +42,13 @@ defmodule Appsignal.ErrorHandlerTest do
       :erlang.error(:error_ignored)
     end)
 
-    :timer.sleep(100)
-
-    refute fake_transaction
-           |> FakeTransaction.errors()
-           |> Enum.any?(fn error ->
-             match?({%Transaction{}, ":error_ignored", _, _}, error)
-           end)
+    repeatedly(fn ->
+      refute fake_transaction
+             |> FakeTransaction.errors()
+             |> Enum.any?(fn error ->
+               match?({%Transaction{}, ":error_ignored", _, _}, error)
+             end)
+    end)
   end
 
   test "submitting the transaction", %{fake_transaction: fake_transaction} do

--- a/test/appsignal/error_logger_handler_test.exs
+++ b/test/appsignal/error_logger_handler_test.exs
@@ -28,7 +28,7 @@ defmodule Appsignal.ErrorLoggerHandlerTest do
       end)
 
     [{transaction, reason, _, _}] =
-      with_retries(fn ->
+      until(fn ->
         assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
       end)
 

--- a/test/appsignal/error_logger_handler_test.exs
+++ b/test/appsignal/error_logger_handler_test.exs
@@ -44,13 +44,13 @@ defmodule Appsignal.ErrorLoggerHandlerTest do
       :erlang.error(:error_ignored)
     end)
 
-    :timer.sleep(100)
-
-    refute fake_transaction
-           |> FakeTransaction.errors()
-           |> Enum.any?(fn error ->
-             match?({%Transaction{}, ":error_ignored", _, _}, error)
-           end)
+    repeatedly(fn ->
+      refute fake_transaction
+             |> FakeTransaction.errors()
+             |> Enum.any?(fn error ->
+               match?({%Transaction{}, ":error_ignored", _, _}, error)
+             end)
+    end)
   end
 
   test "does not cause warnings for noise on handle_info" do

--- a/test/appsignal/error_logger_handler_test.exs
+++ b/test/appsignal/error_logger_handler_test.exs
@@ -1,6 +1,7 @@
 defmodule Appsignal.ErrorLoggerHandlerTest do
-  use ExUnit.Case, async: false
   alias Appsignal.{FakeTransaction, Transaction}
+  import AppsignalTest.Utils
+  use ExUnit.Case, async: false
 
   setup do
     Appsignal.remove_report_handler()
@@ -26,9 +27,10 @@ defmodule Appsignal.ErrorLoggerHandlerTest do
         :erlang.error(:error_http_request)
       end)
 
-    :timer.sleep(20)
-
-    [{transaction, reason, _message, _stack}] = FakeTransaction.errors(fake_transaction)
+    [{transaction, reason, _, _}] =
+      with_retries(fn ->
+        assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
+      end)
 
     assert transaction.id == inspect(pid)
     assert reason == ":error_http_request"

--- a/test/appsignal/instrumentation/helpers_test.exs
+++ b/test/appsignal/instrumentation/helpers_test.exs
@@ -31,11 +31,7 @@ defmodule AppsignalHelpersTest do
   end
 
   defp call_instrument(arg) do
-    r =
-      Helpers.instrument(arg, "name", "title", fn ->
-        :timer.sleep(100)
-        :result
-      end)
+    r = Helpers.instrument(arg, "name", "title", fn -> :result end)
 
     assert :result == r
   end

--- a/test/appsignal/logger_handler_test.exs
+++ b/test/appsignal/logger_handler_test.exs
@@ -1,7 +1,8 @@
 if System.otp_release() >= "21" do
   defmodule Appsignal.LoggerHandlerTest do
-    use ExUnit.Case, async: false
     alias Appsignal.{FakeTransaction, Transaction}
+    use ExUnit.Case, async: false
+    import AppsignalTest.Utils
 
     setup do
       Appsignal.remove_report_handler()
@@ -27,9 +28,10 @@ if System.otp_release() >= "21" do
           :erlang.error(:error_http_request)
         end)
 
-      :timer.sleep(20)
-
-      [{transaction, reason, _message, _stack}] = FakeTransaction.errors(fake_transaction)
+      [{transaction, reason, _, _}] =
+        with_retries(fn ->
+          assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
+        end)
 
       assert transaction.id == inspect(pid)
       assert reason == ":error_http_request"

--- a/test/appsignal/logger_handler_test.exs
+++ b/test/appsignal/logger_handler_test.exs
@@ -47,13 +47,13 @@ if System.otp_release() >= "21" do
         :erlang.error(:error_ignored)
       end)
 
-      :timer.sleep(100)
-
-      refute fake_transaction
-             |> FakeTransaction.errors()
-             |> Enum.any?(fn error ->
-               match?({%Transaction{}, ":error_ignored", _, _}, error)
-             end)
+      repeatedly(fn ->
+        refute fake_transaction
+               |> FakeTransaction.errors()
+               |> Enum.any?(fn error ->
+                 match?({%Transaction{}, ":error_ignored", _, _}, error)
+               end)
+      end)
     end
   end
 end

--- a/test/appsignal/logger_handler_test.exs
+++ b/test/appsignal/logger_handler_test.exs
@@ -29,7 +29,7 @@ if System.otp_release() >= "21" do
         end)
 
       [{transaction, reason, _, _}] =
-        with_retries(fn ->
+        until(fn ->
           assert [{_, _, _, _}] = FakeTransaction.errors(fake_transaction)
         end)
 

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -56,8 +56,9 @@ defmodule OverridingAppSignalPlug do
 end
 
 defmodule Appsignal.PlugTest do
-  use ExUnit.Case
   alias Appsignal.FakeTransaction
+  import AppsignalTest.Utils
+  use ExUnit.Case
 
   setup do
     {:ok, fake_transaction} = FakeTransaction.start_link()
@@ -203,8 +204,9 @@ defmodule Appsignal.PlugTest do
     end
 
     test "ignores the process' pid" do
-      :timer.sleep(1)
-      assert Appsignal.TransactionRegistry.ignored?(self()) == true
+      with_retries(fn ->
+        assert Appsignal.TransactionRegistry.ignored?(self()) == true
+      end)
     end
   end
 

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -204,7 +204,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "ignores the process' pid" do
-      with_retries(fn ->
+      until(fn ->
         assert Appsignal.TransactionRegistry.ignored?(self()) == true
       end)
     end

--- a/test/appsignal/probes/probes_test.exs
+++ b/test/appsignal/probes/probes_test.exs
@@ -3,6 +3,7 @@ defmodule Appsignal.Probes.ProbesTest do
 
   alias Appsignal.Probes
   alias FakeProbe
+  import AppsignalTest.Utils
 
   describe "register/2" do
     test "registers a probe when given a function as probe" do
@@ -27,10 +28,9 @@ defmodule Appsignal.Probes.ProbesTest do
 
       refute FakeProbe.get(fake_probe, :probe_called)
 
-      # Sleep for some time to give the Probe system time to do its work
-      :timer.sleep(100)
-
-      assert FakeProbe.get(fake_probe, :probe_called)
+      with_retries(fn ->
+        assert FakeProbe.get(fake_probe, :probe_called)
+      end)
 
       Probes.unregister(:test_probe)
     end
@@ -41,12 +41,9 @@ defmodule Appsignal.Probes.ProbesTest do
       AppsignalTest.Utils.with_config(%{enable_minutely_probes: false}, fn ->
         Probes.register(:test_probe, &FakeProbe.call/0)
 
-        refute FakeProbe.get(fake_probe, :probe_called)
-
-        # Sleep for some time to give the Probe system time to do its work
-        :timer.sleep(100)
-
-        refute FakeProbe.get(fake_probe, :probe_called)
+        repeatedly(fn ->
+          refute FakeProbe.get(fake_probe, :probe_called)
+        end)
 
         Probes.unregister(:test_probe)
       end)

--- a/test/appsignal/probes/probes_test.exs
+++ b/test/appsignal/probes/probes_test.exs
@@ -28,7 +28,7 @@ defmodule Appsignal.Probes.ProbesTest do
 
       refute FakeProbe.get(fake_probe, :probe_called)
 
-      with_retries(fn ->
+      until(fn ->
         assert FakeProbe.get(fake_probe, :probe_called)
       end)
 

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -92,4 +92,22 @@ defmodule AppsignalTest.Utils do
     (Map.keys(System.get_env()) -- Map.keys(before))
     |> Enum.each(&System.delete_env/1)
   end
+
+  def with_retries(assertion) do
+    with_retries(assertion, 50)
+  end
+
+  def with_retries(assertion, retries) when retries < 1 do
+    assertion.()
+  end
+
+  def with_retries(assertion, retries) do
+    try do
+      assertion.()
+    rescue
+      ExUnit.AssertionError ->
+        :timer.sleep(10)
+        with_retries(assertion, retries - 1)
+    end
+  end
 end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -110,4 +110,17 @@ defmodule AppsignalTest.Utils do
         with_retries(assertion, retries - 1)
     end
   end
+
+  def repeatedly(assertion) do
+    repeatedly(assertion, 10)
+  end
+
+  defp repeatedly(assertion, retries) when retries < 1 do
+    assertion.()
+  end
+
+  defp repeatedly(assertion, retries) do
+    assertion.()
+    repeatedly(assertion, retries - 1)
+  end
 end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -97,11 +97,11 @@ defmodule AppsignalTest.Utils do
     with_retries(assertion, 50)
   end
 
-  def with_retries(assertion, retries) when retries < 1 do
+  defp with_retries(assertion, retries) when retries < 1 do
     assertion.()
   end
 
-  def with_retries(assertion, retries) do
+  defp with_retries(assertion, retries) do
     try do
       assertion.()
     rescue

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -93,21 +93,21 @@ defmodule AppsignalTest.Utils do
     |> Enum.each(&System.delete_env/1)
   end
 
-  def with_retries(assertion) do
-    with_retries(assertion, 50)
+  def until(assertion) do
+    until(assertion, 50)
   end
 
-  defp with_retries(assertion, retries) when retries < 1 do
+  defp until(assertion, retries) when retries < 1 do
     assertion.()
   end
 
-  defp with_retries(assertion, retries) do
+  defp until(assertion, retries) do
     try do
       assertion.()
     rescue
       ExUnit.AssertionError ->
         :timer.sleep(10)
-        with_retries(assertion, retries - 1)
+        until(assertion, retries - 1)
     end
   end
 


### PR DESCRIPTION
To remove the sleeps that caused timing issues CI, this patch adds the `until/1` and `repeatedly/1` test helpers to deal with timing-sensitive tests. The former retries an assertion every 10 ms until no AssertionError is raised, and the latter runs a function for ten times to make sure no failure happens in a 100 ms timespan.