### PR TITLE
Restore get_filter_(parameters|session_data) to patch backwards compatibility

### DIFF
--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -9,27 +9,28 @@ defmodule Appsignal.Utils.MapFilter do
   @doc """
   Filter parameters based on Appsignal and Phoenix configuration.
   """
-  def filter_parameters(values) do
-    filter_values(
-      values,
-      merge_filters(
-        Application.get_env(:appsignal, :config)[:filter_parameters],
-        Application.get_env(:phoenix, :filter_parameters, [])
-      )
-    )
-  end
+  def filter_parameters(values), do: filter_values(values, get_filter_parameters())
 
   @doc """
   Filter session data based Appsignal configuration.
   """
-  def filter_session_data(values) do
-    filter_values(values, Application.get_env(:appsignal, :config)[:filter_session_data] || [])
-  end
+  def filter_session_data(values), do: filter_values(values, get_filter_session_data())
 
   @doc false
   def filter_values(values, {:discard, params}), do: discard_values(values, params)
   def filter_values(values, {:keep, params}), do: keep_values(values, params)
   def filter_values(values, params), do: discard_values(values, params)
+
+  def get_filter_parameters do
+    merge_filters(
+      Application.get_env(:appsignal, :config)[:filter_parameters],
+      Application.get_env(:phoenix, :filter_parameters, [])
+    )
+  end
+
+  def get_filter_session_data do
+    Application.get_env(:appsignal, :config)[:filter_session_data] || []
+  end
 
   defp discard_values(%{__struct__: mod} = struct, _params) when is_atom(mod) do
     struct

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -9,6 +9,50 @@ defmodule Appsignal.Transaction.FilterTest do
     defstruct foo: 1
   end
 
+  describe "get_filter_parameters/0" do
+    test "returns parameter filters from the appsignal config" do
+      with_config(%{filter_parameters: ["password"]}, fn ->
+        Config.initialize()
+
+        assert MapFilter.get_filter_parameters() == ["password"]
+      end)
+    end
+
+    test "returns parameter filters from the phoenix config" do
+      Application.put_env(:phoenix, :filter_parameters, ~w(password))
+      Config.initialize()
+      assert MapFilter.get_filter_parameters() == ["password"]
+
+      Application.delete_env(:phoenix, :filter_parameters)
+    end
+
+    test "merges AppSignal's parameter filters with Phoenix' parameter filters" do
+      Application.put_env(:phoenix, :filter_parameters, ~w(password))
+
+      with_config(%{filter_parameters: ["token"]}, fn ->
+        Config.initialize()
+
+        assert MapFilter.get_filter_parameters() == ["token", "password"]
+      end)
+
+      Application.delete_env(:phoenix, :filter_parameters)
+    end
+  end
+
+  describe "get_filter_session_data/0" do
+    test "returns an empty list when no filters are set" do
+      assert MapFilter.get_filter_session_data() == []
+    end
+
+    test "returns session data filters from the appsignal config" do
+      with_config(%{filter_session_data: ["token"]}, fn ->
+        Config.initialize()
+
+        assert MapFilter.get_filter_session_data() == ["token"]
+      end)
+    end
+  end
+
   describe "filter_parameters/1" do
     test "uses parameter filters from the appsignal config" do
       with_config(%{filter_parameters: ["password"]}, fn ->


### PR DESCRIPTION
As reported in https://github.com/appsignal/appsignal-elixir/pull/499#issuecomment-512785992, #499 breaks backwards compatibility by removing the `get_filter_parameters/0` and `get_filter_session_data/0` functions. 

This patch restores these two functions. These aren't deprecated, as they're now used by the current implementation, so they're still part of the API.