### PR TITLE
Fix musl detection on installation

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -410,11 +410,8 @@ defmodule Mix.Appsignal.Helper do
   # If `ldd` is not found it returns `nil`
   defp ldd_version_output do
     case @system.cmd("ldd", ["--version"], stderr_to_stdout: true) do
-      {output, 0} ->
-        {:ok, output}
-
       {output, _} ->
-        {:error, output}
+        {:ok, output}
     end
   rescue
     exception ->


### PR DESCRIPTION
The command `ldd --version` always returns exit code `1`.
This is because `--version` is not a supported option, it always prints
the version number when it runs into an issue when starting.
It's mostly there so we know what it's doing.

Because it always returns exit code `1`, don't listen to the exit code.
Only check if the command does not exist. That raises an error which we
catch instead and only then return an error tuple.

This behavior broke in #487

Fixes https://github.com/appsignal/support/issues/19