### PR TITLE
Remove log statements from TransactionRegisty

### DIFF
--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -40,7 +40,6 @@ defmodule Appsignal.TransactionRegistry do
       true = :ets.insert(@table, {pid, transaction, monitor_reference})
       :ok
     else
-      Logger.debug("AppSignal was not started, skipping transaction registration.")
       nil
     end
   end
@@ -79,7 +78,6 @@ defmodule Appsignal.TransactionRegistry do
         transaction
 
       false ->
-        Logger.debug("AppSignal was not started, skipping transaction lookup.")
         nil
 
       [] ->


### PR DESCRIPTION
The integration will log on startup, so these are not needed and too
verbose now the integration can be disabled completely.