### PR TITLE
Move action nil-check to Appsignal.Transaction.set_action/2

### DIFF
--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -77,10 +77,8 @@ if Appsignal.plug?() do
     end
 
     def try_set_action(transaction, conn) do
-      case Appsignal.Plug.extract_action(conn) do
-        nil -> transaction
-        action -> @transaction.set_action(transaction, action)
-      end
+      action = Appsignal.Plug.extract_action(conn)
+      @transaction.set_action(transaction, action)
     end
 
     @doc false

--- a/lib/appsignal/transaction.ex
+++ b/lib/appsignal/transaction.ex
@@ -300,7 +300,7 @@ defmodule Appsignal.Transaction do
   - `action`: This transactions action (`"HomepageController.show"`)
   """
   @spec set_action(Transaction.t() | any(), String.t()) :: Transaction.t() | nil
-  def set_action(%Transaction{} = transaction, action) do
+  def set_action(%Transaction{} = transaction, action) when is_binary(action) do
     :ok = Nif.set_action(transaction.resource, action)
     transaction
   end

--- a/test/appsignal/transaction_test.exs
+++ b/test/appsignal/transaction_test.exs
@@ -518,9 +518,11 @@ defmodule AppsignalTransactionTest do
   end
 
   describe "set_action/2" do
-    test "returns the current transaction" do
-      transaction = Transaction.start("set_action/2", :http_request)
+    setup do
+      [transaction: Transaction.start("set_action/2", :http_request)]
+    end
 
+    test "returns the current transaction", %{transaction: transaction} do
       assert Transaction.set_action(transaction, "GET:/") == transaction
     end
 
@@ -530,6 +532,10 @@ defmodule AppsignalTransactionTest do
 
     test "returns nil for a missing process" do
       assert Transaction.set_action(nil, "GET:/") == nil
+    end
+
+    test "does not fail on a non-string action name", %{transaction: transaction} do
+      assert Transaction.set_action(transaction, nil) == nil
     end
   end
 


### PR DESCRIPTION
Instead of checking wether action names are `nil` in the `Plug` module, this patch moves the check to `Transaction.set_action/2`. This allows the function to be called without having to check it first, like we've seen happening with LiveView requests.