### PR TITLE
Temporary workaround for hackney OTP22.1 ssl issue

### DIFF
--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -14,7 +14,7 @@ defmodule Appsignal.Transmitter do
     options =
       case File.stat(ca_file_path) do
         {:ok, %{access: access}} when access in [:read, :read_write] ->
-          {:ok, [ssl_options: [cacertfile: ca_file_path, ciphers: ciphers()]]}
+          {:ok, [ssl_options: [cacertfile: ca_file_path, ciphers: ciphers(), honor_cipher_order: :undefined]]}
 
         {:ok, %{access: access}} ->
           {:error, "File access is #{inspect(access)}"}

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -198,6 +198,13 @@ defmodule Mix.Appsignal.Helper do
         Mix.shell().info("- using proxy from #{var} (#{url})")
         options ++ [proxy: url]
     end
+
+    case System.otp_release() do
+      "22" ->
+        options ++ [honor_cipher_order: :undefined]
+      _ ->
+        options
+    end
   end
 
   defp extract_package(filename) do

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -188,7 +188,7 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp download_options do
-    options = [ssl_options: [cacertfile: priv_path("cacert.pem"), ciphers: ciphers()]]
+    options = [ssl_options: [cacertfile: priv_path("cacert.pem"), ciphers: ciphers(), honor_cipher_order: :undefined]]
 
     case check_proxy() do
       nil ->
@@ -197,13 +197,6 @@ defmodule Mix.Appsignal.Helper do
       {var, url} ->
         Mix.shell().info("- using proxy from #{var} (#{url})")
         options ++ [proxy: url]
-    end
-
-    case System.otp_release() do
-      "22" ->
-        options ++ [honor_cipher_order: :undefined]
-      _ ->
-        options
     end
   end
 


### PR DESCRIPTION
Since the release of OTP22.1 this has been popping up. hackney shouldn't be passing `honor_cipher_order` from the client side anyway to begin with.

Anyway, rather than waiting for the downstream changes to bubble up, here's a pretty straightforward and presumably safe workaround to get going again.

Refer: https://github.com/erlang/otp/commit/124da8950c1fe93ef02cb044157e78798bc2360d#diff-79b520311347e34fac9cffbc4ea373f9R1720, https://github.com/benoitc/hackney/pull/588 and https://github.com/benoitc/hackney/pull/589