### PR TITLE
Fix FreeBSD compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ CFLAGS = -g -O3 -pedantic -Wall -Wextra -I"$(ERLANG_PATH)" -I"$(LIB_DIR)"
 ifeq ($(shell uname),Linux)
 	LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive -static-libgcc
 else
-	LDFLAGS = "$(LIB_DIR)"/$(LIB_NAME)
+	ifeq ($(shell uname),FreeBSD)
+		LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive
+	else
+		LDFLAGS = "$(LIB_DIR)"/$(LIB_NAME)
+	endif
 endif
 
 LIB = appsignal_extension

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ LIB_NAME = libappsignal.a
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
 CFLAGS = -g -O3 -pedantic -Wall -Wextra -I"$(ERLANG_PATH)" -I"$(LIB_DIR)"
 ifeq ($(shell uname),Linux)
-	LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive -static-libgcc
+	LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive -static-libgcc -Wl,-fatal_warnings
 else
 	ifeq ($(shell uname),FreeBSD)
-		LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive
+		LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive -Wl,--fatal-warnings
 	else
-		LDFLAGS = "$(LIB_DIR)"/$(LIB_NAME)
+		LDFLAGS = "$(LIB_DIR)"/$(LIB_NAME) -Wl,-fatal_warnings
 	endif
 endif
 
@@ -21,8 +21,6 @@ endif
 ifeq ($(shell uname),Darwin)
 	LDFLAGS += -dynamiclib -undefined dynamic_lookup
 endif
-
-LDFLAGS += -Wl,-fatal_warnings
 
 all:
 	@$(CC) $(CFLAGS) $(CFLAGS_ADD) -shared $(LDFLAGS) -o $(OUTPUT) c_src/$(LIB).c


### PR DESCRIPTION
On my local test setup I needed more LDFLAGS (linking flags) for the
FreeBSD build to work.

Without it the following error would be returned on Nif.start:

```
warning: Error loading NIF (Is your operating system
  (amd64-portbld-freebsd11.2) supported? Please check
  http://docs.appsignal.com/support/operating-systems.html):
Failed to load NIF library:
  '/path/_build/dev/lib/appsignal/priv/appsignal_extension.so:
    Undefined symbol "appsignal_running_in_container"'
    (appsignal) lib/appsignal/nif.ex:48: Appsignal.Nif.init/0
    (kernel) code_server.erl:1347: anonymous fn/1 in
      :code_server.handle_on_load/5
```