### PR TITLE
Filter structs in MapFilter

### DIFF
--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -36,6 +36,12 @@ defmodule Appsignal.Utils.MapFilter do
     discard_values(list, filter_keys, [])
   end
 
+  defp discard_values(%{__struct__: _} = struct, filter_keys) do
+    struct
+    |> Map.from_struct()
+    |> discard_values(filter_keys)
+  end
+
   defp discard_values(map, filter_keys) when is_map(map) do
     map
     |> Map.to_list()

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -236,7 +236,11 @@ defmodule Appsignal.Transaction.FilterTest do
       values = %{"foo" => "bar", "password" => "abc123", "file" => %SomeStruct{}}
 
       assert MapFilter.filter_values(values, {:keep, []}) ==
-               %{"foo" => "[FILTERED]", "password" => "[FILTERED]", "file" => "[FILTERED]"}
+               %{
+                 "foo" => "[FILTERED]",
+                 "password" => "[FILTERED]",
+                 "file" => %{foo: "[FILTERED]", password: "[FILTERED]"}
+               }
     end
 
     test "keeps values that are specified in params" do

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -6,7 +6,7 @@ defmodule Appsignal.Transaction.FilterTest do
   import AppsignalTest.Utils
 
   defmodule SomeStruct do
-    defstruct foo: 1
+    defstruct foo: 1, password: nil
   end
 
   describe "get_filter_parameters/0" do
@@ -212,16 +212,11 @@ defmodule Appsignal.Transaction.FilterTest do
                %{"foo" => "bar", "list" => [%{"password" => "[FILTERED]"}]}
     end
 
-    test "does not filter structs" do
-      values = %{"foo" => "bar", "file" => %SomeStruct{}}
+    test "when a list has a struct with secret" do
+      values = %{"foo" => "bar", "list" => [%SomeStruct{password: "should_not_show"}]}
 
       assert MapFilter.filter_values(values, ["password"]) ==
-               %{"foo" => "bar", "file" => %SomeStruct{}}
-
-      values = %{"foo" => "bar", "file" => %{__struct__: "s"}}
-
-      assert MapFilter.filter_values(values, ["password"]) ==
-               %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
+               %{"foo" => "bar", "list" => [%SomeStruct{password: "[FILTERED]"}]}
     end
 
     test "does not fail on atomic keys" do

--- a/test/appsignal/transaction/filter_test.exs
+++ b/test/appsignal/transaction/filter_test.exs
@@ -216,7 +216,7 @@ defmodule Appsignal.Transaction.FilterTest do
       values = %{"foo" => "bar", "list" => [%SomeStruct{password: "should_not_show"}]}
 
       assert MapFilter.filter_values(values, ["password"]) ==
-               %{"foo" => "bar", "list" => [%SomeStruct{password: "[FILTERED]"}]}
+               %{"foo" => "bar", "list" => [%{password: "[FILTERED]", foo: 1}]}
     end
 
     test "does not fail on atomic keys" do
@@ -243,7 +243,7 @@ defmodule Appsignal.Transaction.FilterTest do
       values = %{"foo" => "bar", "password" => "abc123", "file" => %SomeStruct{}}
 
       assert MapFilter.filter_values(values, {:keep, ["foo", "file"]}) ==
-               %{"foo" => "bar", "password" => "[FILTERED]", "file" => %SomeStruct{}}
+               %{"foo" => "bar", "password" => "[FILTERED]", "file" => %{foo: 1, password: nil}}
     end
 
     test "keeps all values under keys that are kept" do


### PR DESCRIPTION
The `MapFilter` is used to filter parameters and session data before sending it to AppSignal. Currently, it filters nested maps and lists. Structs aren't generally found in parameter maps, unless a plug adds them when parsing the parameters. We've seen this in the [open_api_spex](https://github.com/open-api-spex/open_api_spex) library, where it's not an issue as the extracted parameter struct isn't actually added to the params map.

However, since it makes sense to properly filter structs if they end up in the parameters, this patch adds struct filtering by converting both maps and stucts to lists, and then filtering those. 

It also includes a general cleanup in the tests for `MapFilter`, which is contained in c7de233 and includes no structural changes.