### PR TITLE
Add Phoenix Telemetry event handler to add Phoenix 1.5 instrumentation

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -38,6 +38,8 @@ defmodule Appsignal do
     initialize()
     add_report_handler()
 
+    if phoenix?(), do: Appsignal.Phoenix.EventHandler.attach()
+
     children = [
       worker(Appsignal.Transaction.Receiver, [], restart: :permanent),
       worker(Appsignal.Transaction.ETS, [], restart: :permanent),

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -1,6 +1,7 @@
 defmodule Appsignal.Phoenix.EventHandler do
   @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 
+  @spec attach() :: :ok | {:error, :already_exists}
   def attach do
     :telemetry.attach_many(
       "appsignal_phoenix_event_handler",
@@ -13,6 +14,7 @@ defmodule Appsignal.Phoenix.EventHandler do
     )
   end
 
+  @spec handle_event(list(atom()), map(), map(), any()) :: Appsignal.Transaction.t() | nil
   def handle_event(
         [:phoenix, :endpoint, :start],
         _measurements,

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -1,0 +1,7 @@
+defmodule Appsignal.Phoenix.EventHandler do
+  @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
+
+  def handle_event([:phoenix, :endpoint, :start], _measurements, _metadata, _config) do
+    @transaction.start_event()
+  end
+end

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -4,4 +4,13 @@ defmodule Appsignal.Phoenix.EventHandler do
   def handle_event([:phoenix, :endpoint, :start], _measurements, _metadata, _config) do
     @transaction.start_event()
   end
+
+  def handle_event([:phoenix, :endpoint, :stop], _measurements, _metadata, _config) do
+    @transaction.finish_event(
+      "call.phoenix_endpoint",
+      "call.phoenix_endpoint",
+      nil,
+      0
+    )
+  end
 end

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -38,12 +38,12 @@ defmodule Appsignal.Phoenix.EventHandler do
       transaction,
       "call.phoenix_endpoint",
       "call.phoenix_endpoint",
-      nil,
+      %{},
       0
     )
   end
 
   def handle_event([:phoenix, :endpoint, :stop], _measurements, _metadata, _config) do
-    @transaction.finish_event("call.phoenix_endpoint", "call.phoenix_endpoint", nil, 0)
+    @transaction.finish_event("call.phoenix_endpoint", "call.phoenix_endpoint", %{}, 0)
   end
 end

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -1,6 +1,18 @@
 defmodule Appsignal.Phoenix.EventHandler do
   @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 
+  def attach do
+    :telemetry.attach_many(
+      "appsignal_phoenix_event_handler",
+      [
+        [:phoenix, :endpoint, :start],
+        [:phoenix, :endpoint, :stop]
+      ],
+      &Appsignal.Phoenix.EventHandler.handle_event/4,
+      nil
+    )
+  end
+
   def handle_event([:phoenix, :endpoint, :start], _measurements, _metadata, _config) do
     @transaction.start_event()
   end

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -13,16 +13,35 @@ defmodule Appsignal.Phoenix.EventHandler do
     )
   end
 
+  def handle_event(
+        [:phoenix, :endpoint, :start],
+        _measurements,
+        %{conn: %Plug.Conn{private: %{appsignal_transaction: transaction}}},
+        _config
+      ) do
+    @transaction.start_event(transaction)
+  end
+
   def handle_event([:phoenix, :endpoint, :start], _measurements, _metadata, _config) do
     @transaction.start_event()
   end
 
-  def handle_event([:phoenix, :endpoint, :stop], _measurements, _metadata, _config) do
+  def handle_event(
+        [:phoenix, :endpoint, :stop],
+        _measurements,
+        %{conn: %Plug.Conn{private: %{appsignal_transaction: transaction}}},
+        _config
+      ) do
     @transaction.finish_event(
+      transaction,
       "call.phoenix_endpoint",
       "call.phoenix_endpoint",
       nil,
       0
     )
+  end
+
+  def handle_event([:phoenix, :endpoint, :stop], _measurements, _metadata, _config) do
+    @transaction.finish_event("call.phoenix_endpoint", "call.phoenix_endpoint", nil, 0)
   end
 end

--- a/lib/appsignal/phoenix/instrumenter.ex
+++ b/lib/appsignal/phoenix/instrumenter.ex
@@ -52,8 +52,7 @@ if Appsignal.phoenix?() do
       Appsignal.TransactionRegistry.lookup(self())
     end
 
-    defp start_event(%Appsignal.Transaction{} = transaction, %{conn: conn} = args) do
-      @transaction.set_action(Appsignal.Plug.extract_action(conn))
+    defp start_event(%Appsignal.Transaction{} = transaction, args) do
       {@transaction.start_event(transaction), args}
     end
 

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -43,10 +43,6 @@ if Appsignal.plug?() do
                    Appsignal.Transaction
                  )
 
-    def handle_error(_conn, kind, %{plug_status: status} = reason, stack) when status < 500 do
-      :erlang.raise(kind, reason, stack)
-    end
-
     def handle_error(_conn, :error, %Plug.Conn.WrapperError{} = original_reason, _stack) do
       %{conn: conn, kind: kind, reason: reason, stack: stack} = original_reason
       do_handle_error(reason, stack, conn)
@@ -59,6 +55,8 @@ if Appsignal.plug?() do
 
       :erlang.raise(kind, reason, stack)
     end
+
+    defp do_handle_error(%{plug_status: status}, _stack, _conn) when status < 500, do: :ok
 
     defp do_handle_error(
            error,

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -14,10 +14,7 @@ if Appsignal.plug?() do
 
         def call(conn, opts) do
           if Appsignal.Config.active?() do
-            transaction =
-              @transaction.generate_id()
-              |> @transaction.start(:http_request)
-              |> Appsignal.Plug.try_set_action(conn)
+            transaction = @transaction.start(@transaction.generate_id(), :http_request)
 
             conn =
               conn
@@ -69,6 +66,8 @@ if Appsignal.plug?() do
     defp do_handle_error(_exception, _stack, _conn), do: :ok
 
     def finish_with_conn(transaction, conn) do
+      try_set_action(transaction, conn)
+
       if @transaction.finish(transaction) == :sample do
         @transaction.set_request_metadata(transaction, conn)
       end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -63,8 +63,9 @@ if Appsignal.plug?() do
            stack,
            %Plug.Conn{private: %{appsignal_transaction: transaction}} = conn
          ) do
-      Appsignal.ErrorHandler.handle_error(transaction, error, stack, conn)
       Appsignal.TransactionRegistry.ignore(self())
+      Appsignal.ErrorHandler.set_error(transaction, error, stack)
+      finish_with_conn(transaction, conn)
     end
 
     defp do_handle_error(_exception, _stack, _conn), do: :ok

--- a/mix.exs
+++ b/mix.exs
@@ -107,7 +107,8 @@ defmodule Appsignal.Mixfile do
       {:plug_cowboy, "~> 1.0", only: [:test, :test_phoenix, :test_no_nif]},
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},
       {:credo, "~> 1.0.0", only: [:test, :dev], runtime: false},
-      {:dialyxir, "~> 1.0.0-rc4", only: [:dev], runtime: false}
+      {:dialyxir, "~> 1.0.0-rc4", only: [:dev], runtime: false},
+      {:telemetry, "~> 0.4"}
     ]
   end
 end

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -125,7 +125,7 @@ defmodule Appsignal.PlugTest do
       conn: conn,
       fake_transaction: fake_transaction
     } do
-      assert conn == FakeTransaction.request_metadata(fake_transaction)
+      assert %{conn | state: :set} == FakeTransaction.request_metadata(fake_transaction)
     end
 
     test "completes the transaction", %{fake_transaction: fake_transaction} do
@@ -505,13 +505,6 @@ defmodule Appsignal.PlugTest do
                  []
                }
              ] == FakeTransaction.errors(fake_transaction)
-    end
-
-    test "sets the transaction's request metdata", %{
-      fake_transaction: fake_transaction,
-      conn: conn
-    } do
-      assert conn == FakeTransaction.request_metadata(fake_transaction)
     end
   end
 

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -238,23 +238,23 @@ defmodule Appsignal.PlugTest do
     end
   end
 
-  # describe "for a transaction with a bad request error" do
-  #   setup do
-  #     [conn: conn(:get, "/bad_request", "")]
-  #   end
+  describe "for a transaction with a bad request error" do
+    setup do
+      [conn: conn(:get, "/bad_request", "")]
+    end
 
-  #   test "does not set the transaction error", %{conn: conn, fake_transaction: fake_transaction} do
-  #     :ok =
-  #       try do
-  #         PlugWithAppSignal.call(conn, %{})
-  #       catch
-  #         :error, %Plug.Conn.WrapperError{reason: %Plug.BadRequestError{}} -> :ok
-  #         type, reason -> {type, reason}
-  #       end
+    test "does not set the transaction error", %{conn: conn, fake_transaction: fake_transaction} do
+      :ok =
+        try do
+          PlugWithAppSignal.call(conn, %{})
+        catch
+          :error, %Plug.Conn.WrapperError{reason: %Plug.BadRequestError{}} -> :ok
+          type, reason -> {type, reason}
+        end
 
-  #     assert [] = FakeTransaction.errors(fake_transaction)
-  #   end
-  # end
+      assert [] = FakeTransaction.errors(fake_transaction)
+    end
+  end
 
   describe "for a wrapped undefined error" do
     setup do

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -1,0 +1,42 @@
+defmodule Appsignal.Phoenix.EventHandlerTest do
+  use ExUnit.Case, async: true
+  alias Appsignal.FakeTransaction
+
+  setup do
+    {:ok, fake_transaction} = FakeTransaction.start_link()
+
+    :telemetry.attach_many(
+      "event_handler_test",
+      [
+        [:phoenix, :endpoint, :start],
+        [:phoenix, :endpoint, :stop]
+      ],
+      &Appsignal.Phoenix.EventHandler.handle_event/4,
+      nil
+    )
+
+    [
+      fake_transaction: fake_transaction,
+      transaction: Appsignal.Transaction.start("test", :http_request)
+    ]
+  end
+
+  describe "after receiving an endpoint-start event" do
+    setup :start_event
+
+    test "starts an event", %{fake_transaction: fake_transaction, transaction: transaction} do
+      assert FakeTransaction.started_events(fake_transaction) == [transaction]
+    end
+  end
+
+  defp start_event(_) do
+    :telemetry.execute(
+      [:phoenix, :endpoint, :start],
+      %{time: -576_460_736_044_040_000},
+      %{
+        conn: %Plug.Conn{},
+        options: []
+      }
+    )
+  end
+end

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -29,10 +29,37 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
   end
 
+  describe "after receiving an endpoint-start and an endpoint-stop event" do
+    setup [:start_event, :finish_event]
+
+    test "finishes an event", %{fake_transaction: fake_transaction, transaction: transaction} do
+      assert FakeTransaction.finished_events(fake_transaction) == [
+               %{
+                 body: nil,
+                 body_format: 0,
+                 name: "call.phoenix_endpoint",
+                 title: "call.phoenix_endpoint",
+                 transaction: transaction
+               }
+             ]
+    end
+  end
+
   defp start_event(_) do
     :telemetry.execute(
       [:phoenix, :endpoint, :start],
       %{time: -576_460_736_044_040_000},
+      %{
+        conn: %Plug.Conn{},
+        options: []
+      }
+    )
+  end
+
+  defp finish_event(_) do
+    :telemetry.execute(
+      [:phoenix, :endpoint, :stop],
+      %{duration: 49_474_000},
       %{
         conn: %Plug.Conn{},
         options: []

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -5,16 +5,6 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
   setup do
     {:ok, fake_transaction} = FakeTransaction.start_link()
 
-    :telemetry.attach_many(
-      "event_handler_test",
-      [
-        [:phoenix, :endpoint, :start],
-        [:phoenix, :endpoint, :stop]
-      ],
-      &Appsignal.Phoenix.EventHandler.handle_event/4,
-      nil
-    )
-
     [
       fake_transaction: fake_transaction,
       transaction: Appsignal.Transaction.start("test", :http_request)

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -5,14 +5,11 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
   setup do
     {:ok, fake_transaction} = FakeTransaction.start_link()
 
-    [
-      fake_transaction: fake_transaction,
-      transaction: Appsignal.Transaction.start("test", :http_request)
-    ]
+    [fake_transaction: fake_transaction]
   end
 
   describe "after receiving an endpoint-start event" do
-    setup :start_event
+    setup [:start_transaction, :start_event]
 
     test "starts an event", %{fake_transaction: fake_transaction, transaction: transaction} do
       assert FakeTransaction.started_events(fake_transaction) == [transaction]
@@ -20,7 +17,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
   end
 
   describe "after receiving an endpoint-start and an endpoint-stop event" do
-    setup [:start_event, :finish_event]
+    setup [:start_transaction, :start_event, :finish_event]
 
     test "finishes an event", %{fake_transaction: fake_transaction, transaction: transaction} do
       assert FakeTransaction.finished_events(fake_transaction) == [
@@ -33,6 +30,10 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
                }
              ]
     end
+  end
+
+  defp start_transaction(_) do
+    [transaction: Appsignal.Transaction.start("test", :http_request)]
   end
 
   defp start_event(_) do

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -16,8 +16,32 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
   end
 
+  describe "after receiving an endpoint-start event with a transaction in the conn" do
+    setup [:start_event_with_transaction_in_conn]
+
+    test "starts an event", %{fake_transaction: fake_transaction, transaction: transaction} do
+      assert FakeTransaction.started_events(fake_transaction) == [transaction]
+    end
+  end
+
   describe "after receiving an endpoint-start and an endpoint-stop event" do
     setup [:start_transaction, :start_event, :finish_event]
+
+    test "finishes an event", %{fake_transaction: fake_transaction, transaction: transaction} do
+      assert FakeTransaction.finished_events(fake_transaction) == [
+               %{
+                 body: nil,
+                 body_format: 0,
+                 name: "call.phoenix_endpoint",
+                 title: "call.phoenix_endpoint",
+                 transaction: transaction
+               }
+             ]
+    end
+  end
+
+  describe "after receiving an endpoint-stop event with a transaction in the conn" do
+    setup [:finish_event_with_transaction_in_conn]
 
     test "finishes an event", %{fake_transaction: fake_transaction, transaction: transaction} do
       assert FakeTransaction.finished_events(fake_transaction) == [
@@ -36,23 +60,47 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     [transaction: Appsignal.Transaction.start("test", :http_request)]
   end
 
-  defp start_event(_) do
+  defp start_event_with_transaction_in_conn(_) do
+    transaction = %Appsignal.Transaction{}
+
+    %Plug.Conn{}
+    |> Plug.Conn.put_private(:appsignal_transaction, transaction)
+    |> do_start_event()
+
+    [transaction: transaction]
+  end
+
+  defp start_event(_), do: do_start_event()
+
+  defp do_start_event(conn \\ %Plug.Conn{}) do
     :telemetry.execute(
       [:phoenix, :endpoint, :start],
       %{time: -576_460_736_044_040_000},
       %{
-        conn: %Plug.Conn{},
+        conn: conn,
         options: []
       }
     )
   end
 
-  defp finish_event(_) do
+  defp finish_event_with_transaction_in_conn(_) do
+    transaction = %Appsignal.Transaction{}
+
+    %Plug.Conn{}
+    |> Plug.Conn.put_private(:appsignal_transaction, transaction)
+    |> do_finish_event()
+
+    [transaction: transaction]
+  end
+
+  defp finish_event(_), do: do_finish_event()
+
+  defp do_finish_event(conn \\ %Plug.Conn{}) do
     :telemetry.execute(
       [:phoenix, :endpoint, :stop],
       %{duration: 49_474_000},
       %{
-        conn: %Plug.Conn{},
+        conn: conn,
         options: []
       }
     )

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -30,7 +30,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     test "finishes an event", %{fake_transaction: fake_transaction, transaction: transaction} do
       assert FakeTransaction.finished_events(fake_transaction) == [
                %{
-                 body: nil,
+                 body: %{},
                  body_format: 0,
                  name: "call.phoenix_endpoint",
                  title: "call.phoenix_endpoint",
@@ -46,7 +46,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     test "finishes an event", %{fake_transaction: fake_transaction, transaction: transaction} do
       assert FakeTransaction.finished_events(fake_transaction) == [
                %{
-                 body: nil,
+                 body: %{},
                  body_format: 0,
                  name: "call.phoenix_endpoint",
                  title: "call.phoenix_endpoint",

--- a/test/phoenix/instrumenter_test.exs
+++ b/test/phoenix/instrumenter_test.exs
@@ -21,17 +21,6 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
              Instrumenter.phoenix_controller_call(:start, nil, arguments)
   end
 
-  test "sets the action name in phoenix_controller_call", %{
-    conn: conn,
-    fake_transaction: fake_transaction
-  } do
-    transaction = Transaction.start("test", :http_request)
-    arguments = %{conn: conn, transaction: transaction}
-
-    Instrumenter.phoenix_controller_call(:start, nil, arguments)
-    assert "foo#bar" == FakeTransaction.action(fake_transaction)
-  end
-
   test "does not start an event in phoenix_controller_call without a transaction", %{
     conn: conn,
     fake_transaction: fake_transaction

--- a/test/support/appsignal/fake_transaction.ex
+++ b/test/support/appsignal/fake_transaction.ex
@@ -31,6 +31,12 @@ defmodule Appsignal.FakeTransaction do
     transaction
   end
 
+  def finish_event(name, title, body, body_format) do
+    self()
+    |> Appsignal.TransactionRegistry.lookup()
+    |> finish_event(name, title, body, body_format)
+  end
+
   def finish_event(transaction, name, title, body, body_format) do
     Agent.update(__MODULE__, fn state ->
       {_, new_state} =


### PR DESCRIPTION
Phoenix 1.5 [removes the instrumentation API](https://github.com/phoenixframework/phoenix/commit/19b0b01e2fc751901e06fcd74db1fc5b39672d26) in favour of using Telemetry. This pull request adds a Telemetry event handler that catches `[:phoenix, :endpoint, :start]` and `[:phoenix, :endpoint, :stop]` events to create an event named `call.endpoint`, which is comparable to `call.controller` in the current version.

> Before version Phoenix version 1.5. AppSignal’s Phoenix instrumentation depended on data from the Phoenix instrumenter, and the installation instructions included a step to attach AppSignal’s instrumenter to your application in your app’s configuration:
> 
> ```
> config :appsignal_phoenix_example, AppsignalPhoenixExampleWeb.Endpoint,
>   #...
>   instrumenters: [Appsignal.Phoenix.Instrumenter]
> ```
> 
> From Phoenix 1.5 on, the old Phoenix instrumentation is deprecated and removed in favor of the new Telemetry-based instrumentation. When upgrading to Phoenix 1.5, you’ll see a warning during compilation when using the old instrumenters:
> 
> ```
> [warn] :instrumenters configuration for AppsignalPhoenixExampleWeb.Endpoint is deprecated and has no effect
> ```
> 
> To switch to the new instrumentation, make sure you’re running version 1.12.0 of the AppSignal integration or higher. Then, remove the instrumenters configuration option from your endpoint configuration.
> 
> The new instrumentation should appear automatically in your samples as an event named `call.phoenix_endpoint`. To gain more insights into your app, you can.

# Reviewing

To review this patch, remove the instrumenter from your configuration like described above, and check to make sure you're still getting endpoint events in AppSignal when you request a controller action. Also, feel free to un-request your review, I've requested reviews for all of you make sure I could find someone with time to test this.

# TODO:
- [x] Take the current Transaction from the conn, instead of doing a lookup for both events
- [x] Set the action name from the endpoint start event
- [x] Make sure the current implementation works with multiple Phoenix apps in an umbrella
- [ ] Determine if the automatic setup (through `EventHandler.attach/0`) works for different application setups