### PR TITLE
Add explicit error handling for Phoenix channels

### DIFF
--- a/lib/appsignal/error_handler.ex
+++ b/lib/appsignal/error_handler.ex
@@ -25,11 +25,7 @@ defmodule Appsignal.ErrorHandler do
   end
 
   def handle_error(%Transaction{} = transaction, error, stack, conn) do
-    {exception, stacktrace} = Error.normalize(error, stack)
-    {reason, message} = Error.metadata(exception)
-    backtrace = Backtrace.from_stacktrace(stacktrace)
-
-    @transaction.set_error(transaction, reason, message, backtrace)
+    set_error(transaction, error, stack)
 
     if @transaction.finish(transaction) == :sample do
       @transaction.set_request_metadata(transaction, conn)
@@ -39,6 +35,15 @@ defmodule Appsignal.ErrorHandler do
   end
 
   def handle_error(_transaction, _error, _stack, _conn), do: :ok
+
+  @spec set_error(Transaction.t(), any(), Exception.stacktrace()) :: Transaction.t()
+  def set_error(transaction, error, stack) do
+    {exception, stacktrace} = Error.normalize(error, stack)
+    {reason, message} = Error.metadata(exception)
+    backtrace = Backtrace.from_stacktrace(stacktrace)
+
+    @transaction.set_error(transaction, reason, message, backtrace)
+  end
 
   def submit_transaction(transaction, reason, message, stack, metadata, conn \\ nil)
 

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -110,8 +110,7 @@ if Appsignal.phoenix?() do
       end
     end
 
-    @spec finish_with_socket(Appsignal.Transaction.t() | nil, Phoenix.Socket.t(), map()) ::
-            :ok | nil
+    @spec finish_with_socket(Transaction.t() | nil, Phoenix.Socket.t(), map()) :: :ok | nil
     defp finish_with_socket(transaction, socket, params) do
       if @transaction.finish(transaction) == :sample do
         transaction

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -108,6 +108,7 @@ if Appsignal.phoenix?() do
           @transaction.set_error(transaction, reason_string, message, backtrace)
 
           finish_with_socket(transaction, socket, params)
+          Appsignal.TransactionRegistry.ignore(self())
           :erlang.raise(kind, reason, stack)
       else
         result ->

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -28,6 +28,7 @@ end
 defmodule Appsignal.Phoenix.ChannelTest do
   use ExUnit.Case
   alias Appsignal.FakeTransaction
+  import AppsignalTest.Utils
 
   setup do
     {:ok, fake_transaction} = Appsignal.FakeTransaction.start_link()
@@ -163,14 +164,14 @@ defmodule Appsignal.Phoenix.ChannelTest do
     end
 
     test "ignores the process' pid" do
-      AppsignalTest.Utils.until(fn ->
+      until(fn ->
         assert Appsignal.TransactionRegistry.lookup(self()) == :ignored
       end)
     end
   end
 
   test "filters parameters", %{socket: socket, fake_transaction: fake_transaction} do
-    AppsignalTest.Utils.with_config(%{filter_parameters: ["password"]}, fn ->
+    with_config(%{filter_parameters: ["password"]}, fn ->
       InstrumentedPhoenixChannel.handle_in("instrumented", %{"password" => "secret"}, socket)
       assert "[FILTERED]" == FakeTransaction.sample_data(fake_transaction)["params"]["password"]
     end)
@@ -181,7 +182,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
       socket: socket,
       fake_transaction: fake_transaction
     } do
-      AppsignalTest.Utils.with_config(%{active: false}, fn ->
+      with_config(%{active: false}, fn ->
         InstrumentedPhoenixChannel.handle_in("instrumented", %{"body" => "Hello, world!"}, socket)
       end)
 

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -161,6 +161,12 @@ defmodule Appsignal.Phoenix.ChannelTest do
                }
              ] = FakeTransaction.errors(fake_transaction)
     end
+
+    test "ignores the process' pid" do
+      AppsignalTest.Utils.until(fn ->
+        assert Appsignal.TransactionRegistry.lookup(self()) == :ignored
+      end)
+    end
   end
 
   test "filters parameters", %{socket: socket, fake_transaction: fake_transaction} do


### PR DESCRIPTION
In current versions of the integration, exceptions raised in channel actions fall through and get picked up by the error handler, which adds the exception to the Transaction that's opened by the channel instrumentation.

This, however, skips setting the environment data, which happens at the end of the Transaction for performance samples. The code never reaches that, as the exception isn't caught.

This patch adds a `try`-block to the channel instrumentation to make sure the error is caught there, and allowing the environment data to be set in the `catch` block.