### PR TITLE
Add support for both Jason and Poison

### DIFF
--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -7,7 +7,7 @@ defmodule Appsignal.Diagnose.Agent do
       report_string = @nif.diagnose
 
       report =
-        case Jason.decode(report_string) do
+        case Json.decode(report_string) do
           {:ok, report} -> {:ok, report}
           {:error, _} -> {:error, report_string}
         end

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -7,7 +7,7 @@ defmodule Appsignal.Diagnose.Agent do
       report_string = @nif.diagnose
 
       report =
-        case Json.decode(report_string) do
+        case Appsignal.Json.decode(report_string) do
           {:ok, report} -> {:ok, report}
           {:error, _} -> {:error, report_string}
         end

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -7,7 +7,7 @@ defmodule Appsignal.Diagnose.Agent do
       report_string = @nif.diagnose
 
       report =
-        case Poison.decode(report_string) do
+        case Jason.decode(report_string) do
           {:ok, report} -> {:ok, report}
           {:error, _} -> {:error, report_string}
         end

--- a/lib/appsignal/diagnose/report.ex
+++ b/lib/appsignal/diagnose/report.ex
@@ -18,14 +18,14 @@ defmodule Appsignal.Diagnose.Report do
       })
 
     url = "#{config[:diagnose_endpoint]}?#{params}"
-    body = Poison.encode!(%{diagnose: report})
+    body = Jason.encode!(%{diagnose: report})
     headers = [{"Content-Type", "application/json; charset=UTF-8"}]
 
     case Transmitter.request(:post, url, headers, body) do
       {:ok, 200, _, reference} ->
         {:ok, body} = :hackney.body(reference)
 
-        case Poison.decode(body) do
+        case Jason.decode(body) do
           {:ok, response} -> {:ok, response["token"]}
           {:error, _} -> {:error, %{status_code: 200, body: body}}
         end

--- a/lib/appsignal/diagnose/report.ex
+++ b/lib/appsignal/diagnose/report.ex
@@ -18,14 +18,14 @@ defmodule Appsignal.Diagnose.Report do
       })
 
     url = "#{config[:diagnose_endpoint]}?#{params}"
-    body = Jason.encode!(%{diagnose: report})
+    body = Json.encode!(%{diagnose: report})
     headers = [{"Content-Type", "application/json; charset=UTF-8"}]
 
     case Transmitter.request(:post, url, headers, body) do
       {:ok, 200, _, reference} ->
         {:ok, body} = :hackney.body(reference)
 
-        case Jason.decode(body) do
+        case Json.decode(body) do
           {:ok, response} -> {:ok, response["token"]}
           {:error, _} -> {:error, %{status_code: 200, body: body}}
         end

--- a/lib/appsignal/diagnose/report.ex
+++ b/lib/appsignal/diagnose/report.ex
@@ -18,14 +18,14 @@ defmodule Appsignal.Diagnose.Report do
       })
 
     url = "#{config[:diagnose_endpoint]}?#{params}"
-    body = Json.encode!(%{diagnose: report})
+    body = Appsignal.Json.encode!(%{diagnose: report})
     headers = [{"Content-Type", "application/json; charset=UTF-8"}]
 
     case Transmitter.request(:post, url, headers, body) do
       {:ok, 200, _, reference} ->
         {:ok, body} = :hackney.body(reference)
 
-        case Json.decode(body) do
+        case Appsignal.Json.decode(body) do
           {:ok, response} -> {:ok, response["token"]}
           {:error, _} -> {:error, %{status_code: 200, body: body}}
         end

--- a/lib/appsignal/json.ex
+++ b/lib/appsignal/json.ex
@@ -1,4 +1,4 @@
-defmodule Json do
+defmodule Appsignal.Json do
   if(!Code.ensure_loaded?(Jason) && Code.ensure_loaded?(Poison)) do
     @json Poison
   else

--- a/lib/appsignal/json.ex
+++ b/lib/appsignal/json.ex
@@ -1,6 +1,12 @@
 defmodule Json do
-  defdelegate encode(input), to: Jason
-  defdelegate encode!(input), to: Jason
-  defdelegate decode(input), to: Jason
-  defdelegate decode!(input), to: Jason
+  if(!Code.ensure_loaded?(Jason) && Code.ensure_loaded?(Poison)) do
+    @json Poison
+  else
+    @json Jason
+  end
+
+  defdelegate encode(input), to: @json
+  defdelegate encode!(input), to: @json
+  defdelegate decode(input), to: @json
+  defdelegate decode!(input), to: @json
 end

--- a/lib/appsignal/json.ex
+++ b/lib/appsignal/json.ex
@@ -1,0 +1,6 @@
+defmodule Json do
+  defdelegate encode(input), to: Jason
+  defdelegate encode!(input), to: Jason
+  defdelegate decode(input), to: Jason
+  defdelegate decode!(input), to: Jason
+end

--- a/lib/appsignal/json.ex
+++ b/lib/appsignal/json.ex
@@ -1,8 +1,28 @@
+defmodule Appsignal.Json.MissingEncoderError do
+  defexception message: """
+               No JSON encoder found. Please add jason to your list of dependencies in mix.exs:
+
+                   def deps do
+                     [
+                       {:appsignal, "~> 1.0"},
+                       {:jason, "~> 1.1"}
+                     ]
+                   end
+               """
+end
+
+defmodule Appsignal.Json.MissingEncoder do
+  def encode(input), do: {:error, :no_json_encoder}
+  def encode!(_input), do: raise(%Appsignal.Json.MissingEncoderError{})
+  def decode(input), do: {:error, :no_json_encoder}
+  def decode!(_input), do: raise(%Appsignal.Json.MissingEncoderError{})
+end
+
 defmodule Appsignal.Json do
-  if(!Code.ensure_loaded?(Jason) && Code.ensure_loaded?(Poison)) do
-    @json Poison
-  else
-    @json Jason
+  cond do
+    Code.ensure_loaded?(Jason) -> @json Jason
+    Code.ensure_loaded?(Poison) -> @json Poison
+    true -> @json Appsignal.Json.MissingEncoder
   end
 
   defdelegate encode(input), to: @json

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -89,7 +89,7 @@ defmodule Appsignal.Transaction do
     @spec to_map(Appsignal.Transaction.t()) :: map()
     def to_map(transaction) do
       {:ok, json} = Nif.transaction_to_json(transaction.resource)
-      Json.decode!(json)
+      Appsignal.Json.decode!(json)
     end
   end
 

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -89,7 +89,7 @@ defmodule Appsignal.Transaction do
     @spec to_map(Appsignal.Transaction.t()) :: map()
     def to_map(transaction) do
       {:ok, json} = Nif.transaction_to_json(transaction.resource)
-      Jason.decode!(json)
+      Json.decode!(json)
     end
   end
 

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -89,7 +89,7 @@ defmodule Appsignal.Transaction do
     @spec to_map(Appsignal.Transaction.t()) :: map()
     def to_map(transaction) do
       {:ok, json} = Nif.transaction_to_json(transaction.resource)
-      Poison.decode!(json)
+      Jason.decode!(json)
     end
   end
 

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -121,7 +121,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   defp do_fetch_installation_report(file) do
     case File.read(Path.join([:code.priv_dir(:appsignal), "#{file}.report"])) do
       {:ok, raw_report} ->
-        case Poison.decode(raw_report) do
+        case Jason.decode(raw_report) do
           {:ok, report} ->
             {:ok, report}
 

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -121,7 +121,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   defp do_fetch_installation_report(file) do
     case File.read(Path.join([:code.priv_dir(:appsignal), "#{file}.report"])) do
       {:ok, raw_report} ->
-        case Json.decode(raw_report) do
+        case Appsignal.Json.decode(raw_report) do
           {:ok, report} ->
             {:ok, report}
 

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -121,7 +121,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   defp do_fetch_installation_report(file) do
     case File.read(Path.join([:code.priv_dir(:appsignal), "#{file}.report"])) do
       {:ok, raw_report} ->
-        case Jason.decode(raw_report) do
+        case Json.decode(raw_report) do
           {:ok, report} ->
             {:ok, report}
 

--- a/mix.exs
+++ b/mix.exs
@@ -82,6 +82,12 @@ defmodule Appsignal.Mixfile do
   defp deps do
     system_version = System.version()
 
+    poison_version =
+      case Version.compare(system_version, "1.6.0") do
+        :lt -> ">= 1.3.0 and < 4.0.0"
+        _ -> ">= 1.3.0"
+      end
+
     phoenix_version =
       case Version.compare(system_version, "1.4.0") do
         :lt -> ">= 1.2.0 and < 1.4.0"
@@ -92,6 +98,7 @@ defmodule Appsignal.Mixfile do
       {:benchee, "~> 1.0", only: :bench},
       {:hackney, "~> 1.6"},
       {:jason, "~> 1.0", optional: true},
+      {:poison, poison_version, optional: true},
       {:decorator, "~> 1.2.3"},
       {:plug, ">= 1.1.0", optional: true},
       {:phoenix, phoenix_version, optional: true, only: [:prod, :test_phoenix, :dev]},

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Appsignal.Mixfile do
   end
 
   def application do
-    [mod: {Appsignal, []}, applications: [:logger, :decorator, :hackney, :poison]]
+    [mod: {Appsignal, []}, applications: [:logger, :decorator, :hackney]]
   end
 
   defp compilers(:test_phoenix), do: [:phoenix] ++ compilers(:prod)
@@ -82,12 +82,6 @@ defmodule Appsignal.Mixfile do
   defp deps do
     system_version = System.version()
 
-    poison_version =
-      case Version.compare(system_version, "1.6.0") do
-        :lt -> ">= 1.3.0 and < 4.0.0"
-        _ -> ">= 1.3.0"
-      end
-
     phoenix_version =
       case Version.compare(system_version, "1.4.0") do
         :lt -> ">= 1.2.0 and < 1.4.0"
@@ -97,7 +91,7 @@ defmodule Appsignal.Mixfile do
     [
       {:benchee, "~> 1.0", only: :bench},
       {:hackney, "~> 1.6"},
-      {:poison, poison_version},
+      {:jason, "~> 1.0"},
       {:decorator, "~> 1.2.3"},
       {:plug, ">= 1.1.0", optional: true},
       {:phoenix, phoenix_version, optional: true, only: [:prod, :test_phoenix, :dev]},

--- a/mix.exs
+++ b/mix.exs
@@ -91,7 +91,7 @@ defmodule Appsignal.Mixfile do
     [
       {:benchee, "~> 1.0", only: :bench},
       {:hackney, "~> 1.6"},
-      {:jason, "~> 1.0"},
+      {:jason, "~> 1.0", optional: true},
       {:decorator, "~> 1.2.3"},
       {:plug, ">= 1.1.0", optional: true},
       {:phoenix, phoenix_version, optional: true, only: [:prod, :test_phoenix, :dev]},

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -497,8 +497,10 @@ defmodule Mix.Appsignal.Helper do
     # Write nothing if no download details are recorded in the report
   end
 
-  defp json_encoder do
-    Jason
+  if(!Code.ensure_loaded?(Jason) && Code.ensure_loaded?(Poison)) do
+    defp json_encoder, do: Poison
+  else
+    defp json_encoder, do: Jason
   end
 
   defp write_report_file(file, report) do

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -497,8 +497,12 @@ defmodule Mix.Appsignal.Helper do
     # Write nothing if no download details are recorded in the report
   end
 
+  defp json_encoder do
+    Jason
+  end
+
   defp write_report_file(file, report) do
-    case Jason.encode(report) do
+    case json_encoder().encode(report) do
       {:ok, body} ->
         File.mkdir_p!(priv_dir())
 

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -498,7 +498,7 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp write_report_file(file, report) do
-    case Poison.encode(report) do
+    case Jason.encode(report) do
       {:ok, body} ->
         File.mkdir_p!(priv_dir())
 

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -497,35 +497,53 @@ defmodule Mix.Appsignal.Helper do
     # Write nothing if no download details are recorded in the report
   end
 
-  if(!Code.ensure_loaded?(Jason) && Code.ensure_loaded?(Poison)) do
-    defp json_encoder, do: Poison
+  if(Code.ensure_loaded?(Jason)) do
+    defp json_encoder do
+      {:ok, Jason}
+    end
   else
-    defp json_encoder, do: Jason
+    if(Code.ensure_loaded?(Poison)) do
+      defp json_encoder do
+        {:ok, Poison}
+      end
+    else
+      defp json_encoder do
+        :error
+      end
+    end
   end
 
   defp write_report_file(file, report) do
-    case json_encoder().encode(report) do
-      {:ok, body} ->
-        File.mkdir_p!(priv_dir())
+    case json_encoder() do
+      {:ok, encoder} ->
+        case encoder.encoder(report) do
+          {:ok, body} ->
+            File.mkdir_p!(priv_dir())
 
-        filename = "#{file}.report"
+            filename = "#{file}.report"
 
-        case File.open(priv_path(filename), [:write]) do
-          {:ok, file} ->
-            result = IO.binwrite(file, body)
-            File.close(file)
-            result
+            case File.open(priv_path(filename), [:write]) do
+              {:ok, file} ->
+                result = IO.binwrite(file, body)
+                File.close(file)
+                result
 
-          {:error, reason} ->
+              {:error, reason} ->
+                Mix.Shell.IO.error(
+                  "Error: Could not write AppSignal report file '#{file}'.\n#{reason}"
+                )
+
+                {:error, reason}
+            end
+
+          {:error, error} ->
             Mix.Shell.IO.error(
-              "Error: Could not write AppSignal report file '#{file}'.\n#{reason}"
+              "Error: Could not encode AppSignal report file '#{file}'.\n#{error}"
             )
-
-            {:error, reason}
         end
 
-      {:error, error} ->
-        Mix.Shell.IO.error("Error: Could not encode AppSignal report file '#{file}'.\n#{error}")
+      :error ->
+        Mix.Shell.IO.error("Cannot find any Json encoders.")
     end
   end
 


### PR DESCRIPTION
Closes #474.

Instead of depending directly on Poison, this patch adds support for the now-preferred Jason.

Both the Jason and Poison dependencies are made optional, so projects that don't depend on a JSON encoder (which should be a very small number) are asked to depend on Jason in explicitly when trying to build the installation- or diagnose reports. 