### PR TITLE
Deactivate AppSignal when not active

### DIFF
--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -60,7 +60,7 @@ defmodule Appsignal.Demo do
 
   defp finish_demo_transaction(transaction) do
     @transaction.finish(transaction)
-    :ok = @transaction.complete(transaction)
+    @transaction.complete(transaction)
 
     transaction
   end

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -78,8 +78,10 @@ defmodule Appsignal.Transaction do
   """
   @spec create(String.t(), atom) :: Transaction.t()
   def create(transaction_id, namespace) when is_binary(transaction_id) and is_atom(namespace) do
-    {:ok, resource} = Nif.start_transaction(transaction_id, Atom.to_string(namespace))
-    %Transaction{resource: resource, id: transaction_id}
+    if Appsignal.Config.active?() do
+      {:ok, resource} = Nif.start_transaction(transaction_id, Atom.to_string(namespace))
+      %Transaction{resource: resource, id: transaction_id}
+    end
   end
 
   if Mix.env() in [:test, :test_phoenix] do

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -35,7 +35,7 @@ defmodule Appsignal.TransactionRegistry do
   def register(transaction) do
     pid = self()
 
-    if registry_alive?() do
+    if Appsignal.Config.active?() && registry_alive?() do
       monitor_reference = GenServer.call(__MODULE__, {:monitor, pid})
       true = :ets.insert(@table, {pid, transaction, monitor_reference})
       :ok
@@ -50,16 +50,12 @@ defmodule Appsignal.TransactionRegistry do
   """
   @spec lookup(pid) :: Transaction.t() | nil
   def lookup(pid) do
-    case registry_alive?() && :ets.lookup(@table, pid) do
+    case Appsignal.Config.active?() && registry_alive?() && :ets.lookup(@table, pid) do
       [{^pid, %Transaction{} = transaction, _}] ->
         transaction
 
       [{^pid, %Transaction{} = transaction}] ->
         transaction
-
-      false ->
-        Logger.debug("AppSignal was not started, skipping transaction lookup.")
-        nil
 
       _ ->
         nil

--- a/lib/mix/tasks/appsignal.demo.ex
+++ b/lib/mix/tasks/appsignal.demo.ex
@@ -6,13 +6,21 @@ defmodule Mix.Tasks.Appsignal.Demo do
 
   def run(_args) do
     {:ok, _} = Application.ensure_all_started(:appsignal)
-    Appsignal.Demo.create_transaction_performance_request()
-    Appsignal.Demo.create_transaction_error_request()
-    Appsignal.stop(nil)
-    Logger.info("Demonstration sample data sent!")
 
-    Logger.info(
-      "It may take about a minute for the data to appear on https://appsignal.com/accounts"
-    )
+    if Appsignal.Config.active?() do
+      Appsignal.Demo.create_transaction_performance_request()
+      Appsignal.Demo.create_transaction_error_request()
+      Appsignal.stop(nil)
+      Logger.info("Demonstration sample data sent!")
+
+      Logger.info(
+        "It may take about a minute for the data to appear on https://appsignal.com/accounts"
+      )
+    else
+      Logger.error("""
+      Unable to start the AppSignal agent and send data to AppSignal.com
+      Please use the diagnose command (https://docs.appsignal.com/elixir/command-line/diagnose.html) to debug your configuration.
+      """)
+    end
   end
 end

--- a/lib/mix/tasks/appsignal.demo.ex
+++ b/lib/mix/tasks/appsignal.demo.ex
@@ -18,8 +18,10 @@ defmodule Mix.Tasks.Appsignal.Demo do
       )
     else
       Logger.error("""
-      Unable to start the AppSignal agent and send data to AppSignal.com
-      Please use the diagnose command (https://docs.appsignal.com/elixir/command-line/diagnose.html) to debug your configuration.
+      Error: Unable to start the AppSignal agent and send data to AppSignal.com.
+      Please use the diagnose command (https://docs.appsignal.com/elixir/command-line/diagnose.html) to debug your configuration:
+
+            MIX_ENV=prod mix appsignal.diagnose
       """)
     end
   end

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -64,6 +64,7 @@ defmodule Appsignal.EctoTest do
   test "does not record an event without a Transaction", %{fake_transaction: fake_transaction} do
     perform_event()
     perform_telemetry_0_3_event()
+    log_event()
 
     assert [] == FakeTransaction.recorded_events(fake_transaction)
   end

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -63,6 +63,7 @@ defmodule Appsignal.EctoTest do
 
   test "does not record an event without a Transaction", %{fake_transaction: fake_transaction} do
     perform_event()
+    perform_telemetry_0_3_event()
 
     assert [] == FakeTransaction.recorded_events(fake_transaction)
   end

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -318,6 +318,25 @@ defmodule Appsignal.PlugTest do
     end
   end
 
+  describe "when AppSignal is disabled" do
+    setup do
+      conn =
+        AppsignalTest.Utils.with_config(%{active: false}, fn ->
+          OverridingAppSignalPlug.call(%Plug.Conn{}, %{})
+        end)
+
+      [conn: conn]
+    end
+
+    test "does not start a transaction", %{fake_transaction: fake_transaction} do
+      refute FakeTransaction.started_transaction?(fake_transaction)
+    end
+
+    test "calls super and returns the conn", %{conn: conn} do
+      assert conn.assigns[:called?]
+    end
+  end
+
   describe "extracting action names" do
     test "from a Plug conn" do
       assert Appsignal.Plug.extract_action(%Plug.Conn{method: "GET", request_path: "/foo"}) ==

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -1,7 +1,7 @@
 defmodule Appsignal.Transaction.RegistryTest do
-  use ExUnit.Case, async: false
-
   alias Appsignal.{Transaction, TransactionRegistry}
+  import AppsignalTest.Utils
+  use ExUnit.Case, async: false
 
   test "lookup/1 returns nil after process has ended" do
     transaction = %Transaction{id: Transaction.generate_id()}
@@ -80,11 +80,29 @@ defmodule Appsignal.Transaction.RegistryTest do
     end
   end
 
+  describe "register/1, when disabled" do
+    test "returns nil" do
+      with_config(%{active: false}, fn ->
+        assert nil == TransactionRegistry.register(%Transaction{})
+      end)
+    end
+  end
+
   describe "lookup/1, when the registry is not running" do
     setup [:register_transaction, :terminate_registry]
 
     test "does not find an existing transaction by pid" do
       assert TransactionRegistry.lookup(self()) == nil
+    end
+  end
+
+  describe "lookup/1, when disabled" do
+    setup :register_transaction
+
+    test "returns nil" do
+      with_config(%{active: false}, fn ->
+        assert nil == TransactionRegistry.register(%Transaction{})
+      end)
     end
   end
 

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -309,6 +309,18 @@ defmodule AppsignalTransactionTest do
     end
   end
 
+  describe "creating a transaction when disabled" do
+    setup do
+      with_config(%{active: false}, fn ->
+        [transaction: Transaction.create("123", :http_request)]
+      end)
+    end
+
+    test "does not create a transaction", %{transaction: transaction} do
+      assert transaction == nil
+    end
+  end
+
   describe "starting a transaction" do
     setup do
       id = Transaction.generate_id()


### PR DESCRIPTION
Closes #409.

This patch makes sure not to start transactions when AppSignal is configured to not be active. The `Transaction` and `Registry` modules won't create, register or lookup Transactions, and the `Plug` will only call `super` in the host application's `call/2` function.

The demo command doesn't work when AppSignal is disabled, so it prints an error to explain to run the diagnose command instead, like we do in the Ruby intergation (but with a link to the documentation, which I'll also propose for Ruby).