### PR TITLE
Extract ETS and Receiver logic from TransactionRegistry

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -39,8 +39,8 @@ defmodule Appsignal do
     add_report_handler()
 
     children = [
-      worker(Appsignal.Transaction.Receiver, []),
-      worker(Appsignal.Transaction.ETS, []),
+      worker(Appsignal.Transaction.Receiver, [], restart: :permanent),
+      worker(Appsignal.Transaction.ETS, [], restart: :permanent),
       worker(Appsignal.Probes, [])
     ]
 

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -39,7 +39,8 @@ defmodule Appsignal do
     add_report_handler()
 
     children = [
-      worker(Appsignal.TransactionRegistry, []),
+      worker(Appsignal.Transaction.Receiver, []),
+      worker(Appsignal.Transaction.ETS, []),
       worker(Appsignal.Probes, [])
     ]
 

--- a/lib/appsignal/transaction/ets.ex
+++ b/lib/appsignal/transaction/ets.ex
@@ -1,0 +1,23 @@
+defmodule Appsignal.Transaction.ETS do
+  use Agent
+
+  @name __MODULE__
+  @table :"$appsignal_transaction_registry"
+
+  def start_link do
+    Agent.start_link(
+      fn ->
+        :ets.new(@table, [:set, :named_table, {:keypos, 1}, :public, {:write_concurrency, true}])
+      end,
+      name: @name
+    )
+  end
+
+  def insert(value), do: :ets.insert(@table, value)
+
+  def lookup(pid), do: :ets.lookup(@table, pid)
+
+  def match(pattern), do: :ets.match(@table, pattern)
+
+  def delete(pid), do: :ets.delete(@table, pid)
+end

--- a/lib/appsignal/transaction/ets.ex
+++ b/lib/appsignal/transaction/ets.ex
@@ -1,5 +1,9 @@
 defmodule Appsignal.Transaction.ETS do
-  use Agent
+  # When support for Elixir 1.4 is dropped, please uncomment the below code. The
+  # `Agent.__using__/1` implements a simple `child_spec` as a permanent process
+  # and states to use the `__MODULE__.start_link/1` function.
+  #
+  # use Agent, restart: :permanent
 
   @name __MODULE__
   @table :"$appsignal_transaction_registry"

--- a/lib/appsignal/transaction/receiver.ex
+++ b/lib/appsignal/transaction/receiver.ex
@@ -1,0 +1,44 @@
+defmodule Appsignal.Transaction.Receiver do
+  use Task
+
+  alias Appsignal.Transaction.ETS
+  alias Appsignal.TransactionRegistry, as: Registry
+
+  def start_link do
+    with {:ok, pid} <- Task.start_link(&receiver/0) do
+      Process.register(pid, __MODULE__)
+      {:ok, pid}
+    end
+  end
+
+  def receiver do
+    receive do
+      {:DOWN, _ref, :process, pid, _reason} ->
+        Process.send_after(self(), {:delete, pid}, 5000)
+        receiver()
+
+      {:delete, pid} ->
+        ETS.delete(pid)
+        receiver()
+
+      _ ->
+        receiver()
+    end
+  end
+
+  def monitor(pid), do: Process.monitor(pid)
+
+  def demonitor(transaction) do
+    transaction
+    |> Registry.pids_and_monitor_references()
+    |> process_demonitor()
+  end
+
+  defp process_demonitor([[_, reference] | tail]) do
+    Process.demonitor(reference)
+    process_demonitor(tail)
+  end
+
+  defp process_demonitor([_ | tail]), do: process_demonitor(tail)
+  defp process_demonitor([]), do: :ok
+end

--- a/lib/appsignal/transaction/receiver.ex
+++ b/lib/appsignal/transaction/receiver.ex
@@ -1,5 +1,9 @@
 defmodule Appsignal.Transaction.Receiver do
-  use Task
+  # When support for Elixir 1.4 is dropped, please uncomment the below code. The
+  # `Task.__using__/1` implements a simple `child_spec` as a temporary process
+  # and states to use the `__MODULE__.start_link/1` function.
+  #
+  # use Task, restart: :permanent
 
   alias Appsignal.Transaction.ETS
   alias Appsignal.TransactionRegistry, as: Registry

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -12,35 +12,22 @@ defmodule Appsignal.TransactionRegistry do
   `{:write_concurrency, true}`, so no bottleneck is created); and the
   originating process is monitored to clean up the ETS table when the
   process has finished.
-
   """
-
-  use GenServer
 
   require Logger
 
-  @table :"$appsignal_transaction_registry"
-
-  alias Appsignal.Transaction
-
-  @spec start_link :: {:ok, pid}
-  def start_link do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
-  end
+  alias Appsignal.{Config, Transaction}
+  alias Appsignal.Transaction.{ETS, Receiver}
 
   @doc """
   Register the current process as the owner of the given transaction.
   """
   @spec register(Transaction.t()) :: :ok
   def register(transaction) do
-    pid = self()
-
-    if Appsignal.Config.active?() && registry_alive?() do
-      monitor_reference = GenServer.call(__MODULE__, {:monitor, pid})
-      true = :ets.insert(@table, {pid, transaction, monitor_reference})
+    if Config.active?() && receiver_alive?() do
+      pid = self()
+      true = ETS.insert({pid, transaction, Receiver.monitor(pid)})
       :ok
-    else
-      nil
     end
   end
 
@@ -49,7 +36,7 @@ defmodule Appsignal.TransactionRegistry do
   """
   @spec lookup(pid) :: Transaction.t() | nil
   def lookup(pid) do
-    case Appsignal.Config.active?() && registry_alive?() && :ets.lookup(@table, pid) do
+    case Config.active?() && receiver_alive?() && ETS.lookup(pid) do
       [{^pid, %Transaction{} = transaction, _}] -> transaction
       [{^pid, %Transaction{} = transaction}] -> transaction
       [{^pid, :ignore}] -> :ignored
@@ -57,14 +44,14 @@ defmodule Appsignal.TransactionRegistry do
     end
   end
 
-  @spec lookup(pid, boolean) :: Transaction.t() | nil | :removed
   @doc false
+  @spec lookup(pid, boolean) :: Transaction.t() | nil | :removed
   def lookup(pid, return_removed) do
     IO.warn(
       "Appsignal.TransactionRegistry.lookup/2 is deprecated. Use Appsignal.TransactionRegistry.lookup/1 instead"
     )
 
-    case registry_alive?() && :ets.lookup(@table, pid) do
+    case receiver_alive?() && ETS.lookup(pid) do
       [{^pid, :removed}] ->
         case return_removed do
           false -> nil
@@ -88,13 +75,26 @@ defmodule Appsignal.TransactionRegistry do
   @doc """
   Unregister the current process as the owner of the given transaction.
   """
-  @spec remove_transaction(Transaction.t()) :: :ok | {:error, :not_found} | {:error, :no_registry}
+  @spec remove_transaction(Transaction.t()) :: :ok | {:error, :not_found} | {:error, :no_receiver}
   def remove_transaction(%Transaction{} = transaction) do
-    if registry_alive?() do
-      GenServer.cast(__MODULE__, {:demonitor, transaction})
-      GenServer.call(__MODULE__, {:remove, transaction})
+    if receiver_alive?() do
+      Receiver.demonitor(transaction)
+      remove(transaction)
     else
-      {:error, :no_registry}
+      {:error, :no_receiver}
+    end
+  end
+
+  defp remove(transaction) do
+    case pids_and_monitor_references(transaction) do
+      [[_pid, _reference] | _] = pids_and_refs ->
+        delete(pids_and_refs)
+
+      [[_pid] | _] = pids ->
+        delete(pids)
+
+      [] ->
+        {:error, :not_found}
     end
   end
 
@@ -103,11 +103,11 @@ defmodule Appsignal.TransactionRegistry do
   """
   @spec ignore(pid()) :: :ok
   def ignore(pid) do
-    if registry_alive?() do
-      :ets.insert(@table, {pid, :ignore})
+    if receiver_alive?() do
+      ETS.insert({pid, :ignore})
       :ok
     else
-      {:error, :no_registry}
+      {:error, :no_receiver}
     end
   end
 
@@ -117,94 +117,30 @@ defmodule Appsignal.TransactionRegistry do
   @deprecated "Use Appsignal.TransactionRegistry.lookup/1 instead."
   @spec ignored?(pid()) :: boolean()
   def ignored?(pid) do
-    case registry_alive?() && :ets.lookup(@table, pid) do
+    case receiver_alive?() && ETS.lookup(pid) do
       [{^pid, :ignore}] -> true
       _ -> false
     end
   end
 
-  defmodule State do
-    @moduledoc false
-    defstruct table: nil
-  end
-
-  def init([]) do
-    table =
-      :ets.new(@table, [:set, :named_table, {:keypos, 1}, :public, {:write_concurrency, true}])
-
-    {:ok, %State{table: table}}
-  end
-
-  def handle_call({:remove, transaction}, _from, state) do
-    reply =
-      case pids_and_monitor_references(transaction) do
-        [[_pid, _reference] | _] = pids_and_refs ->
-          delete(pids_and_refs)
-
-        [[_pid] | _] = pids ->
-          delete(pids)
-
-        [] ->
-          {:error, :not_found}
-      end
-
-    {:reply, reply, state}
-  end
-
-  def handle_call({:monitor, pid}, _from, state) do
-    monitor_reference = Process.monitor(pid)
-    {:reply, monitor_reference, state}
-  end
-
-  def handle_cast({:demonitor, %Transaction{} = transaction}, state) do
-    transaction
-    |> pids_and_monitor_references()
-    |> demonitor
-
-    {:noreply, state}
-  end
-
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    # we give the error handler some time to process the error report
-    Process.send_after(self(), {:delete, pid}, 5000)
-    {:noreply, state}
-  end
-
-  def handle_info({:delete, pid}, state) do
-    :ets.delete(@table, pid)
-    {:noreply, state}
-  end
-
-  def handle_info(_msg, state) do
-    {:noreply, state}
-  end
-
   defp delete([[pid, _] | tail]) do
-    :ets.delete(@table, pid)
+    ETS.delete(pid)
     delete(tail)
   end
 
   defp delete([[pid] | tail]) do
-    :ets.delete(@table, pid)
+    ETS.delete(pid)
     delete(tail)
   end
 
   defp delete([]), do: :ok
 
-  defp demonitor([[_, reference] | tail]) do
-    Process.demonitor(reference)
-    demonitor(tail)
-  end
-
-  defp demonitor([_ | tail]), do: demonitor(tail)
-  defp demonitor([]), do: :ok
-
-  defp registry_alive? do
-    pid = Process.whereis(__MODULE__)
+  defp receiver_alive? do
+    pid = Process.whereis(Receiver)
     !is_nil(pid) && Process.alive?(pid)
   end
 
-  defp pids_and_monitor_references(transaction) do
-    :ets.match(@table, {:"$1", transaction, :"$2"}) ++ :ets.match(@table, {:"$1", transaction})
+  def pids_and_monitor_references(transaction) do
+    ETS.match({:"$1", transaction, :"$2"}) ++ ETS.match({:"$1", transaction})
   end
 end

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -1,7 +1,10 @@
 defmodule Appsignal.Transaction.RegistryTest do
-  alias Appsignal.{Transaction, TransactionRegistry}
-  import AppsignalTest.Utils
   use ExUnit.Case
+
+  import AppsignalTest.Utils
+
+  alias Appsignal.{Transaction, TransactionRegistry}
+  alias Appsignal.Transaction.Receiver
 
   test "lookup/1 returns nil after process has ended" do
     transaction = %Transaction{id: Transaction.generate_id()}
@@ -67,7 +70,7 @@ defmodule Appsignal.Transaction.RegistryTest do
 
     test "can't ignore a pid" do
       pid = :c.pid(0, 992, 0)
-      {:error, :no_registry} = TransactionRegistry.ignore(pid)
+      {:error, :no_receiver} = TransactionRegistry.ignore(pid)
       refute TransactionRegistry.lookup(pid) == :ignored
     end
   end
@@ -128,7 +131,7 @@ defmodule Appsignal.Transaction.RegistryTest do
     setup [:register_transaction, :terminate_registry]
 
     test "returns no registry error", %{transaction: transaction} do
-      assert TransactionRegistry.remove_transaction(transaction) == {:error, :no_registry}
+      assert TransactionRegistry.remove_transaction(transaction) == {:error, :no_receiver}
     end
   end
 
@@ -147,10 +150,10 @@ defmodule Appsignal.Transaction.RegistryTest do
   end
 
   defp terminate_registry(_) do
-    :ok = Supervisor.terminate_child(Appsignal.Supervisor, TransactionRegistry)
+    :ok = Supervisor.terminate_child(Appsignal.Supervisor, Receiver)
 
     on_exit(fn ->
-      {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, TransactionRegistry)
+      {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, Receiver)
     end)
   end
 

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -3,6 +3,7 @@ defmodule AppsignalTransactionTest do
   import AppsignalTest.Utils
 
   alias Appsignal.{Transaction, TransactionRegistry}
+  alias Appsignal.Transaction.Receiver
 
   test "transaction lifecycle" do
     transaction = Transaction.start("test1", :http_request)
@@ -358,10 +359,10 @@ defmodule AppsignalTransactionTest do
   describe "when the registry is not running" do
     setup do
       transaction = Transaction.start(Transaction.generate_id(), :http_request)
-      :ok = Supervisor.terminate_child(Appsignal.Supervisor, TransactionRegistry)
+      :ok = Supervisor.terminate_child(Appsignal.Supervisor, Receiver)
 
       on_exit(fn ->
-        {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, TransactionRegistry)
+        {:ok, _} = Supervisor.restart_child(Appsignal.Supervisor, Receiver)
       end)
 
       [transaction: transaction]


### PR DESCRIPTION
This pull request contains @BenMorganIO's changes, submitted in https://github.com/appsignal/appsignal-elixir/pull/504. I'm opening this one here as the original included some unrelated fixes to the test suite and a benchmark for the Registry, which are already merged.

I've also removed the style changes from the original pull request's commits, to make this easier to review and push out as a new release. We should decide on a coding and documentation style, but we're definitely willing to clean the codebase up in this regard.

Ben's functionality remains unchanged and has been working great in my testing. @tombruijn and @jvanbaarsen could you try this branch in your apps, to make sure everything still works as you'd expect? I haven't seen it fail, but one place this patch might have an effect on would be error reporting from the Plug include. We need to make sure errors from Plug and Phoenix apps don't get reported twice. Please ping if you need help testing this out.

@BenMorganIO thanks once more for this patch! After we're done reviewing, we'll cut a beta that includes this patch to have users test it before the final release.