### PR TITLE
hackney workaround for honor_cipher_order

### DIFF
--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -14,7 +14,14 @@ defmodule Appsignal.Transmitter do
     options =
       case File.stat(ca_file_path) do
         {:ok, %{access: access}} when access in [:read, :read_write] ->
-          {:ok, [ssl_options: [cacertfile: ca_file_path, ciphers: ciphers()]]}
+          {:ok,
+           [
+             ssl_options: [
+               cacertfile: ca_file_path,
+               ciphers: ciphers(),
+               honor_cipher_order: :undefined
+             ]
+           ]}
 
         {:ok, %{access: access}} ->
           {:error, "File access is #{inspect(access)}"}

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -187,7 +187,13 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp download_options do
-    options = [ssl_options: [cacertfile: priv_path("cacert.pem"), ciphers: ciphers()]]
+    options = [
+      ssl_options: [
+        cacertfile: priv_path("cacert.pem"),
+        ciphers: ciphers(),
+        honor_cipher_order: :undefined
+      ]
+    ]
 
     case check_proxy() do
       nil ->

--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -15,16 +15,26 @@ defmodule Appsignal.TransmitterTest do
   test "uses the default CA certificate" do
     path = Config.ca_file_path()
 
-    assert [_method, _url, _headers, _body, [ssl_options: [cacertfile: ^path, ciphers: _]]] =
-             Transmitter.request(:get, "https://example.com")
+    assert [
+             _method,
+             _url,
+             _headers,
+             _body,
+             [ssl_options: [cacertfile: ^path, ciphers: _, honor_cipher_order: :undefined]]
+           ] = Transmitter.request(:get, "https://example.com")
   end
 
   test "uses the configured CA certificate" do
     path = "priv/cacert.pem"
 
     with_config(%{ca_file_path: path}, fn ->
-      assert [_method, _url, _headers, _body, [ssl_options: [cacertfile: ^path, ciphers: _]]] =
-               Transmitter.request(:get, "https://example.com")
+      assert [
+               _method,
+               _url,
+               _headers,
+               _body,
+               [ssl_options: [cacertfile: ^path, ciphers: _, honor_cipher_order: :undefined]]
+             ] = Transmitter.request(:get, "https://example.com")
     end)
   end
 


### PR DESCRIPTION
In Erlang OTP 22.1 the honor_cipher_order option gives an error. hackney
sets this by default to `true`. Setting it to `:undefined` (and not
`false`) unsets the option so requests made with hackney work again.

Workaround for #512 
Based on #514 