### PR TITLE
Disable integration for non-map configurations

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -90,9 +90,13 @@ defmodule Appsignal.Config do
   """
   @spec active?() :: boolean
   def active? do
-    config = Application.fetch_env!(:appsignal, :config)
-    config.valid && config.active
+    :appsignal
+    |> Application.fetch_env!(:config)
+    |> do_active?
   end
+
+  defp do_active?(%{valid: true, active: true}), do: true
+  defp do_active?(_), do: false
 
   def request_headers do
     Application.fetch_env!(:appsignal, :config)[:request_headers]

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -106,6 +106,13 @@ defmodule Appsignal.ConfigTest do
                &Config.active?/0
              )
     end
+
+    test "when the configuration is not a map" do
+      refute with_frozen_environment(fn ->
+               Application.put_env(:appsignal, :config, [])
+               Config.active?()
+             end)
+    end
   end
 
   describe "request_headers" do


### PR DESCRIPTION
Ecto 2.x's logger, which we use to instrument queries on Ecto < 3, logs events when running migrations. Since https://github.com/appsignal/appsignal-elixir/pull/480/files on 1.10.5, we explicitly check if the configuration is active when creating a Transaction. For unconfigured applications, or applications that start without loading the AppSignal dependency (like migrations), the check fails, as the configuration isn't yet converted to a map.

To fix this, this patch adds an explicit pattern to match on (`%{valid: true, active: true}`) in `Config.active?/2`. Anything that doesn't match this pattern returns `false`, which disables the integration.