### PR TITLE
Don't match on return from `Transaction.complete/1`

### DIFF
--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -97,7 +97,7 @@ defmodule Appsignal.Instrumentation.Decorators do
     result = body.()
 
     @transaction.finish(transaction)
-    :ok = @transaction.complete(transaction)
+    @transaction.complete(transaction)
 
     result
   end

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -110,7 +110,7 @@ if Appsignal.phoenix?() do
         )
       end
 
-      :ok = @transaction.complete(transaction)
+      @transaction.complete(transaction)
 
       result
     end

--- a/test/appsignal/instrumentation/decorator_test.exs
+++ b/test/appsignal/instrumentation/decorator_test.exs
@@ -140,4 +140,14 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
              }
            ] = FakeTransaction.finished_events(fake_transaction)
   end
+
+  describe "when AppSignal is disabled" do
+    test "does not start a transaction", %{fake_transaction: fake_transaction} do
+      AppsignalTest.Utils.with_config(%{active: false}, fn ->
+        UsingAppsignalDecorators.transaction()
+      end)
+
+      refute FakeTransaction.started_transaction?(fake_transaction)
+    end
+  end
 end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -104,4 +104,17 @@ defmodule Appsignal.Phoenix.ChannelTest do
       assert "[FILTERED]" == FakeTransaction.sample_data(fake_transaction)["params"]["password"]
     end)
   end
+
+  describe "when AppSignal is disabled" do
+    test "does not start a transaction", %{
+      socket: socket,
+      fake_transaction: fake_transaction
+    } do
+      AppsignalTest.Utils.with_config(%{active: false}, fn ->
+        InstrumentedPhoenixChannel.handle_in("instrumented", %{"body" => "Hello, world!"}, socket)
+      end)
+
+      refute FakeTransaction.started_transaction?(fake_transaction)
+    end
+  end
 end


### PR DESCRIPTION
Since 1.11.0, `Appsignal.Transaction.complete/1` can return `nil` if
there was no Transaction to be completed. When AppSignal is disabled and
while using transaction decorators, this could result in a broken
match. This patch removes the match.