### PR TITLE
Handle atom keys in MapFilter.filter_values/2

### DIFF
--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -19,7 +19,7 @@ defmodule Appsignal.Utils.MapFilter do
 
   def filter_values(%{} = map, filter_params) do
     Enum.into(map, %{}, fn {k, v} ->
-      if is_binary(k) and String.contains?(k, filter_params) do
+      if (is_binary(k) or is_atom(k)) and String.contains?(to_string(k), filter_params) do
         {k, "[FILTERED]"}
       else
         {k, filter_values(v, filter_params)}

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -48,6 +48,12 @@ defmodule Appsignal.Transaction.FilterTest do
              ]) == %{"foo" => "bar", "password" => "[FILTERED]"}
     end
 
+    test "filter_values with an atom key" do
+      assert MapFilter.filter_values(%{"foo" => "bar", password: "should_not_show"}, [
+               "password"
+             ]) == %{"foo" => "bar", password: "[FILTERED]"}
+    end
+
     test "filter_values when a map has secret key" do
       assert MapFilter.filter_values(
                %{"foo" => "bar", "map" => %{"password" => "should_not_show"}},


### PR DESCRIPTION
As reported in https://app.intercom.io/a/apps/yzor8gyw/users/5c0137be92ce92ecda020682/all-conversations. Although Phoenix exclusively uses string keys, Addict uses atom keys. This patch adds support for atom keys besides string keys.