### PR TITLE
ldd version error handling

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -417,14 +417,14 @@ defmodule Mix.Appsignal.Helper do
       {:error, exception}
   end
 
-  defp extract_ldd_version(nil), do: nil
-
-  defp extract_ldd_version(ldd_output) do
+  defp extract_ldd_version(ldd_output) when is_binary(ldd_output) do
     case Regex.run(~r/\d+\.\d+/, ldd_output) do
       [version | _tail] -> version
       _ -> nil
     end
   end
+
+  defp extract_ldd_version(_), do: nil
 
   defp initial_report do
     {_, os} = :os.type()

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -385,34 +385,45 @@ defmodule Mix.Appsignal.Helper do
             "linux-musl"
 
           false ->
-            ldd_version = extract_ldd_version(output)
+            case extract_ldd_version(output) do
+              nil ->
+                "linux"
 
-            case Version.compare("#{ldd_version}.0", "2.15.0") do
-              :lt -> "linux-musl"
-              _ -> "linux"
+              ldd_version ->
+                case Version.compare("#{ldd_version}.0", "2.15.0") do
+                  :lt -> "linux-musl"
+                  _ -> "linux"
+                end
             end
         end
 
       _ ->
         "linux"
     end
-  rescue
-    _ -> "linux"
   end
 
   # Fetches the libc version number from the `ldd` command
   # If `ldd` is not found it returns `nil`
   defp ldd_version_output do
-    {output, 0} = @system.cmd("ldd", ["--version"], stderr_to_stdout: true)
-    {:ok, output}
+    case @system.cmd("ldd", ["--version"], stderr_to_stdout: true) do
+      {output, 0} ->
+        {:ok, output}
+
+      {output, _} ->
+        {:error, output}
+    end
   rescue
-    exception -> {:error, exception}
+    exception ->
+      {:error, exception}
   end
 
   defp extract_ldd_version(nil), do: nil
 
   defp extract_ldd_version(ldd_output) do
-    List.first(Regex.run(~r/\d+\.\d+/, ldd_output))
+    case Regex.run(~r/\d+\.\d+/, ldd_output) do
+      [version | _tail] -> version
+      _ -> nil
+    end
   end
 
   defp initial_report do

--- a/test/mix/helpers_test.exs
+++ b/test/mix/helpers_test.exs
@@ -58,6 +58,16 @@ defmodule Mix.Appsignal.HelperTest do
       assert Mix.Appsignal.Helper.agent_platform() == "linux-musl"
     end
 
+    test "agent_platform returns libc build when ldd doesn't return a version number", %{
+      fake_system: fake_system
+    } do
+      FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
+        {"", 0}
+      end)
+
+      assert Mix.Appsignal.Helper.agent_platform() == "linux"
+    end
+
     test "defaults to the libc build when ldd fails", %{fake_system: fake_system} do
       FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
         {"ldd: command not found", 1}

--- a/test/mix/helpers_test.exs
+++ b/test/mix/helpers_test.exs
@@ -26,7 +26,7 @@ defmodule Mix.Appsignal.HelperTest do
 
     test "returns the musl build when on a musl system", %{fake_system: fake_system} do
       FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
-        {"musl libc (x86_64)\nVersion 1.1.16", 1}
+        {"musl libc (x86_64)\nVersion 1.1.16", 0}
       end)
 
       assert Mix.Appsignal.Helper.agent_platform() == "linux-musl"
@@ -34,7 +34,7 @@ defmodule Mix.Appsignal.HelperTest do
 
     test "returns the libc build when on a libc linux system", %{fake_system: fake_system} do
       FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
-        {"ldd (Debian GLIBC 2.15-18+deb8u7) 2.15", 1}
+        {"ldd (Debian GLIBC 2.15-18+deb8u7) 2.15", 0}
       end)
 
       assert Mix.Appsignal.Helper.agent_platform() == "linux"
@@ -42,7 +42,7 @@ defmodule Mix.Appsignal.HelperTest do
 
     test "returns the musl build when on an old libc linux system", %{fake_system: fake_system} do
       FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
-        {"ldd (Debian GLIBC 2.14-18+deb8u7) 2.14", 1}
+        {"ldd (Debian GLIBC 2.14-18+deb8u7) 2.14", 0}
       end)
 
       assert Mix.Appsignal.Helper.agent_platform() == "linux-musl"
@@ -52,10 +52,18 @@ defmodule Mix.Appsignal.HelperTest do
       fake_system: fake_system
     } do
       FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
-        {"ldd (Debian GLIBC 2.5-18+deb8u7) 2.5", 1}
+        {"ldd (Debian GLIBC 2.5-18+deb8u7) 2.5", 0}
       end)
 
       assert Mix.Appsignal.Helper.agent_platform() == "linux-musl"
+    end
+
+    test "defaults to the libc build when ldd fails", %{fake_system: fake_system} do
+      FakeSystem.update(fake_system, :cmd, fn _, _, _ ->
+        {"ldd: command not found", 1}
+      end)
+
+      assert Mix.Appsignal.Helper.agent_platform() == "linux"
     end
 
     test "returns the darwin build when on a darwin system", %{


### PR DESCRIPTION
Inspired by #483. 

This patch makes sure errors (non-zero status codes) from the ldd command are properly handled, as well as situations where the command doesn't include a parsable version number.