### PR TITLE
 Implicitly check ignored transactions in `TransactionRegistry.lookup/1`

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -10,9 +10,8 @@ defmodule Appsignal.ErrorHandler do
 
   """
 
+  alias Appsignal.{Backtrace, Error}
   require Logger
-
-  alias Appsignal.{Backtrace, Error, TransactionRegistry}
 
   @transaction Application.get_env(
                  :appsignal,
@@ -30,10 +29,7 @@ defmodule Appsignal.ErrorHandler do
   end
 
   def handle_error(pid, error, stack, conn) do
-    transaction =
-      unless TransactionRegistry.ignored?(pid) do
-        @transaction.lookup_or_create_transaction(pid)
-      end
+    transaction = @transaction.lookup_or_create_transaction(pid)
 
     if transaction != nil do
       handle_error(transaction, error, stack, conn)

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -533,6 +533,10 @@ defmodule Appsignal.Transaction do
   case, we should not continue submitting the transaction.
   """
   def lookup_or_create_transaction(origin \\ self(), namespace \\ :background_job) do
-    TransactionRegistry.lookup(origin) || Transaction.start("_" <> generate_id(), namespace)
+    case TransactionRegistry.lookup(origin) do
+      %Transaction{} = transaction -> transaction
+      :ignored -> nil
+      _ -> Transaction.start("_" <> generate_id(), namespace)
+    end
   end
 end

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -116,6 +116,7 @@ defmodule Appsignal.TransactionRegistry do
   @doc """
   Check if a progress is ignored.
   """
+  @deprecated "Use Appsignal.TransactionRegistry.lookup/1 instead."
   @spec ignored?(pid()) :: boolean()
   def ignored?(pid) do
     case registry_alive?() && :ets.lookup(@table, pid) do

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -35,7 +35,7 @@ defmodule Appsignal.TransactionRegistry do
   def register(transaction) do
     pid = self()
 
-    if registry_alive?() do
+    if Appsignal.Config.active?() && registry_alive?() do
       monitor_reference = GenServer.call(__MODULE__, {:monitor, pid})
       true = :ets.insert(@table, {pid, transaction, monitor_reference})
       :ok
@@ -50,19 +50,11 @@ defmodule Appsignal.TransactionRegistry do
   """
   @spec lookup(pid) :: Transaction.t() | nil
   def lookup(pid) do
-    case registry_alive?() && :ets.lookup(@table, pid) do
-      [{^pid, %Transaction{} = transaction, _}] ->
-        transaction
-
-      [{^pid, %Transaction{} = transaction}] ->
-        transaction
-
-      false ->
-        Logger.debug("AppSignal was not started, skipping transaction lookup.")
-        nil
-
-      _ ->
-        nil
+    case Appsignal.Config.active?() && registry_alive?() && :ets.lookup(@table, pid) do
+      [{^pid, %Transaction{} = transaction, _}] -> transaction
+      [{^pid, %Transaction{} = transaction}] -> transaction
+      [{^pid, :ignore}] -> :ignored
+      _ -> nil
     end
   end
 

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -204,7 +204,7 @@ defmodule Appsignal.PlugTest do
 
     test "ignores the process' pid" do
       :timer.sleep(1)
-      assert Appsignal.TransactionRegistry.ignored?(self()) == true
+      assert Appsignal.TransactionRegistry.lookup(self()) == :ignored
     end
   end
 

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -50,25 +50,25 @@ defmodule Appsignal.Transaction.RegistryTest do
     end
   end
 
-  describe "ignore/1 and ignored?/1" do
+  describe "ignore/1" do
     test "is not ignored by default" do
-      assert TransactionRegistry.ignored?(:c.pid(0, 990, 0)) == false
+      refute TransactionRegistry.lookup(:c.pid(0, 990, 0)) == :ignored
     end
 
     test "ignores a pid" do
       pid = :c.pid(0, 991, 0)
       :ok = TransactionRegistry.ignore(pid)
-      assert TransactionRegistry.ignored?(pid) == true
+      assert TransactionRegistry.lookup(pid) == :ignored
     end
   end
 
-  describe "ignore/1 and ignored?/1, when the registry is not running" do
+  describe "ignore/1, when the registry is not running" do
     setup :terminate_registry
 
     test "can't ignore a pid" do
       pid = :c.pid(0, 992, 0)
       {:error, :no_registry} = TransactionRegistry.ignore(pid)
-      assert TransactionRegistry.ignored?(pid) == false
+      refute TransactionRegistry.lookup(pid) == :ignored
     end
   end
 

--- a/test/support/appsignal/fake_transaction.ex
+++ b/test/support/appsignal/fake_transaction.ex
@@ -169,7 +169,7 @@ defmodule Appsignal.FakeTransaction do
   end
 
   def lookup_or_create_transaction(pid) do
-    start(inspect(pid), :background_job)
+    Appsignal.Transaction.lookup_or_create_transaction(pid)
   end
 
   def create(id, namespace) do


### PR DESCRIPTION
Part of #476. 

This patch removes and deprecates `TransactionRegistry.ignored?/0`, which is now handled using `lookup/0` directly instead, to reduce the amount of work being done in the Registry process.