### PR TITLE
Use the bundled certificate and ciphers when downloading agent

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -187,8 +187,7 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp download_options do
-    ca_file_path = Path.join(:code.priv_dir(:appsignal), "cacert.pem")
-    options = [ssl_options: [cacertfile: ca_file_path, ciphers: ciphers()]]
+    options = [ssl_options: [cacertfile: priv_path("cacert.pem"), ciphers: ciphers()]]
 
     case check_proxy() do
       nil ->

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -167,16 +167,7 @@ defmodule Mix.Appsignal.Helper do
   defp do_download_file!(url, filename, retries \\ 0)
 
   defp do_download_file!(url, filename, 0) do
-    opts =
-      case check_proxy() do
-        nil ->
-          []
-        {var, url} ->
-          Mix.shell().info("- using proxy from #{var} (#{url})")
-          [{:proxy, url}]
-      end
-
-    case :hackney.request(:get, url, [], "", opts) do
+    case :hackney.request(:get, url, [], "", download_options()) do
       {:ok, 200, _, reference} ->
         case :hackney.body(reference) do
           {:ok, body} -> File.write(filename, body)
@@ -192,6 +183,20 @@ defmodule Mix.Appsignal.Helper do
     case do_download_file!(url, filename) do
       :ok -> :ok
       _ -> do_download_file!(url, filename, retries - 1)
+    end
+  end
+
+  defp download_options do
+    ca_file_path = Path.join(:code.priv_dir(:appsignal), "cacert.pem")
+    options = [ssl_options: [cacertfile: ca_file_path, ciphers: ciphers()]]
+
+    case check_proxy() do
+      nil ->
+        options
+
+      {var, url} ->
+        Mix.shell().info("- using proxy from #{var} (#{url})")
+        options ++ [proxy: url]
     end
   end
 
@@ -566,6 +571,12 @@ defmodule Mix.Appsignal.Helper do
 
   defp make do
     if System.find_executable("gmake"), do: "gmake", else: "make"
+  end
+
+  if System.otp_release() >= "20.3" do
+    defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.2")
+  else
+    defp ciphers, do: :ssl.cipher_suites()
   end
 
   def root? do


### PR DESCRIPTION
Like #489, but for downloading the agent. The code is duplicated from
Appsignal.Transmitter, as that module is not yet compiled at compile
time.