### PR TITLE
Update make clean task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 LIB_NAME = libappsignal.a
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
+LIB_DIR ?= ./priv
 CFLAGS = -g -O3 -pedantic -Wall -Wextra -I"$(ERLANG_PATH)" -I"$(LIB_DIR)"
 ifeq ($(shell uname),Linux)
 	LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive -static-libgcc
@@ -24,4 +25,4 @@ all:
 	@$(CC) $(CFLAGS) $(CFLAGS_ADD) -shared $(LDFLAGS) -o $(OUTPUT) c_src/$(LIB).c
 
 clean:
-	@$(RM) -r "$(LIB_DIR)"/$(LIB).so*
+	@$(RM) -r "$(LIB_DIR)"/*appsignal* "$(LIB_DIR)"/*.report

--- a/scripts/test
+++ b/scripts/test
@@ -15,4 +15,4 @@ fi
 
 MIX_ENV=test mix test
 MIX_ENV=test_phoenix mix test
-(cd priv && rm -r *appsignal* *.report) && MIX_ENV=test_no_nif mix test
+make clean && MIX_ENV=test_no_nif mix test


### PR DESCRIPTION
Update it to clean all files that are in the `priv/` dir of the package.

Also set a default value to the `LIB_DIR` if it's not set. This is
usually set by the `mix_helpers.exs` file instead, but in case we run
`make clean` directoy, it is not set.