### PR TITLE
Remove honor_cipher_order option

### DIFF
--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -18,8 +18,7 @@ defmodule Appsignal.Transmitter do
            [
              ssl_options: [
                cacertfile: ca_file_path,
-               ciphers: ciphers(),
-               honor_cipher_order: :undefined
+               ciphers: ciphers()
              ]
            ]}
 

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -190,8 +190,7 @@ defmodule Mix.Appsignal.Helper do
     options = [
       ssl_options: [
         cacertfile: priv_path("cacert.pem"),
-        ciphers: ciphers(),
-        honor_cipher_order: :undefined
+        ciphers: ciphers()
       ]
     ]
 

--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -20,7 +20,7 @@ defmodule Appsignal.TransmitterTest do
              _url,
              _headers,
              _body,
-             [ssl_options: [cacertfile: ^path, ciphers: _, honor_cipher_order: :undefined]]
+             [ssl_options: [cacertfile: ^path, ciphers: _]]
            ] = Transmitter.request(:get, "https://example.com")
   end
 
@@ -33,7 +33,7 @@ defmodule Appsignal.TransmitterTest do
                _url,
                _headers,
                _body,
-               [ssl_options: [cacertfile: ^path, ciphers: _, honor_cipher_order: :undefined]]
+               [ssl_options: [cacertfile: ^path, ciphers: _]]
              ] = Transmitter.request(:get, "https://example.com")
     end)
   end


### PR DESCRIPTION
A new hackney version has been released which no longer sets
`honor_cipher_order` to `true` by default. This means we can remove our
workaround. Make sure to upgrade hackney for AppSignal to work.

Workaround introduced in #516 
Related issue #512 