### PR TITLE
 Convert time units for all Ecto callbacks

### DIFF
--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -43,18 +43,41 @@ defmodule Appsignal.Ecto do
   @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 
   def handle_event(_event, %{total_time: duration}, metadata, _config) do
-    @transaction.record_event("query.ecto", "", metadata.query, duration, 1)
+    @transaction.record_event(
+      "query.ecto",
+      "",
+      metadata.query,
+      convert_time_unit(duration),
+      1
+    )
   end
 
   def handle_event(_event, duration, metadata, _config) when is_integer(duration) do
-    @transaction.record_event("query.ecto", "", metadata.query, duration, 1)
+    @transaction.record_event(
+      "query.ecto",
+      "",
+      metadata.query,
+      convert_time_unit(duration),
+      1
+    )
   end
 
   def log(entry) do
-    total_time = (entry.queue_time || 0) + (entry.query_time || 0) + (entry.decode_time || 0)
-    duration = System.convert_time_unit(total_time, :native, :nanosecond)
-    @transaction.record_event("query.ecto", "", entry.query, duration, 1)
+    duration = (entry.queue_time || 0) + (entry.query_time || 0) + (entry.decode_time || 0)
+
+    @transaction.record_event(
+      "query.ecto",
+      "",
+      entry.query,
+      convert_time_unit(duration),
+      1
+    )
 
     entry
+  end
+
+  defp convert_time_unit(time) do
+    # Converts the native time to a value in nanoseconds.
+    System.convert_time_unit(time, :native, 1_000_000_000)
   end
 end

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -43,6 +43,24 @@ defmodule Appsignal.EctoTest do
            ] = FakeTransaction.recorded_events(fake_transaction)
   end
 
+  test "records an event from the Ecto logger", %{fake_transaction: fake_transaction} do
+    transaction = Transaction.start("test", :http_request)
+
+    log_event()
+
+    assert [
+             %{
+               transaction: ^transaction,
+               body:
+                 "SELECT u0.\"id\", u0.\"name\", u0.\"inserted_at\", u0.\"updated_at\" FROM \"users\" AS u0",
+               body_format: 1,
+               duration: 58_336_000,
+               name: "query.ecto",
+               title: ""
+             }
+           ] = FakeTransaction.recorded_events(fake_transaction)
+  end
+
   test "does not record an event without a Transaction", %{fake_transaction: fake_transaction} do
     perform_event()
 
@@ -98,5 +116,29 @@ defmodule Appsignal.EctoTest do
       },
       nil
     )
+  end
+
+  defp log_event do
+    Appsignal.Ecto.log(%{
+      decode_time: 22_943_000,
+      params: [],
+      query:
+        "SELECT u0.\"id\", u0.\"name\", u0.\"inserted_at\", u0.\"updated_at\" FROM \"users\" AS u0",
+      query_time: 33_874_000,
+      queue_time: 1_519_000,
+      result:
+        {:ok,
+         %{
+           columns: ["id", "name", "inserted_at", "updated_at"],
+           command: :select,
+           connection_id: 66958,
+           messages: [],
+           num_rows: 1,
+           rows: [
+             [1, "Testing!", ~N[2019-01-10 13:38:27.000000], ~N[2019-01-23 11:42:44.000000]]
+           ]
+         }},
+      source: "users"
+    })
   end
 end


### PR DESCRIPTION
After adding a regression test for the work in #478, the build [failed](https://travis-ci.org/appsignal/appsignal-elixir/builds/522068288) on 1.3.x because `:nanoseconds` wasn't accepted in `System.convert_time_unit` in older versions.

This patch cherry-picks that regression test, uses `1_000_000_000` (which is accepted as nanoseconds in all versions), and makes sure to convert for all callbacks in the Ecto integration. The native time is usually in nanoseconds, but this makes sure we're always reporting correctly. 

Fixes #385, although we should disable completely, which is in #478 (and is now based on this branch).