### PR TITLE
Improving Transaction Registry Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ you have [Elixir installed](http://elixir-lang.org/install.html).
 Then make sure you have all the project's dependencies installed by running the
 following command:
 
-```
+```shell
 mix deps.get
 ```
 
@@ -62,7 +62,7 @@ Testing is done with ExUnit and can be run with the `mix test` command. You can
 also supply a path to a specific file path you want to test and even a specific
 line on which the test you want to run is defined.
 
-```
+```shell
 mix test
 mix test test/appsignal/some_test.ex:123
 ```
@@ -71,7 +71,7 @@ This project has several different test suites defined with different mix
 environments. You can run them by specifying the specific type of test suite in
 the `MIX_ENV` environment variable.
 
-```
+```shell
 # Default
 MIX_ENV=test mix test
 
@@ -82,6 +82,14 @@ MIX_ENV=test_phoenix mix test
 # This will generate errors that the NIF is not active, but should run
 # without failures.
 MIX_ENV=test_no_nif mix test
+```
+
+### Benchmarking
+
+This package uses benchee to benchmark code. To run the benchmarker:
+
+```shell
+mix run bench/<file>.exs
 ```
 
 ### Branches and versions

--- a/bench/registry.exs
+++ b/bench/registry.exs
@@ -1,0 +1,25 @@
+alias Appsignal.Transaction
+
+fibonacci =
+  Enum.map([2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711], fn range ->
+    1
+    |> Range.new(range)
+    |> Enum.reduce([], &([&1 | &2]))
+  end)
+
+Benchee.run(
+  %{
+    "registry" => fn ->
+      Enum.each(fibonacci, fn list ->
+        list
+        |> Task.async_stream(fn index ->
+          index
+          |> to_string()
+          |> Transaction.start(:benchmark)
+          |> Transaction.complete()
+        end, ordered: false, max_concurrency: Enum.count(list))
+        |> Stream.run()
+      end)
+    end
+  }
+)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-if Mix.env() in [:test, :test_phoenix, :test_no_nif] do
+if Mix.env() in [:bench, :test, :test_phoenix, :test_no_nif] do
   config :logger,
     level: :warn,
     handle_otp_reports: false,

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -29,9 +29,7 @@ defmodule Appsignal do
     @report_handler Appsignal.ErrorLoggerHandler
   end
 
-  @doc """
-  Application callback function
-  """
+  @doc "Application callback function."
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
@@ -39,7 +37,8 @@ defmodule Appsignal do
     add_report_handler()
 
     children = [
-      worker(Appsignal.TransactionRegistry, []),
+      worker(Appsignal.Transaction.Receiver, []),
+      worker(Appsignal.Transaction.ETS, []),
       worker(Appsignal.Probes, [])
     ]
 

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -37,8 +37,8 @@ defmodule Appsignal do
     add_report_handler()
 
     children = [
-      worker(Appsignal.Transaction.Receiver, []),
-      worker(Appsignal.Transaction.ETS, []),
+      worker(Appsignal.Transaction.Receiver, [], restart: :permanent),
+      worker(Appsignal.Transaction.ETS, [], restart: :permanent),
       worker(Appsignal.Probes, [])
     ]
 

--- a/lib/appsignal/transaction/ets.ex
+++ b/lib/appsignal/transaction/ets.ex
@@ -1,0 +1,20 @@
+defmodule Appsignal.Transaction.ETS do
+  use Agent
+
+  @name __MODULE__
+  @table :"$appsignal_transaction_registry"
+
+  def start_link do
+    Agent.start_link(fn ->
+      :ets.new(@table, [:set, :named_table, {:keypos, 1}, :public, {:write_concurrency, true}])
+    end, name: @name)
+  end
+
+  def insert(value), do: :ets.insert(@table, value)
+
+  def lookup(pid), do: :ets.lookup(@table, pid)
+
+  def match(pattern), do: :ets.match(@table, pattern)
+
+  def delete(pid), do: :ets.delete(@table, pid)
+end

--- a/lib/appsignal/transaction/ets.ex
+++ b/lib/appsignal/transaction/ets.ex
@@ -1,5 +1,9 @@
 defmodule Appsignal.Transaction.ETS do
-  use Agent
+  # When support for Elixir 1.4 is dropped, please uncomment the below code. The
+  # `Agent.__using__/1` implements a simple `child_spec` as a permanent process
+  # and states to use the `__MODULE__.start_link/1` function.
+  #
+  # use Agent, restart: :permanent
 
   @name __MODULE__
   @table :"$appsignal_transaction_registry"

--- a/lib/appsignal/transaction/ets.ex
+++ b/lib/appsignal/transaction/ets.ex
@@ -9,9 +9,12 @@ defmodule Appsignal.Transaction.ETS do
   @table :"$appsignal_transaction_registry"
 
   def start_link do
-    Agent.start_link(fn ->
-      :ets.new(@table, [:set, :named_table, {:keypos, 1}, :public, {:write_concurrency, true}])
-    end, name: @name)
+    Agent.start_link(
+      fn ->
+        :ets.new(@table, [:set, :named_table, {:keypos, 1}, :public, {:write_concurrency, true}])
+      end,
+      name: @name
+    )
   end
 
   def insert(value), do: :ets.insert(@table, value)

--- a/lib/appsignal/transaction/receiver.ex
+++ b/lib/appsignal/transaction/receiver.ex
@@ -1,0 +1,44 @@
+defmodule Appsignal.Transaction.Receiver do
+  use Task
+
+  alias Appsignal.Transaction.ETS
+  alias Appsignal.TransactionRegistry, as: Registry
+
+  def start_link do
+    with {:ok, pid} <- Task.start_link(&receiver/0) do
+      Process.register(pid, __MODULE__)
+      {:ok, pid}
+    end
+  end
+
+  def receiver do
+    receive do
+      {:DOWN, _ref, :process, pid, _reason} ->
+        Process.send_after(self(), {:delete, pid}, 5000)
+        receiver()
+
+      {:delete, pid} ->
+        ETS.delete(pid)
+        receiver()
+
+      _ ->
+        receiver()
+    end
+  end
+
+  def monitor(pid), do: Process.monitor(pid)
+
+  def demonitor(transaction) do
+    transaction
+    |> Registry.pids_and_monitor_references()
+    |> process_demonitor()
+  end
+
+  defp process_demonitor([[_, reference] | tail]) do
+    Process.demonitor(reference)
+    process_demonitor(tail)
+  end
+
+  defp process_demonitor([_ | tail]), do: process_demonitor(tail)
+  defp process_demonitor([]), do: :ok
+end

--- a/lib/appsignal/transaction/receiver.ex
+++ b/lib/appsignal/transaction/receiver.ex
@@ -1,5 +1,9 @@
 defmodule Appsignal.Transaction.Receiver do
-  use Task
+  # When support for Elixir 1.4 is dropped, please uncomment the below code. The
+  # `Task.__using__/1` implements a simple `child_spec` as a temporary process
+  # and states to use the `__MODULE__.start_link/1` function.
+  #
+  # use Task, restart: :permanent
 
   alias Appsignal.Transaction.ETS
   alias Appsignal.TransactionRegistry, as: Registry

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -1,6 +1,5 @@
 defmodule Appsignal.TransactionRegistry do
   @moduledoc """
-
   Internal module which keeps a registry of the transaction handles
   linked to their originating process.
 
@@ -12,44 +11,27 @@ defmodule Appsignal.TransactionRegistry do
   `{:write_concurrency, true}`, so no bottleneck is created); and the
   originating process is monitored to clean up the ETS table when the
   process has finished.
-
   """
-
-  use GenServer
 
   require Logger
 
-  @table :"$appsignal_transaction_registry"
+  alias Appsignal.{Config, Transaction}
+  alias Appsignal.Transaction.{ETS, Receiver}
 
-  alias Appsignal.Transaction
-
-  @spec start_link :: {:ok, pid}
-  def start_link do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
-  end
-
-  @doc """
-  Register the current process as the owner of the given transaction.
-  """
+  @doc "Register the current process as the owner of the given transaction."
   @spec register(Transaction.t()) :: :ok
   def register(transaction) do
-    pid = self()
-
-    if Appsignal.Config.active?() && registry_alive?() do
-      monitor_reference = GenServer.call(__MODULE__, {:monitor, pid})
-      true = :ets.insert(@table, {pid, transaction, monitor_reference})
+    if Config.active?() && receiver_alive?() do
+      pid = self()
+      true = ETS.insert({pid, transaction, Receiver.monitor(pid)})
       :ok
-    else
-      nil
     end
   end
 
-  @doc """
-  Given a process ID, return its associated transaction.
-  """
+  @doc "Given a process ID, return its associated transaction."
   @spec lookup(pid) :: Transaction.t() | nil
   def lookup(pid) do
-    case Appsignal.Config.active?() && registry_alive?() && :ets.lookup(@table, pid) do
+    case Config.active?() && receiver_alive?() && ETS.lookup(pid) do
       [{^pid, %Transaction{} = transaction, _}] -> transaction
       [{^pid, %Transaction{} = transaction}] -> transaction
       [{^pid, :ignore}] -> :ignored
@@ -57,14 +39,14 @@ defmodule Appsignal.TransactionRegistry do
     end
   end
 
-  @spec lookup(pid, boolean) :: Transaction.t() | nil | :removed
   @doc false
+  @spec lookup(pid, boolean) :: Transaction.t() | nil | :removed
   def lookup(pid, return_removed) do
     IO.warn(
       "Appsignal.TransactionRegistry.lookup/2 is deprecated. Use Appsignal.TransactionRegistry.lookup/1 instead"
     )
 
-    case registry_alive?() && :ets.lookup(@table, pid) do
+    case receiver_alive?() && ETS.lookup(pid) do
       [{^pid, :removed}] ->
         case return_removed do
           false -> nil
@@ -88,123 +70,68 @@ defmodule Appsignal.TransactionRegistry do
   @doc """
   Unregister the current process as the owner of the given transaction.
   """
-  @spec remove_transaction(Transaction.t()) :: :ok | {:error, :not_found} | {:error, :no_registry}
+  @spec remove_transaction(Transaction.t()) :: :ok | {:error, :not_found} | {:error, :no_receiver}
   def remove_transaction(%Transaction{} = transaction) do
-    if registry_alive?() do
-      GenServer.cast(__MODULE__, {:demonitor, transaction})
-      GenServer.call(__MODULE__, {:remove, transaction})
+    if receiver_alive?() do
+      Receiver.demonitor(transaction)
+      remove(transaction)
     else
-      {:error, :no_registry}
+      {:error, :no_receiver}
     end
   end
 
-  @doc """
-  Ignore a process in the error handler.
-  """
+  defp remove(transaction) do
+    case pids_and_monitor_references(transaction) do
+      [[_pid, _reference] | _] = pids_and_refs ->
+        delete(pids_and_refs)
+
+      [[_pid] | _] = pids ->
+        delete(pids)
+
+      [] ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc "Ignore a process in the error handler."
   @spec ignore(pid()) :: :ok
   def ignore(pid) do
-    if registry_alive?() do
-      :ets.insert(@table, {pid, :ignore})
+    if receiver_alive?() do
+      ETS.insert({pid, :ignore})
       :ok
     else
-      {:error, :no_registry}
+      {:error, :no_receiver}
     end
   end
 
-  @doc """
-  Check if a progress is ignored.
-  """
+  @doc "Check if a progress is ignored."
   @deprecated "Use Appsignal.TransactionRegistry.lookup/1 instead."
   @spec ignored?(pid()) :: boolean()
   def ignored?(pid) do
-    case registry_alive?() && :ets.lookup(@table, pid) do
+    case receiver_alive?() && ETS.lookup(pid) do
       [{^pid, :ignore}] -> true
       _ -> false
     end
   end
 
-  defmodule State do
-    @moduledoc false
-    defstruct table: nil
-  end
-
-  def init([]) do
-    table =
-      :ets.new(@table, [:set, :named_table, {:keypos, 1}, :public, {:write_concurrency, true}])
-
-    {:ok, %State{table: table}}
-  end
-
-  def handle_call({:remove, transaction}, _from, state) do
-    reply =
-      case pids_and_monitor_references(transaction) do
-        [[_pid, _reference] | _] = pids_and_refs ->
-          delete(pids_and_refs)
-
-        [[_pid] | _] = pids ->
-          delete(pids)
-
-        [] ->
-          {:error, :not_found}
-      end
-
-    {:reply, reply, state}
-  end
-
-  def handle_call({:monitor, pid}, _from, state) do
-    monitor_reference = Process.monitor(pid)
-    {:reply, monitor_reference, state}
-  end
-
-  def handle_cast({:demonitor, %Transaction{} = transaction}, state) do
-    transaction
-    |> pids_and_monitor_references()
-    |> demonitor
-
-    {:noreply, state}
-  end
-
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    # we give the error handler some time to process the error report
-    Process.send_after(self(), {:delete, pid}, 5000)
-    {:noreply, state}
-  end
-
-  def handle_info({:delete, pid}, state) do
-    :ets.delete(@table, pid)
-    {:noreply, state}
-  end
-
-  def handle_info(_msg, state) do
-    {:noreply, state}
-  end
-
   defp delete([[pid, _] | tail]) do
-    :ets.delete(@table, pid)
+    ETS.delete(pid)
     delete(tail)
   end
 
   defp delete([[pid] | tail]) do
-    :ets.delete(@table, pid)
+    ETS.delete(pid)
     delete(tail)
   end
 
   defp delete([]), do: :ok
 
-  defp demonitor([[_, reference] | tail]) do
-    Process.demonitor(reference)
-    demonitor(tail)
-  end
-
-  defp demonitor([_ | tail]), do: demonitor(tail)
-  defp demonitor([]), do: :ok
-
-  defp registry_alive? do
-    pid = Process.whereis(__MODULE__)
+  defp receiver_alive? do
+    pid = Process.whereis(Receiver)
     !is_nil(pid) && Process.alive?(pid)
   end
 
-  defp pids_and_monitor_references(transaction) do
-    :ets.match(@table, {:"$1", transaction, :"$2"}) ++ :ets.match(@table, {:"$1", transaction})
+  def pids_and_monitor_references(transaction) do
+    ETS.match({:"$1", transaction, :"$2"}) ++ ETS.match({:"$1", transaction})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -94,6 +94,7 @@ defmodule Appsignal.Mixfile do
       end
 
     [
+      {:benchee, "~> 1.0", only: :bench},
       {:hackney, "~> 1.6"},
       {:poison, poison_version},
       {:decorator, "~> 1.2.3"},

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -284,12 +284,14 @@ defmodule Mix.Appsignal.Helper do
 
   defp map_arch(arch, platform), do: {:error, {:unknown, {arch, platform}}}
 
-  defp build_for(bit, platform) do
-    arch = {bit, platform}
+  if Mix.env() != :test_no_nif do
+    defp build_for(bit, platform) do
+      arch = {bit, platform}
 
-    case Map.has_key?(Appsignal.Agent.triples(), arch_key(arch)) do
-      true -> {:ok, arch}
-      false -> {:error, {:unsupported, arch}}
+      case Map.has_key?(Appsignal.Agent.triples(), arch_key(arch)) do
+        true -> {:ok, arch}
+        false -> {:error, {:unsupported, arch}}
+      end
     end
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -241,7 +241,7 @@ defmodule Appsignal.ConfigTest do
     test "log_path" do
       log_path = File.cwd!()
 
-      assert %{log_path: log_path} = with_config(%{log_path: log_path}, &init_config/0)
+      assert %{log_path: ^log_path} = with_config(%{log_path: log_path}, &init_config/0)
     end
 
     test "name" do

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -1,7 +1,10 @@
 defmodule Appsignal.Transaction.RegistryTest do
-  alias Appsignal.{Transaction, TransactionRegistry}
-  import AppsignalTest.Utils
   use ExUnit.Case
+
+  import AppsignalTest.Utils
+
+  alias Appsignal.{Transaction, TransactionRegistry}
+  alias Appsignal.Transaction.Receiver
 
   test "lookup/1 returns nil after process has ended" do
     transaction = %Transaction{id: Transaction.generate_id()}
@@ -67,7 +70,7 @@ defmodule Appsignal.Transaction.RegistryTest do
 
     test "can't ignore a pid" do
       pid = :c.pid(0, 992, 0)
-      {:error, :no_registry} = TransactionRegistry.ignore(pid)
+      {:error, :no_receiver} = TransactionRegistry.ignore(pid)
       refute TransactionRegistry.lookup(pid) == :ignored
     end
   end
@@ -128,7 +131,7 @@ defmodule Appsignal.Transaction.RegistryTest do
     setup [:register_transaction, :terminate_registry]
 
     test "returns no registry error", %{transaction: transaction} do
-      assert TransactionRegistry.remove_transaction(transaction) == {:error, :no_registry}
+      assert TransactionRegistry.remove_transaction(transaction) == {:error, :no_receiver}
     end
   end
 
@@ -147,10 +150,10 @@ defmodule Appsignal.Transaction.RegistryTest do
   end
 
   defp terminate_registry(_) do
-    :ok = Supervisor.terminate_child(Appsignal.Supervisor, TransactionRegistry)
+    :ok = Supervisor.terminate_child(Appsignal.Supervisor, Receiver)
 
     on_exit(fn ->
-      {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, TransactionRegistry)
+      {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, Receiver)
     end)
   end
 

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -3,6 +3,7 @@ defmodule AppsignalTransactionTest do
   import AppsignalTest.Utils
 
   alias Appsignal.{Transaction, TransactionRegistry}
+  alias Appsignal.Transaction.Receiver
 
   test "transaction lifecycle" do
     transaction = Transaction.start("test1", :http_request)
@@ -358,10 +359,10 @@ defmodule AppsignalTransactionTest do
   describe "when the registry is not running" do
     setup do
       transaction = Transaction.start(Transaction.generate_id(), :http_request)
-      :ok = Supervisor.terminate_child(Appsignal.Supervisor, TransactionRegistry)
+      :ok = Supervisor.terminate_child(Appsignal.Supervisor, Receiver)
 
       on_exit(fn ->
-        {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, TransactionRegistry)
+        {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, Receiver)
       end)
 
       [transaction: transaction]


### PR DESCRIPTION
This PR is all about improving the transaction registry. Currently, since it's a genserver, we end up getting backpressure. This PR is about trying to reduce that backpressure as intelligently as possible.

First up, we got a benchmark. I used the Fibonacci sequence to make a list of concurrent processes and then started hitting it. My initial benchmark for the system:

```
Name               ips        average  deviation         median         99th %
registry         0.109         9.15 s     ±0.00%         9.15 s         9.15 s
```

Then I checked in on what effect PR #503 had on the benchmark:

```
Name               ips        average  deviation         median         99th %
registry        0.0609        16.42 s     ±0.00%        16.42 s        16.42 s
```

Now, this is caused by silent backpressure, so to remove that we alter a `handle_cast` to a `handle_call` and we get:

```
Name               ips        average  deviation         median         99th %
registry         0.113         8.87 s     ±0.00%         8.87 s         8.87 s
```

Looking better, but barely. The problem is now with the GenServer in the transaction registry being the root cause of the backpressure.

The first step was moving ETS to its own file and its own process. We start the process up with an Agent to boot ETS and to make sure that ETS calls to its own process for management if needed in the future (such as changing ownership).

After that, the `init` call was free of responsibilities and we could start moving code over to a task; that's the `Receiver`. We start a simple task, register it, and listen and loop over messages send to the process. This will be the only blocking part.

Then we add two public functions called `monitor/1` and `demonitor/1` for the `Receiver` to monitor and demonitor. We update the code in the `TransactionRegistry` and benchmark:

```
Name               ips        average  deviation         median         99th %
registry         0.122         8.19 s     ±0.00%         8.19 s         8.19 s
```

The **average duration is 10.5% smaller** than the initial, the **ips is 10.6% larger**.