### PR TITLE
Handle errors in Mix.Appsignal.Helper.uid/0

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -557,14 +557,19 @@ defmodule Mix.Appsignal.Helper do
   end
 
   def uid do
-    case System.cmd("id", ["-u"]) do
-      {id, 0} ->
-        case Integer.parse(List.first(String.split(id, "\n"))) do
-          {int, _} -> int
-          :error -> nil
-        end
+    try do
+      case @system.cmd("id", ["-u"]) do
+        {id, 0} ->
+          case Integer.parse(List.first(String.split(id, "\n"))) do
+            {int, _} -> int
+            :error -> nil
+          end
 
-      {_, _} ->
+        {_, _} ->
+          nil
+      end
+    catch
+      :error, _ ->
         nil
     end
   end

--- a/test/mix/helpers_test.exs
+++ b/test/mix/helpers_test.exs
@@ -119,4 +119,22 @@ defmodule Mix.Appsignal.HelperTest do
       assert Mix.Appsignal.Helper.check_proxy(env) == nil
     end
   end
+
+  describe "uid/0" do
+    test "returns the uid", %{fake_system: fake_system} do
+      FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
+        {"999\n", 0}
+      end)
+
+      assert Mix.Appsignal.Helper.uid() == 999
+    end
+
+    test "nil", %{fake_system: fake_system} do
+      FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
+        :erlang.raise(:error, :enoent, [])
+      end)
+
+      assert Mix.Appsignal.Helper.uid() == nil
+    end
+  end
 end

--- a/test/support/fake_system.ex
+++ b/test/support/fake_system.ex
@@ -1,7 +1,7 @@
 defmodule FakeSystem do
   use TestAgent, %{cmd: fn _, _, _ -> raise "oh no!" end}
 
-  def cmd(command, args, opts) do
+  def cmd(command, args, opts \\ []) do
     get(__MODULE__, :cmd).(command, args, opts)
   end
 end


### PR DESCRIPTION
Closes #477. Aside from tuples, `System.cmd/2` can raise POSIX errors.
This patch makes sure that doesn't break compilation.

Based in master to publish this as a patch release.