### PR TITLE
Use Phoenix >= 1.2.0 and < 1.4.0 on Elixir 1.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -79,14 +79,16 @@ defmodule Appsignal.Mixfile do
   defp test?(_), do: false
 
   defp deps do
+    system_version = System.version()
+
     poison_version =
-      case Version.compare(System.version(), "1.6.0") do
+      case Version.compare(system_version, "1.6.0") do
         :lt -> ">= 1.3.0 and < 4.0.0"
         _ -> ">= 1.3.0"
       end
 
     phoenix_version =
-      case Version.compare(System.version(), "1.4.0") do
+      case Version.compare(system_version, "1.4.0") do
         :lt -> ">= 1.2.0 and < 1.4.0"
         _ -> ">= 1.2.0"
       end

--- a/mix.exs
+++ b/mix.exs
@@ -85,12 +85,18 @@ defmodule Appsignal.Mixfile do
         _ -> ">= 1.3.0"
       end
 
+    phoenix_version =
+      case Version.compare(System.version(), "1.4.0") do
+        :lt -> ">= 1.2.0 and < 1.4.0"
+        _ -> ">= 1.2.0"
+      end
+
     [
       {:hackney, "~> 1.6"},
       {:poison, poison_version},
       {:decorator, "~> 1.2.3"},
       {:plug, ">= 1.1.0", optional: true},
-      {:phoenix, ">= 1.2.0", optional: true, only: [:prod, :test_phoenix, :dev]},
+      {:phoenix, phoenix_version, optional: true, only: [:prod, :test_phoenix, :dev]},
       {:bypass, "~> 0.6.0", only: [:test, :test_phoenix, :test_no_nif]},
       {:plug_cowboy, "~> 1.0", only: [:test, :test_phoenix, :test_no_nif]},
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},


### PR DESCRIPTION
Support for Elixir 1.3 was
[dropped](https://github.com/phoenixframework/phoenix/blob/v1.4/.travis.yml)
in Phoenix 1.4. As Phoenix 1.4.8 now expects :telemetry_handler_table
to be running, we've reached incompatibility between Elixir 1.3 and
Phoenix 1.4, so we're dropping support for this specific combination as
well.