### PR TITLE
Fix building on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifeq ($(shell uname),Darwin)
 	LDFLAGS += -dynamiclib -undefined dynamic_lookup
 endif
 
-LDFLAGS += -Wl,-fatal_warnings
+LDFLAGS += -Wl,--fatal-warnings
 
 all:
 	@$(CC) $(CFLAGS) $(CFLAGS_ADD) -shared $(LDFLAGS) -o $(OUTPUT) c_src/$(LIB).c

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -407,7 +407,7 @@ defmodule Mix.Appsignal.Helper do
   defp extract_ldd_version(nil), do: nil
 
   defp extract_ldd_version(ldd_output) do
-    List.first(Regex.run(~r/\d+\.\d+/, ldd_output))
+    List.first(Regex.run(~r/\d+\.\d+/, ldd_output) || [])
   end
 
   defp initial_report do


### PR DESCRIPTION
Feel free to rewrite in any way

2 changes
1) on FreeBSD `ldd` doesn't support `-v` flag,  which causes regex to return `nil`, and `List.first(nil)` crashes 
2) clang doesn't understand `-fatal_warning`, quick web search showed that there is `--fatal-warning` flags that both gcc and clang understand, not sure if it has same meaning