### PR TITLE
Move module name cleanup to Appsignal.Utils, clean up module names from decorators

### DIFF
--- a/lib/appsignal/error.ex
+++ b/lib/appsignal/error.ex
@@ -2,6 +2,7 @@ defmodule Appsignal.Error do
   @moduledoc """
   Functions for extracting information from Elixir exceptions and Erlang errors.
   """
+  import Appsignal.Utils
 
   @spec metadata(Exception.t()) :: {String.t(), String.t()}
   def metadata(exception) do
@@ -54,15 +55,6 @@ defmodule Appsignal.Error do
   defp name(%module{}) do
     module_name(module)
   end
-
-  @spec module_name(atom | String.t()) :: String.t()
-  defp module_name(module) when is_atom(module) do
-    module
-    |> Atom.to_string()
-    |> module_name
-  end
-
-  defp module_name("Elixir." <> module), do: module
 
   defp stacktrace?(stacktrace) when is_list(stacktrace) do
     Enum.all?(stacktrace, &stacktrace_line?/1)

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -36,6 +36,8 @@ defmodule Appsignal.Instrumentation.Decorators do
     transaction_event: 1,
     channel_action: 0
 
+  import Appsignal.Utils
+
   @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 
   @doc false
@@ -48,7 +50,7 @@ defmodule Appsignal.Instrumentation.Decorators do
     quote do
       Appsignal.Instrumentation.Decorators.in_transaction(
         unquote(namespace),
-        unquote("#{context.module}##{context.name}"),
+        unquote("#{module_name(context.module)}##{context.name}"),
         fn -> unquote(body) end
       )
     end
@@ -69,7 +71,7 @@ defmodule Appsignal.Instrumentation.Decorators do
       Appsignal.Instrumentation.Helpers.instrument(
         self(),
         unquote("#{context.name}#{postfix}"),
-        unquote("#{context.module}.#{context.name}"),
+        unquote("#{module_name(context.module)}.#{context.name}"),
         fn -> unquote(body) end
       )
     end
@@ -79,7 +81,7 @@ defmodule Appsignal.Instrumentation.Decorators do
   def channel_action(body, %{args: [action, _payload, socket]} = context) do
     quote do
       Appsignal.Phoenix.Channel.channel_action(
-        unquote(context.module),
+        unquote(module_name(context.module)),
         unquote(action),
         unquote(socket),
         fn -> unquote(body) end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -3,6 +3,7 @@ if Appsignal.plug?() do
     @moduledoc """
     Plug handler for Phoenix requests
     """
+    import Appsignal.Utils
 
     defmacro __using__(_) do
       quote do
@@ -103,7 +104,7 @@ if Appsignal.plug?() do
     def extract_action(%Plug.Conn{
           private: %{phoenix_action: action, phoenix_controller: controller}
         }) do
-      merge_action_and_controller(action, controller)
+      "#{module_name(controller)}##{action}"
     end
 
     def extract_action(%Plug.Conn{private: %{phoenix_endpoint: _}}), do: nil
@@ -155,17 +156,6 @@ if Appsignal.plug?() do
         "request_id" => request_id,
         "http_status_code" => status
       }
-    end
-
-    defp merge_action_and_controller(action, controller) when is_atom(controller) do
-      merge_action_and_controller(
-        action,
-        controller |> Atom.to_string() |> String.trim_leading("Elixir.")
-      )
-    end
-
-    defp merge_action_and_controller(action, controller) do
-      "#{controller}##{action}"
     end
 
     defp url(%Plug.Conn{scheme: scheme, host: host, port: port, request_path: request_path}) do

--- a/lib/appsignal/utils.ex
+++ b/lib/appsignal/utils.ex
@@ -1,0 +1,19 @@
+defmodule Appsignal.Utils do
+  @doc """
+  Converts module name atoms to strings.
+
+  ## Examples
+
+      iex> Appsignal.Utils.module_name(MyModule)
+      "MyModule"
+      iex> Appsignal.Utils.module_name("MyModule")
+      "MyModule"
+
+  """
+  @spec module_name(atom() | String.t()) :: String.t()
+  def module_name("Elixir." <> module), do: module
+
+  def module_name(module) when is_binary(module), do: module
+
+  def module_name(module), do: module |> to_string() |> module_name()
+end

--- a/test/appsignal/instrumentation/decorator_test.exs
+++ b/test/appsignal/instrumentation/decorator_test.exs
@@ -56,8 +56,8 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
     assert [{"123", :http_request}] = FakeTransaction.started_transactions(fake_transaction)
 
     assert [
-             %{title: "Elixir.UsingAppsignalDecorators.bar"},
-             %{title: "Elixir.UsingAppsignalDecorators.nested"}
+             %{title: "UsingAppsignalDecorators.bar"},
+             %{title: "UsingAppsignalDecorators.nested"}
            ] = FakeTransaction.finished_events(fake_transaction)
   end
 
@@ -71,14 +71,14 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
                body: "",
                body_format: 0,
                name: "bar",
-               title: "Elixir.UsingAppsignalDecorators.bar",
+               title: "UsingAppsignalDecorators.bar",
                transaction: ^transaction
              },
              %{
                body: "",
                body_format: 0,
                name: "nested",
-               title: "Elixir.UsingAppsignalDecorators.nested",
+               title: "UsingAppsignalDecorators.nested",
                transaction: ^transaction
              }
            ] = FakeTransaction.finished_events(fake_transaction)
@@ -88,8 +88,7 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
     UsingAppsignalDecorators.transaction()
     assert [{"123", :http_request}] = FakeTransaction.started_transactions(fake_transaction)
 
-    assert "Elixir.UsingAppsignalDecorators#transaction" =
-             FakeTransaction.action(fake_transaction)
+    assert "UsingAppsignalDecorators#transaction" = FakeTransaction.action(fake_transaction)
 
     assert [transaction] = FakeTransaction.finished_transactions(fake_transaction)
     assert [^transaction] = FakeTransaction.completed_transactions(fake_transaction)
@@ -99,7 +98,7 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
     UsingAppsignalDecorators.background_transaction()
     assert [{"123", :background_job}] = FakeTransaction.started_transactions(fake_transaction)
 
-    assert "Elixir.UsingAppsignalDecorators#background_transaction" =
+    assert "UsingAppsignalDecorators#background_transaction" =
              FakeTransaction.action(fake_transaction)
 
     assert [transaction] = FakeTransaction.finished_transactions(fake_transaction)
@@ -111,7 +110,7 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
     assert 246 == result
     assert [{"123", :http_request}] = FakeTransaction.started_transactions(fake_transaction)
 
-    assert "Elixir.UsingAppsignalDecorators#transaction_with_return_value" =
+    assert "UsingAppsignalDecorators#transaction_with_return_value" =
              FakeTransaction.action(fake_transaction)
 
     assert [transaction] = FakeTransaction.finished_transactions(fake_transaction)
@@ -128,14 +127,14 @@ defmodule Appsignal.Instrumentation.DecoratorsTest do
                body: "",
                body_format: 0,
                name: "bar.http",
-               title: "Elixir.UsingAppsignalDecoratorsWithCustomNamespaces.bar",
+               title: "UsingAppsignalDecoratorsWithCustomNamespaces.bar",
                transaction: ^transaction
              },
              %{
                body: "",
                body_format: 0,
                name: "nested.db",
-               title: "Elixir.UsingAppsignalDecoratorsWithCustomNamespaces.nested",
+               title: "UsingAppsignalDecoratorsWithCustomNamespaces.nested",
                transaction: ^transaction
              }
            ] = FakeTransaction.finished_events(fake_transaction)

--- a/test/appsignal/utils_test.exs
+++ b/test/appsignal/utils_test.exs
@@ -1,0 +1,4 @@
+defmodule Appsignal.UtilsTest do
+  use ExUnit.Case, async: true
+  doctest Appsignal.Utils
+end


### PR DESCRIPTION
We currently have two functions that clean up module names, in both `AppSignal.Plug` and `AppSignal.Error`. As reported in #529, module names from the decorators weren't cleaned up.

This patch moves to a single implementation in `Appsignal.Utils`, and uses it from `Plug`, `Error`, and `Decorators`.

Closes #529.