### PR TITLE
Run receiver monitors in receiver process

### DIFF
--- a/test/appsignal/transaction/receiver_test.exs
+++ b/test/appsignal/transaction/receiver_test.exs
@@ -1,0 +1,22 @@
+defmodule Appsignal.Transaction.ReceiverTest do
+  use ExUnit.Case
+  import AppsignalTest.Utils
+  alias Appsignal.{Transaction, Transaction.Receiver, Transaction.ETS}
+
+  test "monitors a process" do
+    task =
+      %Task{pid: pid} =
+      Task.async(fn ->
+        ETS.insert({self(), %Transaction{}, Receiver.monitor(self())})
+      end)
+
+    Task.await(task)
+
+    assert [{^pid, %Appsignal.Transaction{}, reference}] = ETS.lookup(pid)
+    assert is_reference(reference)
+
+    until(fn ->
+      assert [] = ETS.lookup(pid)
+    end)
+  end
+end


### PR DESCRIPTION
As reported in https://github.com/appsignal/appsignal-elixir/issues/524,
a regression in version 1.11.0 caused an issue where rows aren't
properly deleted from the ETS table. This causes slowdowns in
`Appsignal.TransactionRegistry.pids_and_monitor_references/1`.