### PR TITLE
Support parameter filtering with {:keep, params}

### DIFF
--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -35,7 +35,7 @@ if Appsignal.phoenix?() do
           @decorate channel_action
           def handle_in("ping", payload, socket) do
             Appsignal.Transaction.set_sample_data(
-              "params", Appsignal.Utils.MapFilter.filter_values(payload, Appsignal.Utils.MapFilter.get_filter_parameters())
+              "params", Appsignal.Utils.MapFilter.filter_parameters(payload)
             )
 
             # your code here..
@@ -102,10 +102,7 @@ if Appsignal.phoenix?() do
         transaction
         |> @transaction.set_sample_data(
           "params",
-          Appsignal.Utils.MapFilter.filter_values(
-            params,
-            Appsignal.Utils.MapFilter.get_filter_parameters()
-          )
+          Appsignal.Utils.MapFilter.filter_parameters(params)
         )
         |> @transaction.set_sample_data(
           "environment",
@@ -131,10 +128,7 @@ if Appsignal.phoenix?() do
       transaction
       |> @transaction.set_sample_data(
         "params",
-        socket.assigns
-        |> Appsignal.Utils.MapFilter.filter_values(
-          Appsignal.Utils.MapFilter.get_filter_parameters()
-        )
+        Appsignal.Utils.MapFilter.filter_parameters(socket.assigns)
       )
       |> @transaction.set_sample_data("environment", request_environment(socket))
     end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -116,11 +116,7 @@ if Appsignal.plug?() do
           } = conn
         ) do
       %{
-        "params" =>
-          Appsignal.Utils.MapFilter.filter_values(
-            params,
-            Appsignal.Utils.MapFilter.get_filter_parameters()
-          ),
+        "params" => Appsignal.Utils.MapFilter.filter_parameters(params),
         "environment" =>
           %{
             "host" => host,

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -499,10 +499,7 @@ defmodule Appsignal.Transaction do
         Transaction.set_sample_data(
           transaction,
           "session_data",
-          Appsignal.Utils.MapFilter.filter_values(
-            conn.private[:plug_session],
-            Appsignal.Utils.MapFilter.get_filter_session_data()
-          )
+          Appsignal.Utils.MapFilter.filter_session_data(conn.private[:plug_session])
         )
       else
         transaction

--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -75,19 +75,21 @@ defmodule Appsignal.Utils.MapFilter do
 
   defp merge_filters({:keep, appsignal}, {:keep, phoenix}), do: {:keep, appsignal ++ phoenix}
 
-  defp merge_filters(appsignal, {:keep, phoenix}) when is_list(appsignal) do
+  defp merge_filters(appsignal, {:keep, phoenix}) when is_list(appsignal) and is_list(phoenix) do
     {:keep, phoenix -- appsignal}
   end
 
-  defp merge_filters({:keep, appsignal}, phoenix) when is_list(phoenix),
-    do: {:keep, appsignal -- phoenix}
+  defp merge_filters({:keep, appsignal}, phoenix) when is_list(appsignal) and is_list(phoenix) do
+    {:keep, appsignal -- phoenix}
+  end
 
   defp merge_filters(appsignal, phoenix) do
     Logger.error("""
     An error occured while merging parameter filters.
 
-    AppSignal expects all parameter_filter values to be either a list of strings
-    (`["email"]`), or a :keep-tuple (`{:keep, ["email"]}`).
+    AppSignal expects all parameter_filter values to be either a list of
+    strings (`["email"]`), or a :keep-tuple with a list of strings as its
+    second element (`{:keep, ["email"]}`).
 
     From the AppSignal configuration:
 

--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -1,4 +1,6 @@
 defmodule Appsignal.Utils.MapFilter do
+  require Logger
+
   @moduledoc """
   Helper functions for filtering parameters to prevent sensitive data
   to be submitted to AppSignal.
@@ -80,5 +82,25 @@ defmodule Appsignal.Utils.MapFilter do
   defp merge_filters({:keep, appsignal}, phoenix) when is_list(phoenix),
     do: {:keep, appsignal -- phoenix}
 
-  defp merge_filters(_, _), do: []
+  defp merge_filters(appsignal, phoenix) do
+    Logger.error("""
+    An error occured while merging parameter filters.
+
+    AppSignal expects all parameter_filter values to be either a list of strings
+    (`["email"]`), or a :keep-tuple (`{:keep, ["email"]}`).
+
+    From the AppSignal configuration:
+
+      #{inspect(appsignal)}
+
+    From the Phoenix configuration:
+
+      #{inspect(phoenix)}
+
+    To ensure no sensitive parameters are sent, all parameters are filtered out
+    for this transaction.
+    """)
+
+    {:keep, []}
+  end
 end

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -99,8 +99,25 @@ defmodule Appsignal.Transaction.FilterTest do
       end)
     end
 
-    test "filters out all parameters in case of a configuration error" do
+    test "filters out all parameters when filter_parameters is not a list" do
       with_config(%{filter_parameters: "foo"}, fn ->
+        Config.initialize()
+
+        values = %{"foo" => "bar", "secret3" => "super_secret", "secret4" => "more_secret"}
+
+        assert ExUnit.CaptureLog.capture_log(fn ->
+                 assert MapFilter.filter_parameters(values) ==
+                          %{
+                            "foo" => "[FILTERED]",
+                            "secret3" => "[FILTERED]",
+                            "secret4" => "[FILTERED]"
+                          }
+               end) =~ "An error occured while merging parameter filters."
+      end)
+    end
+
+    test "filters out all parameters when filter_parameters is a :keep-tuple with aa calue that's not a list" do
+      with_config(%{filter_parameters: {:keep, "foo"}}, fn ->
         Config.initialize()
 
         values = %{"foo" => "bar", "secret3" => "super_secret", "secret4" => "more_secret"}

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -5,18 +5,29 @@ defmodule Appsignal.Transaction.FilterTest do
 
   import AppsignalTest.Utils
 
-  describe "parameter filtering" do
+  defmodule SomeStruct do
+    defstruct foo: 1
+  end
+
+  describe "filter_parameters/1" do
     test "uses parameter filters from the appsignal config" do
       with_config(%{filter_parameters: ["password"]}, fn ->
         Config.initialize()
-        assert Enum.member?(MapFilter.get_filter_parameters(), "password")
+        values = %{"foo" => "bar", "password" => "should_not_show"}
+
+        assert MapFilter.filter_parameters(values) ==
+                 %{"foo" => "bar", "password" => "[FILTERED]"}
       end)
     end
 
     test "uses parameter filters from the phoenix config" do
       Application.put_env(:phoenix, :filter_parameters, ~w(secret1))
       Config.initialize()
-      assert Enum.member?(MapFilter.get_filter_parameters(), "secret1")
+      values = %{"foo" => "bar", "secret1" => "super_secret"}
+
+      assert MapFilter.filter_parameters(values) ==
+               %{"foo" => "bar", "secret1" => "[FILTERED]"}
+
       Application.delete_env(:phoenix, :filter_parameters)
     end
 
@@ -25,9 +36,53 @@ defmodule Appsignal.Transaction.FilterTest do
 
       with_config(%{filter_parameters: ["secret2"]}, fn ->
         Config.initialize()
-        filter_parameters = MapFilter.get_filter_parameters()
-        assert Enum.member?(filter_parameters, "secret1")
-        assert Enum.member?(filter_parameters, "secret2")
+
+        values = %{"foo" => "bar", "secret1" => "super_secret", "secret2" => "more_secret"}
+
+        assert MapFilter.filter_parameters(values) ==
+                 %{"foo" => "bar", "secret1" => "[FILTERED]", "secret2" => "[FILTERED]"}
+      end)
+
+      Application.put_env(:phoenix, :filter_parameters, {:keep, ~w(secret1 secret2 foo)})
+
+      with_config(%{filter_parameters: ["secret2"]}, fn ->
+        Config.initialize()
+
+        values = %{
+          "foo" => "bar",
+          "secret1" => "not_so_secret",
+          "secret2" => "more_secret",
+          "secret3" => "new_secret"
+        }
+
+        assert MapFilter.filter_parameters(values) ==
+                 %{
+                   "foo" => "bar",
+                   "secret1" => "not_so_secret",
+                   "secret2" => "[FILTERED]",
+                   "secret3" => "[FILTERED]"
+                 }
+      end)
+
+      Application.put_env(:phoenix, :filter_parameters, ~w(secret1))
+
+      with_config(%{filter_parameters: {:keep, ~w(foo secret1)}}, fn ->
+        Config.initialize()
+
+        values = %{
+          "foo" => "bar",
+          "secret1" => "not_so_secret",
+          "secret2" => "more_secret",
+          "secret3" => "new_secret"
+        }
+
+        assert MapFilter.filter_parameters(values) ==
+                 %{
+                   "foo" => "bar",
+                   "secret1" => "[FILTERED]",
+                   "secret2" => "[FILTERED]",
+                   "secret3" => "[FILTERED]"
+                 }
       end)
 
       Application.delete_env(:phoenix, :filter_parameters)
@@ -36,54 +91,103 @@ defmodule Appsignal.Transaction.FilterTest do
     test "uses filter parameters from the OS environment" do
       with_env(%{"APPSIGNAL_FILTER_PARAMETERS" => "secret3,secret4"}, fn ->
         Config.initialize()
-        filter_parameters = MapFilter.get_filter_parameters()
-        assert Enum.member?(filter_parameters, "secret3")
-        assert Enum.member?(filter_parameters, "secret4")
+
+        values = %{"foo" => "bar", "secret3" => "super_secret", "secret4" => "more_secret"}
+
+        assert MapFilter.filter_parameters(values) ==
+                 %{"foo" => "bar", "secret3" => "[FILTERED]", "secret4" => "[FILTERED]"}
       end)
     end
+  end
 
-    test "filter_values" do
-      assert MapFilter.filter_values(%{"foo" => "bar", "password" => "should_not_show"}, [
-               "password"
-             ]) == %{"foo" => "bar", "password" => "[FILTERED]"}
+  describe "filter_session_data/1" do
+    test "uses session data filters from the appsignal config" do
+      with_config(%{filter_session_data: ["secret"]}, fn ->
+        Config.initialize()
+        values = %{"foo" => "bar", "secret" => "should_not_show"}
+
+        assert MapFilter.filter_session_data(values) ==
+                 %{"foo" => "bar", "secret" => "[FILTERED]"}
+      end)
+    end
+  end
+
+  describe "filter_values/2 with discard strategy" do
+    test "in top level map" do
+      values = %{"foo" => "bar", "password" => "should_not_show"}
+
+      assert MapFilter.filter_values(values, ["password"]) ==
+               %{"foo" => "bar", "password" => "[FILTERED]"}
     end
 
-    test "filter_values with an atom key" do
+    test "when a map has secret key" do
+      values = %{"foo" => "bar", "map" => %{"password" => "should_not_show"}}
+
+      assert MapFilter.filter_values(values, ["password"]) ==
+               %{"foo" => "bar", "map" => %{"password" => "[FILTERED]"}}
+    end
+
+    test "when a list has a map with secret" do
+      values = %{"foo" => "bar", "list" => [%{"password" => "should_not_show"}]}
+
+      assert MapFilter.filter_values(values, ["password"]) ==
+               %{"foo" => "bar", "list" => [%{"password" => "[FILTERED]"}]}
+    end
+
+    test "does not filter structs" do
+      values = %{"foo" => "bar", "file" => %SomeStruct{}}
+
+      assert MapFilter.filter_values(values, ["password"]) ==
+               %{"foo" => "bar", "file" => %SomeStruct{}}
+
+      values = %{"foo" => "bar", "file" => %{__struct__: "s"}}
+
+      assert MapFilter.filter_values(values, ["password"]) ==
+               %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
+    end
+
+    test "does not fail on atomic keys" do
+      values = %{:foo => "bar", "password" => "should_not_show"}
+
+      assert MapFilter.filter_values(values, ["password"]) ==
+               %{:foo => "bar", "password" => "[FILTERED]"}
+
       assert MapFilter.filter_values(%{"foo" => "bar", password: "should_not_show"}, [
                "password"
              ]) == %{"foo" => "bar", password: "[FILTERED]"}
     end
+  end
 
-    test "filter_values when a map has secret key" do
-      assert MapFilter.filter_values(
-               %{"foo" => "bar", "map" => %{"password" => "should_not_show"}},
-               ["password"]
-             ) == %{"foo" => "bar", "map" => %{"password" => "[FILTERED]"}}
+  describe "filter_values/2 with keep strategy" do
+    test "discards values not specified in params" do
+      values = %{"foo" => "bar", "password" => "abc123", "file" => %SomeStruct{}}
+
+      assert MapFilter.filter_values(values, {:keep, []}) ==
+               %{"foo" => "[FILTERED]", "password" => "[FILTERED]", "file" => "[FILTERED]"}
     end
 
-    test "filter_values when a list has a map with secret" do
-      assert MapFilter.filter_values(
-               %{"foo" => "bar", "list" => [%{"password" => "should_not_show"}]},
-               ["password"]
-             ) == %{"foo" => "bar", "list" => [%{"password" => "[FILTERED]"}]}
+    test "keeps values that are specified in params" do
+      values = %{"foo" => "bar", "password" => "abc123", "file" => %SomeStruct{}}
+
+      assert MapFilter.filter_values(values, {:keep, ["foo", "file"]}) ==
+               %{"foo" => "bar", "password" => "[FILTERED]", "file" => %SomeStruct{}}
     end
 
-    defmodule SomeStruct do
-      defstruct foo: 1
+    test "keeps all values under keys that are kept" do
+      values = %{"foo" => %{"bar" => 1, "baz" => 2}}
+
+      assert MapFilter.filter_values(values, {:keep, ["foo"]}) ==
+               %{"foo" => %{"bar" => 1, "baz" => 2}}
     end
 
-    test "filter_values does not filter structs" do
-      assert MapFilter.filter_values(%{"foo" => "bar", "file" => %SomeStruct{}}, ["password"]) ==
-               %{"foo" => "bar", "file" => %SomeStruct{}}
+    test "only filters leaf values" do
+      values = %{"foo" => %{"bar" => 1, "baz" => 2}, "ids" => [1, 2]}
 
-      assert MapFilter.filter_values(%{"foo" => "bar", "file" => %{__struct__: "s"}}, ["password"]) ==
-               %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
-    end
-
-    test "filter_values does not fail on atomic keys" do
-      assert MapFilter.filter_values(%{:foo => "bar", "password" => "should_not_show"}, [
-               "password"
-             ]) == %{:foo => "bar", "password" => "[FILTERED]"}
+      assert MapFilter.filter_values(values, {:keep, []}) ==
+               %{
+                 "foo" => %{"bar" => "[FILTERED]", "baz" => "[FILTERED]"},
+                 "ids" => ["[FILTERED]", "[FILTERED]"]
+               }
     end
   end
 end

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -98,6 +98,23 @@ defmodule Appsignal.Transaction.FilterTest do
                  %{"foo" => "bar", "secret3" => "[FILTERED]", "secret4" => "[FILTERED]"}
       end)
     end
+
+    test "filters out all parameters in case of a configuration error" do
+      with_config(%{filter_parameters: "foo"}, fn ->
+        Config.initialize()
+
+        values = %{"foo" => "bar", "secret3" => "super_secret", "secret4" => "more_secret"}
+
+        assert ExUnit.CaptureLog.capture_log(fn ->
+                 assert MapFilter.filter_parameters(values) ==
+                          %{
+                            "foo" => "[FILTERED]",
+                            "secret3" => "[FILTERED]",
+                            "secret4" => "[FILTERED]"
+                          }
+               end) =~ "An error occured while merging parameter filters."
+      end)
+    end
   end
 
   describe "filter_session_data/1" do

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -116,7 +116,7 @@ defmodule Appsignal.Transaction.FilterTest do
       end)
     end
 
-    test "filters out all parameters when filter_parameters is a :keep-tuple with aa calue that's not a list" do
+    test "filters out all parameters when filter_parameters is a :keep-tuple with a value that's not a list" do
       with_config(%{filter_parameters: {:keep, "foo"}}, fn ->
         Config.initialize()
 


### PR DESCRIPTION
It includes support for the special syntax `{:keep, params}` for parameter filtering from [Phoenix](https://hexdocs.pm/phoenix/Phoenix.Logger.html#module-parameter-filtering).

It also fixes a bug when merging the filtering configurations of Appsignal and Phoenix as reported in
https://github.com/appsignal/appsignal-elixir/issues/498

Most of the implementation is a copy of the [`Phoenix.Logger`](https://github.com/phoenixframework/phoenix/blob/4d61eacd83d61899a895167715d8754c5c8187be/lib/phoenix/logger.ex#L61)

It closes #498