### PR TITLE
Handle :ignored Transactions in Transaction and Instrumentation.Helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ elixir:
   - 1.8.1
 otp_release:
   - 21.2
-  - 20.3
+  - 20.3.8
   - 19.3
 matrix:
   exclude:
@@ -18,7 +18,7 @@ matrix:
       elixir: 1.4.5
     - otp_release: 21.2
       elixir: 1.5.3
-    - otp_release: 20.3
+    - otp_release: 20.3.8
       elixir: 1.3.4
     - otp_release: 19.3
       elixir: 1.8.1

--- a/lib/appsignal/instrumentation/helpers.ex
+++ b/lib/appsignal/instrumentation/helpers.ex
@@ -51,10 +51,18 @@ defmodule Appsignal.Instrumentation.Helpers do
   ```
 
   """
-  @spec instrument(instrument_arg, String.t(), String.t(), String.t(), integer, function) :: any
+  @spec instrument(
+          pid() | Transaction.t() | any(),
+          String.t(),
+          String.t(),
+          String.t(),
+          integer,
+          function
+        ) :: any
   def instrument(pid, name, title, body, body_format, function) when is_pid(pid) do
-    t = TransactionRegistry.lookup(pid)
-    instrument(t, name, title, body, body_format, function)
+    pid
+    |> TransactionRegistry.lookup()
+    |> instrument(name, title, body, body_format, function)
   end
 
   def instrument(%Transaction{} = transaction, name, title, body, body_format, function) do
@@ -64,7 +72,7 @@ defmodule Appsignal.Instrumentation.Helpers do
     result
   end
 
-  def instrument(nil, _name, _title, _body, _body_format, function) do
+  def instrument(_transaction, _name, _title, _body, _body_format, function) do
     function.()
   end
 end

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -1,22 +1,23 @@
 defmodule Appsignal.TransactionBehaviour do
   @callback start(String.t(), atom) :: Appsignal.Transaction.t()
-  @callback start_event() :: Appsignal.Transaction.t()
-  @callback finish_event(Appsignal.Transaction.t() | nil, String.t(), String.t(), any, integer) ::
-              Appsignal.Transaction.t()
-  @callback finish() :: :sample | :no_sample
-  @callback finish(Appsignal.Transaction.t() | nil) :: :sample | :no_sample
-  @callback complete() :: :ok
-  @callback complete(Appsignal.Transaction.t() | nil) :: :ok
-  @callback set_error(Appsignal.Transaction.t() | nil, String.t(), String.t(), any) ::
-              Appsignal.Transaction.t()
-  @callback set_action(String.t()) :: Appsignal.Transaction.t()
-  @callback set_action(Appsignal.Transaction.t() | nil, String.t()) :: Appsignal.Transaction.t()
-  @callback set_sample_data(Appsignal.Transaction.t() | nil, String.t(), any) ::
-              Appsignal.Transaction.t()
+  @callback start_event() :: Appsignal.Transaction.t() | nil
+  @callback finish_event(Appsignal.Transaction.t() | any(), String.t(), String.t(), any, integer) ::
+              Appsignal.Transaction.t() | nil
+  @callback finish() :: :sample | :no_sample | nil
+  @callback finish(Appsignal.Transaction.t() | any()) :: :sample | :no_sample | nil
+  @callback complete() :: :ok | nil
+  @callback complete(Appsignal.Transaction.t() | any()) :: :ok | nil
+  @callback set_error(Appsignal.Transaction.t() | any(), String.t(), String.t(), any) ::
+              Appsignal.Transaction.t() | nil
+  @callback set_action(String.t()) :: Appsignal.Transaction.t() | nil
+  @callback set_action(Appsignal.Transaction.t() | any(), String.t()) ::
+              Appsignal.Transaction.t() | nil
+  @callback set_sample_data(Appsignal.Transaction.t() | any(), String.t(), any) ::
+              Appsignal.Transaction.t() | nil
 
   if Appsignal.plug?() do
-    @callback set_request_metadata(Appsignal.Transaction.t() | nil, Plug.Conn.t()) ::
-                Appsignal.Transaction.t()
+    @callback set_request_metadata(Appsignal.Transaction.t() | any(), Plug.Conn.t()) ::
+                Appsignal.Transaction.t() | nil
   end
 end
 
@@ -99,7 +100,7 @@ defmodule Appsignal.Transaction do
   @doc """
   Start an event for the current transaction. See `start_event/1`
   """
-  @spec start_event() :: Transaction.t()
+  @spec start_event() :: Transaction.t() | nil
   def start_event do
     start_event(lookup())
   end
@@ -113,18 +114,18 @@ defmodule Appsignal.Transaction do
   - `transaction`: The pointer to the transaction this event occurred in.
 
   """
-  @spec start_event(Transaction.t() | nil) :: Transaction.t()
-  def start_event(nil), do: nil
-
+  @spec start_event(Transaction.t() | any()) :: Transaction.t() | nil
   def start_event(%Transaction{} = transaction) do
     :ok = Nif.start_event(transaction.resource)
     transaction
   end
 
+  def start_event(_transaction), do: nil
+
   @doc """
   Finish an event for the current transaction. See `finish_event/5`.
   """
-  @spec finish_event(String.t(), String.t(), String.t(), integer) :: Transaction.t()
+  @spec finish_event(String.t(), String.t(), String.t(), integer) :: Transaction.t() | nil
   def finish_event(name, title, body, body_format \\ 0) do
     finish_event(lookup(), name, title, body, body_format)
   end
@@ -140,10 +141,8 @@ defmodule Appsignal.Transaction do
   - `body`: Body of the event, should not contain unique information per specific event (`select * from users where id=?`)
   - `body_format` Format of the event's body which can be used for sanitization, 0 for general and 1 for sql currently.
   """
-  @spec finish_event(Transaction.t() | nil, String.t(), String.t(), any, integer) ::
-          Transaction.t()
-  def finish_event(nil, _name, _title, _body, _body_format), do: nil
-
+  @spec finish_event(Transaction.t() | any(), String.t(), String.t(), any(), integer) ::
+          Transaction.t() | nil
   def finish_event(%Transaction{} = transaction, name, title, body, body_format)
       when is_binary(body) do
     :ok = Nif.finish_event(transaction.resource, name, title, body, body_format)
@@ -156,10 +155,13 @@ defmodule Appsignal.Transaction do
     transaction
   end
 
+  def finish_event(_transaction, _name, _title, _body, _body_format), do: nil
+
   @doc """
   Record a finished event for the current transaction. See `record_event/6`.
   """
-  @spec record_event(String.t(), String.t(), String.t(), integer, integer) :: Transaction.t()
+  @spec record_event(String.t(), String.t(), String.t(), integer, integer) ::
+          Transaction.t() | nil
   def record_event(name, title, body, duration, body_format \\ 0) do
     record_event(lookup(), name, title, body, duration, body_format)
   end
@@ -179,19 +181,26 @@ defmodule Appsignal.Transaction do
   - `duration`: Duration of this event in nanoseconds
   - `body_format` Format of the event's body which can be used for sanitization, 0 for general and 1 for sql currently.
   """
-  @spec record_event(Transaction.t() | nil, String.t(), String.t(), String.t(), integer, integer) ::
-          Transaction.t()
-  def record_event(nil, _name, _title, _body, _duration, _body_format), do: nil
-
+  @spec record_event(
+          Transaction.t() | any(),
+          String.t(),
+          String.t(),
+          String.t(),
+          integer,
+          integer
+        ) ::
+          Transaction.t() | nil
   def record_event(%Transaction{} = transaction, name, title, body, duration, body_format) do
     :ok = Nif.record_event(transaction.resource, name, title, body, body_format, duration)
     transaction
   end
 
+  def record_event(_transaction, _name, _title, _body, _duration, _body_format), do: nil
+
   @doc """
   Set an error for a the current transaction. See `set_error/4`.
   """
-  @spec set_error(String.t(), String.t(), any) :: Transaction.t()
+  @spec set_error(String.t(), String.t(), any) :: Transaction.t() | nil
   def set_error(name, message, backtrace) do
     set_error(lookup(), name, message, backtrace)
   end
@@ -208,9 +217,7 @@ defmodule Appsignal.Transaction do
   - `message`: Message of the error ('undefined method call for something')
   - `backtrace`: Backtrace of the error; will be JSON encoded
   """
-  @spec set_error(Transaction.t() | nil, String.t(), String.t(), any) :: Transaction.t()
-  def set_error(nil, _name, _message, _backtrace), do: nil
-
+  @spec set_error(Transaction.t() | any(), String.t(), String.t(), any) :: Transaction.t() | nil
   def set_error(%Transaction{} = transaction, name, message, backtrace) do
     name = name |> String.split_at(@max_name_size) |> elem(0)
 
@@ -223,10 +230,12 @@ defmodule Appsignal.Transaction do
     transaction
   end
 
+  def set_error(_transaction, _name, _message, _backtrace), do: nil
+
   @doc """
   Set sample data for the current transaction. See `set_sample_data/3`.
   """
-  @spec set_sample_data(Transaction.t(), Enum.t()) :: Transaction.t()
+  @spec set_sample_data(Transaction.t(), Enum.t()) :: Transaction.t() | nil
   def set_sample_data(%Transaction{} = transaction, values) do
     values
     |> Enum.each(fn {key, value} ->
@@ -236,7 +245,7 @@ defmodule Appsignal.Transaction do
     transaction
   end
 
-  @spec set_sample_data(String.t(), any) :: Transaction.t()
+  @spec set_sample_data(String.t(), any) :: Transaction.t() | nil
   def set_sample_data(key, payload) do
     set_sample_data(lookup(), key, payload)
   end
@@ -250,9 +259,7 @@ defmodule Appsignal.Transaction do
   - `key`: Key of this piece of metadata (params, session_data)
   - `payload`: Metadata (e.g. `%{user_id: 1}`); will be JSON encoded
   """
-  @spec set_sample_data(Transaction.t() | nil, String.t(), any) :: Transaction.t()
-  def set_sample_data(nil, _key, _payload), do: nil
-
+  @spec set_sample_data(Transaction.t() | any(), String.t(), any()) :: Transaction.t() | nil
   def set_sample_data(%Transaction{} = transaction, "params", payload) do
     if config()[:send_params] do
       do_set_sample_data(transaction, "params", payload)
@@ -265,6 +272,9 @@ defmodule Appsignal.Transaction do
     do_set_sample_data(transaction, key, payload)
   end
 
+  def set_sample_data(_transaction, _key, _payload), do: nil
+
+  @doc false
   def do_set_sample_data(%Transaction{} = transaction, key, payload) do
     payload_data = Appsignal.Utils.DataEncoder.encode(payload)
     :ok = Nif.set_sample_data(transaction.resource, key, payload_data)
@@ -274,7 +284,7 @@ defmodule Appsignal.Transaction do
   @doc """
   Set action of the current transaction. See `set_action/1`.
   """
-  @spec set_action(String.t()) :: Transaction.t()
+  @spec set_action(String.t()) :: Transaction.t() | nil
   def set_action(action) do
     set_action(lookup(), action)
   end
@@ -287,18 +297,18 @@ defmodule Appsignal.Transaction do
   - `transaction`: The pointer to the transaction this event occurred in
   - `action`: This transactions action (`"HomepageController.show"`)
   """
-  @spec set_action(Transaction.t() | nil, String.t()) :: Transaction.t()
-  def set_action(nil, _action), do: nil
-
+  @spec set_action(Transaction.t() | any(), String.t()) :: Transaction.t() | nil
   def set_action(%Transaction{} = transaction, action) do
     :ok = Nif.set_action(transaction.resource, action)
     transaction
   end
 
+  def set_action(_transaction, _action), do: nil
+
   @doc """
   Set namespace of the current transaction. See `set_namespace/1`.
   """
-  @spec set_namespace(atom()) :: Transaction.t()
+  @spec set_namespace(atom()) :: Transaction.t() | nil
   def set_namespace(namespace) do
     set_namespace(lookup(), namespace)
   end
@@ -311,9 +321,7 @@ defmodule Appsignal.Transaction do
   - `transaction`: The pointer to the transaction this event occurred in
   - `namespace`: This transaction's action (`:`)
   """
-  @spec set_namespace(Transaction.t() | nil, String.t() | atom()) :: Transaction.t()
-  def set_namespace(nil, _namespace), do: nil
-
+  @spec set_namespace(Transaction.t() | any(), String.t() | atom()) :: Transaction.t() | nil
   def set_namespace(%Transaction{} = transaction, namespace) when is_atom(namespace) do
     set_namespace(transaction, Atom.to_string(namespace))
   end
@@ -323,10 +331,12 @@ defmodule Appsignal.Transaction do
     transaction
   end
 
+  def set_namespace(_transaction, _namespace), do: nil
+
   @doc """
   Set queue start time of the current transaction. See `set_queue_start/2`.
   """
-  @spec set_queue_start(integer) :: Transaction.t()
+  @spec set_queue_start(integer) :: Transaction.t() | nil
   def set_queue_start(start \\ -1) do
     set_queue_start(lookup(), start)
   end
@@ -339,26 +349,26 @@ defmodule Appsignal.Transaction do
   - `transaction`: The pointer to the transaction this event occurred in
   - `queue_start`: Transaction queue start time in ms if known
   """
-  @spec set_queue_start(Transaction.t() | nil, integer) :: Transaction.t()
-  def set_queue_start(nil, _start), do: nil
-
+  @spec set_queue_start(Transaction.t() | any(), integer) :: Transaction.t() | nil
   def set_queue_start(%Transaction{} = transaction, start) do
     :ok = Nif.set_queue_start(transaction.resource, start)
     transaction
   end
 
+  def set_queue_start(_transaction, _start), do: nil
+
   @doc """
   Set metadata for the current transaction from an enumerable.
   The enumerable needs to be a keyword list or a map.
   """
-  @spec set_meta_data(Enum.t()) :: Transaction.t()
+  @spec set_meta_data(Enum.t()) :: Transaction.t() | nil
   def set_meta_data(values) do
     transaction = lookup()
     set_meta_data(transaction, values)
     transaction
   end
 
-  @spec set_meta_data(Transaction.t(), Enum.t()) :: Transaction.t()
+  @spec set_meta_data(Transaction.t(), Enum.t()) :: Transaction.t() | nil
   def set_meta_data(%Transaction{} = transaction, values) do
     values
     |> Enum.each(fn {key, value} ->
@@ -371,7 +381,7 @@ defmodule Appsignal.Transaction do
   @doc """
   Set metadata for the current transaction. See `set_meta_data/3`.
   """
-  @spec set_meta_data(String.t(), String.t()) :: Transaction.t()
+  @spec set_meta_data(String.t(), String.t()) :: Transaction.t() | nil
   def set_meta_data(key, value) do
     set_meta_data(lookup(), key, value)
   end
@@ -385,8 +395,7 @@ defmodule Appsignal.Transaction do
   - `key`: Key of this piece of metadata (`"email"`)
   - `value`: Value of this piece of metadata (`"thijs@appsignal.com"`)
   """
-  @spec set_meta_data(Transaction.t() | nil, String.t(), String.t()) :: Transaction.t()
-  def set_meta_data(nil, _key, _value), do: nil
+  @spec set_meta_data(Transaction.t() | any(), String.t(), String.t()) :: Transaction.t() | nil
 
   def set_meta_data(%Transaction{} = transaction, key, value)
       when is_binary(key) and is_binary(value) do
@@ -398,10 +407,12 @@ defmodule Appsignal.Transaction do
     set_meta_data(transaction, to_s(key), to_s(value))
   end
 
+  def set_meta_data(_transaction, _key, _value), do: nil
+
   @doc """
   Finish the current transaction. See `finish/1`.
   """
-  @spec finish() :: :sample | :no_sample
+  @spec finish() :: :sample | :no_sample | nil
   def finish do
     finish(lookup())
   end
@@ -416,17 +427,17 @@ defmodule Appsignal.Transaction do
   Returns `:sample` whether sample data for this transaction should be
   collected.
   """
-  @spec finish(Transaction.t() | nil) :: :sample | :no_sample
-  def finish(nil), do: nil
-
+  @spec finish(Transaction.t() | any()) :: :sample | :no_sample | nil
   def finish(%Transaction{} = transaction) do
     Nif.finish(transaction.resource)
   end
 
+  def finish(_transaction), do: nil
+
   @doc """
   Complete the current transaction. See `complete/1`.
   """
-  @spec complete() :: :ok
+  @spec complete() :: :ok | nil
   def complete do
     complete(lookup())
   end
@@ -438,13 +449,13 @@ defmodule Appsignal.Transaction do
 
   - `transaction`: The pointer to the transaction this event occurred in
   """
-  @spec complete(Transaction.t() | nil) :: :ok
-  def complete(nil), do: nil
-
+  @spec complete(Transaction.t() | any()) :: :ok | nil
   def complete(%Transaction{} = transaction) do
     TransactionRegistry.remove_transaction(transaction)
-    :ok = Nif.complete(transaction.resource)
+    Nif.complete(transaction.resource)
   end
+
+  def complete(_transaction), do: nil
 
   @doc """
   Generate a random id as a string to use as transaction identifier.
@@ -471,7 +482,7 @@ defmodule Appsignal.Transaction do
     @doc """
     Set the request metadata, given a Plug.Conn.t.
     """
-    @spec set_request_metadata(Transaction.t() | nil, Plug.Conn.t()) :: Transaction.t()
+    @spec set_request_metadata(Transaction.t() | any(), Plug.Conn.t()) :: Transaction.t() | nil
     def set_request_metadata(%Transaction{} = transaction, %Plug.Conn{} = conn) do
       # preprocess conn
       conn =
@@ -499,7 +510,8 @@ defmodule Appsignal.Transaction do
     end
   end
 
-  def set_request_metadata(transaction, %{}), do: transaction
+  def set_request_metadata(%Transaction{} = transaction, %{}), do: transaction
+  def set_request_metadata(_transaction, _conn), do: nil
 
   if Appsignal.phoenix?() do
     @doc """

--- a/scripts/run_formatter
+++ b/scripts/run_formatter
@@ -4,6 +4,6 @@ version() {
   echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
 }
 
-if [ $(version $TRAVIS_ELIXIR_VERSION) -ge $(version "1.6.6") ]; then
+if [ $(version $TRAVIS_ELIXIR_VERSION) -ge $(version "1.8.0") ]; then
   mix format --dry-run --check-formatted
 fi

--- a/test/appsignal/instrumentation/helpers_test.exs
+++ b/test/appsignal/instrumentation/helpers_test.exs
@@ -26,8 +26,16 @@ defmodule AppsignalHelpersTest do
              FakeTransaction.finished_events(fake_transaction)
   end
 
-  test "instrument with nil" do
+  test "instrument with nil", %{fake_transaction: fake_transaction} do
     call_instrument(nil)
+
+    assert FakeTransaction.finished_events(fake_transaction) == []
+  end
+
+  test "instrument on an ignored process", %{fake_transaction: fake_transaction} do
+    call_instrument(:ignored)
+
+    assert FakeTransaction.finished_events(fake_transaction) == []
   end
 
   defp call_instrument(arg) do

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -385,6 +385,237 @@ defmodule AppsignalTransactionTest do
     end
   end
 
+  describe "start_event/1" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("start_event/1", :http_request)
+      assert Transaction.start_event(transaction) == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.start_event(:ignored) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.start_event(nil) == nil
+    end
+  end
+
+  describe "finish_event/5" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("start_event/1", :http_request)
+
+      assert Transaction.finish_event(
+               transaction,
+               "sql.query",
+               "Model load",
+               "SELECT * FROM table;",
+               1
+             ) == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.finish_event(
+               :ignored,
+               "sql.query",
+               "Model load",
+               "SELECT * FROM table;",
+               1
+             ) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.finish_event(
+               nil,
+               "sql.query",
+               "Model load",
+               "SELECT * FROM table;",
+               1
+             ) == nil
+    end
+  end
+
+  describe "record_event/6" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("start_event/1", :http_request)
+
+      assert Transaction.record_event(
+               transaction,
+               "sql.query",
+               "Model load",
+               "SELECT * FROM table;",
+               1000 * 1000 * 3,
+               1
+             ) == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.record_event(
+               :ignored,
+               "sql.query",
+               "Model load",
+               "SELECT * FROM table;",
+               1000 * 1000 * 3,
+               1
+             ) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.record_event(
+               nil,
+               "sql.query",
+               "Model load",
+               "SELECT * FROM table;",
+               1000 * 1000 * 3,
+               1
+             ) == nil
+    end
+  end
+
+  describe "set_error/4" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("start_event/1", :http_request)
+
+      assert Transaction.set_error(transaction, "error", "error message", stacktrace()) ==
+               transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.set_error(:ignored, "error", "error message", stacktrace()) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.set_error(nil, "error", "error message", stacktrace()) == nil
+    end
+  end
+
+  describe "set_sample_data/3" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("set_sample_data/3", :http_request)
+
+      assert Transaction.set_sample_data(transaction, "key", %{user_id: 1}) == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.set_sample_data(:ignored, "key", %{user_id: 1}) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.set_sample_data(nil, "key", %{user_id: 1}) == nil
+    end
+  end
+
+  describe "set_action/2" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("set_action/2", :http_request)
+
+      assert Transaction.set_action(transaction, "GET:/") == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.set_action(:ignored, "GET:/") == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.set_action(nil, "GET:/") == nil
+    end
+  end
+
+  describe "set_namespace/2" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("set_namespace/2", :http_request)
+
+      assert Transaction.set_namespace(transaction, :background) == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.set_namespace(:ignored, :background) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.set_namespace(nil, :background) == nil
+    end
+  end
+
+  describe "set_queue_start/2" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("set_queue_start/2", :http_request)
+
+      assert Transaction.set_queue_start(transaction, 1000) == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.set_queue_start(:ignored, 1000) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.set_queue_start(nil, 1000) == nil
+    end
+  end
+
+  describe "set_meta_data/3" do
+    test "returns the current transaction" do
+      transaction = Transaction.start("set_meta_data/3", :http_request)
+
+      assert Transaction.set_meta_data(transaction, "email", "info@info.com") == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.set_meta_data(:ignored, "email", "info@info.com") == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.set_meta_data(nil, "email", "info@info.com") == nil
+    end
+  end
+
+  describe "finish/1" do
+    test "returns either :sample or :no_sample" do
+      transaction = Transaction.start("finish/1", :http_request)
+
+      assert Transaction.finish(transaction) in ~w(sample no_sample)a
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.finish(:ignored) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.finish(nil) == nil
+    end
+  end
+
+  describe "complete/1" do
+    test "returns :ok" do
+      transaction = Transaction.start("complete/1", :http_request)
+
+      assert Transaction.complete(transaction) == :ok
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.complete(:ignored) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.complete(nil) == nil
+    end
+  end
+
+  describe "set_request_metadata/2" do
+    test "returns :ok" do
+      transaction = Transaction.start("set_request_metadata/2", :http_request)
+
+      assert Transaction.set_request_metadata(transaction, %Plug.Conn{}) == transaction
+    end
+
+    test "returns nil for an ignored process" do
+      assert Transaction.set_request_metadata(:ignored, %Plug.Conn{}) == nil
+    end
+
+    test "returns nil for a missing process" do
+      assert Transaction.set_request_metadata(nil, %Plug.Conn{}) == nil
+    end
+  end
+
   def stacktrace do
     try do
       raise "error message"


### PR DESCRIPTION
Since #480, `TransactionRegistry.lookup/1` can return `:ignored`. This patch makes sure every function that handles Transactions have a wildcard to ignore those instead of explicitly matching on nil.