### PR TITLE
Explicitly set ciphers in hackney https requests

### DIFF
--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -14,7 +14,13 @@ defmodule Appsignal.Transmitter do
     options =
       case File.stat(ca_file_path) do
         {:ok, %{access: access}} when access in [:read, :read_write] ->
-          {:ok, [ssl_options: [cacertfile: ca_file_path]]}
+          {:ok,
+           [
+             ssl_options: [
+               cacertfile: ca_file_path,
+               ciphers: :ssl.cipher_suites(:default, :"tlsv1.2")
+             ]
+           ]}
 
         {:ok, %{access: access}} ->
           {:error, "File access is #{inspect(access)}"}

--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -14,13 +14,7 @@ defmodule Appsignal.Transmitter do
     options =
       case File.stat(ca_file_path) do
         {:ok, %{access: access}} when access in [:read, :read_write] ->
-          {:ok,
-           [
-             ssl_options: [
-               cacertfile: ca_file_path,
-               ciphers: :ssl.cipher_suites(:default, :"tlsv1.2")
-             ]
-           ]}
+          {:ok, [ssl_options: [cacertfile: ca_file_path, ciphers: ciphers()]]}
 
         {:ok, %{access: access}} ->
           {:error, "File access is #{inspect(access)}"}
@@ -48,5 +42,11 @@ defmodule Appsignal.Transmitter do
 
   defp packaged_ca_file_path do
     Path.join(:code.priv_dir(:appsignal), "cacert.pem")
+  end
+
+  if System.otp_release() >= "20.3" do
+    defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.2")
+  else
+    defp ciphers, do: :ssl.cipher_suites()
   end
 end

--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -15,7 +15,7 @@ defmodule Appsignal.TransmitterTest do
   test "uses the default CA certificate" do
     path = Config.ca_file_path()
 
-    assert [_method, _url, _headers, _body, [ssl_options: [cacertfile: ^path]]] =
+    assert [_method, _url, _headers, _body, [ssl_options: [cacertfile: ^path, ciphers: _]]] =
              Transmitter.request(:get, "https://example.com")
   end
 
@@ -23,7 +23,7 @@ defmodule Appsignal.TransmitterTest do
     path = "priv/cacert.pem"
 
     with_config(%{ca_file_path: path}, fn ->
-      assert [_method, _url, _headers, _body, [ssl_options: [cacertfile: ^path]]] =
+      assert [_method, _url, _headers, _body, [ssl_options: [cacertfile: ^path, ciphers: _]]] =
                Transmitter.request(:get, "https://example.com")
     end)
   end


### PR DESCRIPTION
OTP 22 requires the ciphers to be explicitly set for hackney's HTTPs requests to succeed.