### PR TITLE
Add transaction_debug configuration option

### DIFF
--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "1d8917f"
+  def version, do: "f6353b4"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "777cf5c54eeb32d9d0d6de48c61f14d977244351a4a9e70c9b30c4221e38012c",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "53865697d5045f82eaed6fe15289474ec42b6c5fb45ffdb5a73ebbfaf13470e3",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "777cf5c54eeb32d9d0d6de48c61f14d977244351a4a9e70c9b30c4221e38012c",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "53865697d5045f82eaed6fe15289474ec42b6c5fb45ffdb5a73ebbfaf13470e3",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "483417f3afbc76b959d68137717b85d44e9dd14c56bad3a44fd370294dc86273",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "74c910cf90caaac59333d1ab1e9168c2d902fdfa32cf5bcd3e556350c4065519",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "483417f3afbc76b959d68137717b85d44e9dd14c56bad3a44fd370294dc86273",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "74c910cf90caaac59333d1ab1e9168c2d902fdfa32cf5bcd3e556350c4065519",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "ad58fec875496aae76c870e5a1abdf37af27e4d237fc791c4820ef8ccfa05586",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "9a19d33d4d752928ad23699fa09885f7d28599347afec53d7c297807abbff748",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "ad58fec875496aae76c870e5a1abdf37af27e4d237fc791c4820ef8ccfa05586",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "9a19d33d4d752928ad23699fa09885f7d28599347afec53d7c297807abbff748",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "dcab7852e81cbacb0a187cb62ce2f583f3ff835fb7c49c09f4e41df64b4b81c5",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "776b03cf465edd355d5babbe9277e6975bad15937a67cf3fb133f93a825e7d5a",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "63cb4ac3d8befaec47eb907b1ff4c6c4af93e39fd7696db783cb6e656dda297c",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "00432083a2366b10d86ad225d804add5d1a1a8669e4b750e5a767e5c51d11036",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "39c006dd131d1ca452ff79ec988688a69823e0abf26ee6966b1639cc42720416",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "596794281ee1fdda4325c747cc29526596905ad871980df8fb55b40243fb0e49",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "39c006dd131d1ca452ff79ec988688a69823e0abf26ee6966b1639cc42720416",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/1d8917f/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "596794281ee1fdda4325c747cc29526596905ad871980df8fb55b40243fb0e49",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/agent.exs
+++ b/agent.exs
@@ -1,48 +1,58 @@
 defmodule Appsignal.Agent do
-  def version, do: "f6353b4"
+  def version, do: "c348132"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "53865697d5045f82eaed6fe15289474ec42b6c5fb45ffdb5a73ebbfaf13470e3",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "cb287c8e2072fe5b8cf14449bd6892989c392d0c651ce339895ae0302cb69785",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "53865697d5045f82eaed6fe15289474ec42b6c5fb45ffdb5a73ebbfaf13470e3",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "cb287c8e2072fe5b8cf14449bd6892989c392d0c651ce339895ae0302cb69785",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "74c910cf90caaac59333d1ab1e9168c2d902fdfa32cf5bcd3e556350c4065519",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "2c3bcd102592bf38fbdb27e7c70502dccbe54a0dc2739a9d54aaa694fcfb41fb",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "74c910cf90caaac59333d1ab1e9168c2d902fdfa32cf5bcd3e556350c4065519",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "2c3bcd102592bf38fbdb27e7c70502dccbe54a0dc2739a9d54aaa694fcfb41fb",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "9a19d33d4d752928ad23699fa09885f7d28599347afec53d7c297807abbff748",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "0add9eed4452feda7fc5e1bbd0acdff32c353e4ea0b5d527959df57deb1bdcb2",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "9a19d33d4d752928ad23699fa09885f7d28599347afec53d7c297807abbff748",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "0add9eed4452feda7fc5e1bbd0acdff32c353e4ea0b5d527959df57deb1bdcb2",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "776b03cf465edd355d5babbe9277e6975bad15937a67cf3fb133f93a825e7d5a",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "d11221c127c00128da16b419c503281407e429c0ea6f5bfe1691640b8e995e4e",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "00432083a2366b10d86ad225d804add5d1a1a8669e4b750e5a767e5c51d11036",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "7ce44dc23c578933ca37a79d244bc367fdc2438408c2a61558adb92bcfebb1fa",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "596794281ee1fdda4325c747cc29526596905ad871980df8fb55b40243fb0e49",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "df5f8b61e6ecca40f349cf5c83d5f37f031850d367793dee90dc56f13974431d",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "596794281ee1fdda4325c747cc29526596905ad871980df8fb55b40243fb0e49",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/f6353b4/appsignal-x86_64-freebsd-all-static.tar.gz"
-      },
+        checksum: "df5f8b61e6ecca40f349cf5c83d5f37f031850d367793dee90dc56f13974431d",
+        download_url:
+          "https://appsignal-agent-releases.global.ssl.fastly.net/c348132/appsignal-x86_64-freebsd-all-static.tar.gz"
+      }
     }
   end
 end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -20,6 +20,7 @@ defmodule Appsignal.Config do
     ignore_namespaces: [],
     send_params: true,
     skip_session_data: false,
+    transaction_debug_mode: false,
     files_world_accessible: true,
     log: "file",
     request_headers: ~w(
@@ -171,6 +172,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_ENABLE_HOST_METRICS" => :enable_host_metrics,
     "APPSIGNAL_ENABLE_MINUTELY_PROBES" => :enable_minutely_probes,
     "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data,
+    "APPSIGNAL_TRANSACTION_DEBUG_MODE" => :transaction_debug_mode,
     "APPSIGNAL_FILES_WORLD_ACCESSIBLE" => :files_world_accessible,
     "APPSIGNAL_REQUEST_HEADERS" => :request_headers,
     "APP_REVISION" => :revision
@@ -184,8 +186,8 @@ defmodule Appsignal.Config do
   @bool_keys ~w(
     APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING
     APPSIGNAL_ENABLE_ALLOCATION_TRACKING APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER
-    APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA APPSIGNAL_FILES_WORLD_ACCESSIBLE
-    APPSIGNAL_SEND_PARAMS APPSIGNAL_ENABLE_MINUTELY_PROBES
+    APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA APPSIGNAL_TRANSACTION_DEBUG_MODE
+    APPSIGNAL_FILES_WORLD_ACCESSIBLE APPSIGNAL_SEND_PARAMS APPSIGNAL_ENABLE_MINUTELY_PROBES
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV)
   @string_list_keys ~w(
@@ -287,6 +289,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")
     Nif.env_put("_APPSIGNAL_RUNNING_IN_CONTAINER", to_string(config[:running_in_container]))
+    Nif.env_put("_APPSIGNAL_TRANSACTION_DEBUG_MODE", to_string(config[:transaction_debug_mode]))
     Nif.env_put("_APPSIGNAL_WORKING_DIR_PATH", to_string(config[:working_dir_path]))
     Nif.env_put("_APPSIGNAL_WORKING_DIRECTORY_PATH", to_string(config[:working_directory_path]))
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -270,6 +270,11 @@ defmodule Appsignal.ConfigTest do
       assert %{skip_session_data: true} = with_config(%{skip_session_data: true}, &init_config/0)
     end
 
+    test "transaction_debug_mode" do
+      assert %{transaction_debug_mode: true} =
+               with_config(%{transaction_debug_mode: true}, &init_config/0)
+    end
+
     test "files_world_accessible" do
       assert %{files_world_accessible: true} =
                with_config(%{files_world_accessible: true}, &init_config/0)
@@ -480,6 +485,13 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_SKIP_SESSION_DATA" => "true"},
                &init_config/0
              ) == default_configuration() |> Map.put(:skip_session_data, true)
+    end
+
+    test "transaction_debug_mode" do
+      assert with_env(
+               %{"APPSIGNAL_TRANSACTION_DEBUG_MODE" => "true"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:transaction_debug_mode, true)
     end
 
     test "files_world_accessible" do
@@ -697,9 +709,9 @@ defmodule Appsignal.ConfigTest do
           hostname: "My hostname",
           http_proxy: "http://10.10.10.10:8888",
           ignore_actions: ~w(
-          ExampleApplication.PageController#ignored
-          ExampleApplication.PageController#also_ignored
-        ),
+            ExampleApplication.PageController#ignored
+            ExampleApplication.PageController#also_ignored
+          ),
           ignore_errors: ~w(VerySpecificError AnotherError),
           ignore_namespaces: ~w(admin private_namespace),
           log: "stdout",
@@ -709,7 +721,8 @@ defmodule Appsignal.ConfigTest do
           working_dir_path: "/tmp/appsignal-deprecated",
           working_directory_path: "/tmp/appsignal",
           files_world_accessible: false,
-          revision: "03bd9e"
+          revision: "03bd9e",
+          transaction_debug_mode: true
         },
         fn ->
           without_logger(&write_to_environment/0)
@@ -742,6 +755,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_WORKING_DIR_PATH") == '/tmp/appsignal-deprecated'
           assert Nif.env_get("_APPSIGNAL_WORKING_DIRECTORY_PATH") == '/tmp/appsignal'
           assert Nif.env_get("_APPSIGNAL_FILES_WORLD_ACCESSIBLE") == 'false'
+          assert Nif.env_get("_APPSIGNAL_TRANSACTION_DEBUG_MODE") == 'true'
           assert Nif.env_get("_APP_REVISION") == '03bd9e'
         end
       )
@@ -779,7 +793,8 @@ defmodule Appsignal.ConfigTest do
           enable_host_metrics: "true",
           env: "prod",
           running_in_container: "false",
-          files_world_accessible: "false"
+          files_world_accessible: "false",
+          transaction_debug_mode: "false"
         },
         fn ->
           write_to_environment()
@@ -790,6 +805,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_ENVIRONMENT") == 'prod'
           assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == 'false'
           assert Nif.env_get("_APPSIGNAL_FILES_WORLD_ACCESSIBLE") == 'false'
+          assert Nif.env_get("_APPSIGNAL_TRANSACTION_DEBUG_MODE") == 'false'
         end
       )
     end
@@ -839,7 +855,8 @@ defmodule Appsignal.ConfigTest do
         connection content-length path-info range request-method request-uri
         server-name server-port server-protocol
       ),
-      ca_file_path: Path.join(:code.priv_dir(:appsignal), "cacert.pem")
+      ca_file_path: Path.join(:code.priv_dir(:appsignal), "cacert.pem"),
+      transaction_debug_mode: false
     }
   end
 


### PR DESCRIPTION
This patch adds the `transaction_debug` and `APPSIGNAL_TRANSACTION_DEBUG_MODE` configuration option, and bumps the agent to f6353b4, which includes the new debug mode.

This will be released as version 1.11.4.