### PR TITLE
Restore handling timeout errors from Plug integration

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -38,6 +38,8 @@ defmodule Appsignal do
     initialize()
     add_report_handler()
 
+    if phoenix?(), do: Appsignal.Phoenix.EventHandler.attach()
+
     children = [
       worker(Appsignal.Transaction.Receiver, [], restart: :permanent),
       worker(Appsignal.Transaction.ETS, [], restart: :permanent),

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -173,7 +173,6 @@ defmodule Appsignal do
 
   ## Examples
       Appsignal.send_error(%RuntimeError{})
-      Appsignal.send_error(%RuntimeError{}, "Oops!")
       Appsignal.send_error(%RuntimeError{}, "", System.stacktrace())
       Appsignal.send_error(%RuntimeError{}, "", [], %{foo: "bar"})
       Appsignal.send_error(%RuntimeError{}, "", [], %{}, %Plug.Conn{})

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -1,0 +1,49 @@
+defmodule Appsignal.Phoenix.EventHandler do
+  @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
+
+  @spec attach() :: :ok | {:error, :already_exists}
+  def attach do
+    :telemetry.attach_many(
+      "appsignal_phoenix_event_handler",
+      [
+        [:phoenix, :endpoint, :start],
+        [:phoenix, :endpoint, :stop]
+      ],
+      &Appsignal.Phoenix.EventHandler.handle_event/4,
+      nil
+    )
+  end
+
+  @spec handle_event(list(atom()), map(), map(), any()) :: Appsignal.Transaction.t() | nil
+  def handle_event(
+        [:phoenix, :endpoint, :start],
+        _measurements,
+        %{conn: %Plug.Conn{private: %{appsignal_transaction: transaction}}},
+        _config
+      ) do
+    @transaction.start_event(transaction)
+  end
+
+  def handle_event([:phoenix, :endpoint, :start], _measurements, _metadata, _config) do
+    @transaction.start_event()
+  end
+
+  def handle_event(
+        [:phoenix, :endpoint, :stop],
+        _measurements,
+        %{conn: %Plug.Conn{private: %{appsignal_transaction: transaction}}},
+        _config
+      ) do
+    @transaction.finish_event(
+      transaction,
+      "call.phoenix_endpoint",
+      "call.phoenix_endpoint",
+      %{},
+      0
+    )
+  end
+
+  def handle_event([:phoenix, :endpoint, :stop], _measurements, _metadata, _config) do
+    @transaction.finish_event("call.phoenix_endpoint", "call.phoenix_endpoint", %{}, 0)
+  end
+end

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -20,13 +20,15 @@ defmodule Appsignal.Phoenix.EventHandler do
   def handle_event(
         [:phoenix, :endpoint, :start],
         _measurements,
-        %{conn: %Plug.Conn{private: %{appsignal_transaction: transaction}}},
+        %{conn: %Plug.Conn{private: %{appsignal_transaction: transaction}} = conn},
         _config
       ) do
+    @transaction.set_action(transaction, Appsignal.Plug.extract_action(conn))
     @transaction.start_event(transaction)
   end
 
-  def handle_event([:phoenix, :endpoint, :start], _measurements, _metadata, _config) do
+  def handle_event([:phoenix, :endpoint, :start], _measurements, %{conn: conn}, _config) do
+    @transaction.set_action(Appsignal.Plug.extract_action(conn))
     @transaction.start_event()
   end
 

--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -3,6 +3,8 @@ defmodule Appsignal.Phoenix.EventHandler do
 
   @spec attach() :: :ok | {:error, :already_exists}
   def attach do
+    :application.ensure_all_started(:telemetry)
+
     :telemetry.attach_many(
       "appsignal_phoenix_event_handler",
       [

--- a/lib/appsignal/phoenix/instrumenter.ex
+++ b/lib/appsignal/phoenix/instrumenter.ex
@@ -52,8 +52,7 @@ if Appsignal.phoenix?() do
       Appsignal.TransactionRegistry.lookup(self())
     end
 
-    defp start_event(%Appsignal.Transaction{} = transaction, %{conn: conn} = args) do
-      @transaction.set_action(Appsignal.Plug.extract_action(conn))
+    defp start_event(%Appsignal.Transaction{} = transaction, args) do
       {@transaction.start_event(transaction), args}
     end
 

--- a/lib/appsignal/phoenix/instrumenter.ex
+++ b/lib/appsignal/phoenix/instrumenter.ex
@@ -25,7 +25,8 @@ if Appsignal.phoenix?() do
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 
     @doc false
-    def phoenix_controller_call(:start, _, args) do
+    def phoenix_controller_call(:start, _, %{conn: conn} = args) do
+      @transaction.set_action(Appsignal.Plug.extract_action(conn))
       start_event(transaction(), args)
     end
 

--- a/lib/appsignal/phoenix/instrumenter.ex
+++ b/lib/appsignal/phoenix/instrumenter.ex
@@ -57,10 +57,6 @@ if Appsignal.phoenix?() do
       {@transaction.start_event(transaction), args}
     end
 
-    defp start_event(%Appsignal.Transaction{} = transaction, args) do
-      {@transaction.start_event(transaction), args}
-    end
-
     defp start_event(_transaction, _args), do: nil
 
     defp finish_event(transaction, name, args) do

--- a/mix.exs
+++ b/mix.exs
@@ -107,7 +107,8 @@ defmodule Appsignal.Mixfile do
       {:plug_cowboy, "~> 1.0", only: [:test, :test_phoenix, :test_no_nif]},
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},
       {:credo, "~> 1.0.0", only: [:test, :dev], runtime: false},
-      {:dialyxir, "~> 1.0.0-rc4", only: [:dev], runtime: false}
+      {:dialyxir, "~> 1.0.0-rc4", only: [:dev], runtime: false},
+      {:telemetry, "~> 0.4"}
     ]
   end
 end

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -1,3 +1,60 @@
+defmodule PlugWithAppSignal do
+  use Plug.Router
+  use Appsignal.Plug
+  use Plug.ErrorHandler
+
+  plug(:match)
+  plug(:dispatch)
+
+  get "/" do
+    send_resp(conn, 200, "Welcome")
+  end
+
+  get "/exception" do
+    raise("Exception!")
+    send_resp(conn, 200, "Welcome")
+  end
+
+  get "/bad_request" do
+    raise %Plug.BadRequestError{}
+    send_resp(conn, 200, "Welcome")
+  end
+
+  get "/undef" do
+    raise %Plug.Conn.WrapperError{
+      kind: :error,
+      reason: :undef,
+      stack: [],
+      conn: %{conn | params: %{"foo" => "bar"}}
+    }
+
+    send_resp(conn, 200, "Welcome")
+  end
+
+  get "/no_transaction" do
+    new_private = Map.delete(conn.private, :appsignal_transaction)
+
+    raise %Plug.Conn.WrapperError{
+      kind: :error,
+      reason: :undef,
+      stack: [],
+      conn: %{conn | private: new_private}
+    }
+
+    send_resp(conn, 200, "Welcome")
+  end
+
+  get "/timeout" do
+    Task.async(fn -> :timer.sleep(10) end) |> Task.await(1)
+
+    send_resp(conn, 200, "Welcome")
+  end
+
+  defp handle_errors(conn, error) do
+    send_resp(conn, conn.status, inspect(error))
+  end
+end
+
 defmodule ModuleWithCall do
   defmacro __using__(_) do
     quote do
@@ -8,41 +65,6 @@ defmodule ModuleWithCall do
       defoverridable call: 2
     end
   end
-end
-
-defmodule UsingAppsignalPlug do
-  def call(%Plug.Conn{private: %{phoenix_action: :exception}}, _opts) do
-    raise("Exception!")
-  end
-
-  def call(%Plug.Conn{private: %{phoenix_action: :timeout}}, _opts) do
-    Task.async(fn -> :timer.sleep(10) end) |> Task.await(1)
-  end
-
-  def call(%Plug.Conn{private: %{phoenix_action: :bad_request}}, _opts) do
-    raise %Plug.BadRequestError{}
-  end
-
-  def call(%Plug.Conn{private: %{phoenix_action: :undef}} = conn, _opts) do
-    raise %Plug.Conn.WrapperError{
-      kind: :error,
-      reason: :undef,
-      stack: [],
-      conn: %{conn | params: %{"foo" => "bar"}}
-    }
-  end
-
-  def call(%Plug.Conn{private: %{phoenix_action: :no_transaction}}, _opts) do
-    raise %Plug.Conn.WrapperError{
-      kind: :error,
-      reason: :undef,
-      stack: [],
-      conn: %Plug.Conn{}
-    }
-  end
-
-  use ModuleWithCall
-  use Appsignal.Plug
 end
 
 defmodule OverridingAppSignalPlug do
@@ -59,6 +81,7 @@ defmodule Appsignal.PlugTest do
   alias Appsignal.FakeTransaction
   import AppsignalTest.Utils
   use ExUnit.Case
+  use Plug.Test
 
   setup do
     {:ok, fake_transaction} = FakeTransaction.start_link()
@@ -68,10 +91,11 @@ defmodule Appsignal.PlugTest do
   describe "for a :sample transaction" do
     setup do
       conn =
-        %Plug.Conn{}
+        :get
+        |> conn("/", "")
         |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
         |> Plug.Conn.put_private(:phoenix_action, :index)
-        |> UsingAppsignalPlug.call(%{})
+        |> PlugWithAppSignal.call([])
 
       [conn: conn]
     end
@@ -80,8 +104,8 @@ defmodule Appsignal.PlugTest do
       assert FakeTransaction.started_transaction?(fake_transaction)
     end
 
-    test "calls super and returns the conn", %{conn: conn} do
-      assert conn.assigns[:called?]
+    test "returns the updated conn", %{conn: conn} do
+      assert conn.state == :sent
     end
 
     test "adds the transaction to the conn", %{conn: conn} do
@@ -101,7 +125,7 @@ defmodule Appsignal.PlugTest do
       conn: conn,
       fake_transaction: fake_transaction
     } do
-      assert conn == FakeTransaction.request_metadata(fake_transaction)
+      assert %{conn | state: :set} == FakeTransaction.request_metadata(fake_transaction)
     end
 
     test "completes the transaction", %{fake_transaction: fake_transaction} do
@@ -114,10 +138,11 @@ defmodule Appsignal.PlugTest do
       FakeTransaction.update(fake_transaction, :finish, :no_sample)
 
       conn =
-        %Plug.Conn{}
+        :get
+        |> conn("/", "")
         |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
         |> Plug.Conn.put_private(:phoenix_action, :index)
-        |> UsingAppsignalPlug.call(%{})
+        |> PlugWithAppSignal.call([])
 
       [conn: conn]
     end
@@ -130,8 +155,9 @@ defmodule Appsignal.PlugTest do
   describe "for a transaction without a Phoenix endpoint" do
     setup do
       conn =
-        %Plug.Conn{method: "GET", request_path: "/foo"}
-        |> UsingAppsignalPlug.call(%{})
+        :get
+        |> conn("/", "")
+        |> PlugWithAppSignal.call([])
 
       [conn: conn]
     end
@@ -144,9 +170,10 @@ defmodule Appsignal.PlugTest do
   describe "for a transaction with a Phoenix endpoint, but no action" do
     setup do
       conn =
-        %Plug.Conn{}
+        :get
+        |> conn("/", "")
         |> Plug.Conn.put_private(:phoenix_endpoint, MyEndpoint)
-        |> UsingAppsignalPlug.call(%{})
+        |> PlugWithAppSignal.call([])
 
       [conn: conn]
     end
@@ -158,18 +185,19 @@ defmodule Appsignal.PlugTest do
 
   describe "for a transaction with an error" do
     setup do
-      conn =
-        %Plug.Conn{params: %{"foo" => "bar"}}
+      try do
+        :get
+        |> conn("/exception", %{"foo" => "bar"})
         |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
         |> Plug.Conn.put_private(:phoenix_action, :exception)
+        |> PlugWithAppSignal.call([])
+      catch
+        :error, %Plug.Conn.WrapperError{reason: %RuntimeError{message: "Exception!"}} ->
+          :ok
 
-      :ok =
-        try do
-          UsingAppsignalPlug.call(conn, %{})
-        catch
-          :error, %RuntimeError{message: "Exception!"} -> :ok
-          type, reason -> {type, reason}
-        end
+        type, reason ->
+          {type, reason}
+      end
     end
 
     test "sets the transaction error", %{fake_transaction: fake_transaction} do
@@ -212,20 +240,15 @@ defmodule Appsignal.PlugTest do
 
   describe "for a transaction with a bad request error" do
     setup do
-      conn =
-        %Plug.Conn{}
-        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-        |> Plug.Conn.put_private(:phoenix_action, :bad_request)
-
-      [conn: conn]
+      [conn: conn(:get, "/bad_request", "")]
     end
 
     test "does not set the transaction error", %{conn: conn, fake_transaction: fake_transaction} do
       :ok =
         try do
-          UsingAppsignalPlug.call(conn, %{})
+          PlugWithAppSignal.call(conn, %{})
         catch
-          :error, %Plug.BadRequestError{} -> :ok
+          :error, %Plug.Conn.WrapperError{reason: %Plug.BadRequestError{}} -> :ok
           type, reason -> {type, reason}
         end
 
@@ -235,19 +258,14 @@ defmodule Appsignal.PlugTest do
 
   describe "for a wrapped undefined error" do
     setup do
-      conn =
-        %Plug.Conn{params: %{"foo" => "bar"}}
-        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-        |> Plug.Conn.put_private(:phoenix_action, :undef)
-
       :ok =
         try do
-          UsingAppsignalPlug.call(conn, %{})
+          :get
+          |> conn("/undef", %{"foo" => "bar"})
+          |> PlugWithAppSignal.call([])
         rescue
           Plug.Conn.WrapperError -> :ok
         end
-
-      [conn: conn]
     end
 
     test "sets the transaction error", %{fake_transaction: fake_transaction} do
@@ -271,19 +289,14 @@ defmodule Appsignal.PlugTest do
 
   describe "for a conn without a transaction" do
     setup do
-      conn =
-        %Plug.Conn{params: %{"foo" => "bar"}}
-        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-        |> Plug.Conn.put_private(:phoenix_action, :no_transaction)
-
       :ok =
         try do
-          UsingAppsignalPlug.call(conn, %{})
+          :get
+          |> conn("/no_transaction")
+          |> PlugWithAppSignal.call([])
         rescue
           Plug.Conn.WrapperError -> :ok
         end
-
-      [conn: conn]
     end
 
     test "does not set a transaction error", %{fake_transaction: fake_transaction} do
@@ -293,10 +306,7 @@ defmodule Appsignal.PlugTest do
 
   describe "for a transaction with an timeout" do
     setup do
-      conn =
-        %Plug.Conn{}
-        |> Plug.Conn.put_private(:phoenix_controller, AppsignalPhoenixExample.PageController)
-        |> Plug.Conn.put_private(:phoenix_action, :timeout)
+      conn = conn(:get, "/timeout")
 
       [conn: conn]
     end
@@ -304,7 +314,7 @@ defmodule Appsignal.PlugTest do
     test "sets the transaction error", %{conn: conn, fake_transaction: fake_transaction} do
       :ok =
         try do
-          UsingAppsignalPlug.call(conn, %{})
+          PlugWithAppSignal.call(conn, [])
         catch
           :exit, {:timeout, {Task, :await, _}} -> :ok
           type, reason -> {type, reason}
@@ -322,7 +332,9 @@ defmodule Appsignal.PlugTest do
     setup do
       conn =
         AppsignalTest.Utils.with_config(%{active: false}, fn ->
-          OverridingAppSignalPlug.call(%Plug.Conn{}, %{})
+          :get
+          |> conn("/", "")
+          |> PlugWithAppSignal.call([])
         end)
 
       [conn: conn]
@@ -332,8 +344,8 @@ defmodule Appsignal.PlugTest do
       refute FakeTransaction.started_transaction?(fake_transaction)
     end
 
-    test "calls super and returns the conn", %{conn: conn} do
-      assert conn.assigns[:called?]
+    test "returns the updated conn", %{conn: conn} do
+      assert conn.state == :sent
     end
   end
 
@@ -493,13 +505,6 @@ defmodule Appsignal.PlugTest do
                  []
                }
              ] == FakeTransaction.errors(fake_transaction)
-    end
-
-    test "sets the transaction's request metdata", %{
-      fake_transaction: fake_transaction,
-      conn: conn
-    } do
-      assert conn == FakeTransaction.request_metadata(fake_transaction)
     end
   end
 

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -114,7 +114,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     )
   end
 
-  defp conn() do
+  defp conn do
     %Plug.Conn{}
     |> Plug.Conn.put_private(:phoenix_controller, "foo")
     |> Plug.Conn.put_private(:phoenix_action, "bar")

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -14,6 +14,10 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     test "starts an event", %{fake_transaction: fake_transaction, transaction: transaction} do
       assert FakeTransaction.started_events(fake_transaction) == [transaction]
     end
+
+    test "sets the action name", %{fake_transaction: fake_transaction} do
+      assert "foo#bar" == FakeTransaction.action(fake_transaction)
+    end
   end
 
   describe "after receiving an endpoint-start event with a transaction in the conn" do
@@ -21,6 +25,10 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
 
     test "starts an event", %{fake_transaction: fake_transaction, transaction: transaction} do
       assert FakeTransaction.started_events(fake_transaction) == [transaction]
+    end
+
+    test "sets the action name", %{fake_transaction: fake_transaction} do
+      assert "foo#bar" == FakeTransaction.action(fake_transaction)
     end
   end
 
@@ -63,7 +71,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
   defp start_event_with_transaction_in_conn(_) do
     transaction = %Appsignal.Transaction{}
 
-    %Plug.Conn{}
+    conn()
     |> Plug.Conn.put_private(:appsignal_transaction, transaction)
     |> do_start_event()
 
@@ -72,7 +80,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
 
   defp start_event(_), do: do_start_event()
 
-  defp do_start_event(conn \\ %Plug.Conn{}) do
+  defp do_start_event(conn \\ conn()) do
     :telemetry.execute(
       [:phoenix, :endpoint, :start],
       %{time: -576_460_736_044_040_000},
@@ -104,5 +112,11 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
         options: []
       }
     )
+  end
+
+  defp conn() do
+    %Plug.Conn{}
+    |> Plug.Conn.put_private(:phoenix_controller, "foo")
+    |> Plug.Conn.put_private(:phoenix_action, "bar")
   end
 end

--- a/test/phoenix/event_handler_test.exs
+++ b/test/phoenix/event_handler_test.exs
@@ -1,0 +1,108 @@
+defmodule Appsignal.Phoenix.EventHandlerTest do
+  use ExUnit.Case, async: true
+  alias Appsignal.FakeTransaction
+
+  setup do
+    {:ok, fake_transaction} = FakeTransaction.start_link()
+
+    [fake_transaction: fake_transaction]
+  end
+
+  describe "after receiving an endpoint-start event" do
+    setup [:start_transaction, :start_event]
+
+    test "starts an event", %{fake_transaction: fake_transaction, transaction: transaction} do
+      assert FakeTransaction.started_events(fake_transaction) == [transaction]
+    end
+  end
+
+  describe "after receiving an endpoint-start event with a transaction in the conn" do
+    setup [:start_event_with_transaction_in_conn]
+
+    test "starts an event", %{fake_transaction: fake_transaction, transaction: transaction} do
+      assert FakeTransaction.started_events(fake_transaction) == [transaction]
+    end
+  end
+
+  describe "after receiving an endpoint-start and an endpoint-stop event" do
+    setup [:start_transaction, :start_event, :finish_event]
+
+    test "finishes an event", %{fake_transaction: fake_transaction, transaction: transaction} do
+      assert FakeTransaction.finished_events(fake_transaction) == [
+               %{
+                 body: %{},
+                 body_format: 0,
+                 name: "call.phoenix_endpoint",
+                 title: "call.phoenix_endpoint",
+                 transaction: transaction
+               }
+             ]
+    end
+  end
+
+  describe "after receiving an endpoint-stop event with a transaction in the conn" do
+    setup [:finish_event_with_transaction_in_conn]
+
+    test "finishes an event", %{fake_transaction: fake_transaction, transaction: transaction} do
+      assert FakeTransaction.finished_events(fake_transaction) == [
+               %{
+                 body: %{},
+                 body_format: 0,
+                 name: "call.phoenix_endpoint",
+                 title: "call.phoenix_endpoint",
+                 transaction: transaction
+               }
+             ]
+    end
+  end
+
+  defp start_transaction(_) do
+    [transaction: Appsignal.Transaction.start("test", :http_request)]
+  end
+
+  defp start_event_with_transaction_in_conn(_) do
+    transaction = %Appsignal.Transaction{}
+
+    %Plug.Conn{}
+    |> Plug.Conn.put_private(:appsignal_transaction, transaction)
+    |> do_start_event()
+
+    [transaction: transaction]
+  end
+
+  defp start_event(_), do: do_start_event()
+
+  defp do_start_event(conn \\ %Plug.Conn{}) do
+    :telemetry.execute(
+      [:phoenix, :endpoint, :start],
+      %{time: -576_460_736_044_040_000},
+      %{
+        conn: conn,
+        options: []
+      }
+    )
+  end
+
+  defp finish_event_with_transaction_in_conn(_) do
+    transaction = %Appsignal.Transaction{}
+
+    %Plug.Conn{}
+    |> Plug.Conn.put_private(:appsignal_transaction, transaction)
+    |> do_finish_event()
+
+    [transaction: transaction]
+  end
+
+  defp finish_event(_), do: do_finish_event()
+
+  defp do_finish_event(conn \\ %Plug.Conn{}) do
+    :telemetry.execute(
+      [:phoenix, :endpoint, :stop],
+      %{duration: 49_474_000},
+      %{
+        conn: conn,
+        options: []
+      }
+    )
+  end
+end

--- a/test/phoenix/instrumenter_test.exs
+++ b/test/phoenix/instrumenter_test.exs
@@ -21,6 +21,17 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
              Instrumenter.phoenix_controller_call(:start, nil, arguments)
   end
 
+  test "sets the action name in phoenix_controller_call", %{
+    conn: conn,
+    fake_transaction: fake_transaction
+  } do
+    transaction = Transaction.start("test", :http_request)
+    arguments = %{conn: conn, transaction: transaction}
+
+    Instrumenter.phoenix_controller_call(:start, nil, arguments)
+    assert "foo#bar" == FakeTransaction.action(fake_transaction)
+  end
+
   test "does not start an event in phoenix_controller_call without a transaction", %{
     conn: conn,
     fake_transaction: fake_transaction

--- a/test/phoenix/instrumenter_test.exs
+++ b/test/phoenix/instrumenter_test.exs
@@ -21,17 +21,6 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
              Instrumenter.phoenix_controller_call(:start, nil, arguments)
   end
 
-  test "sets the action name in phoenix_controller_call", %{
-    conn: conn,
-    fake_transaction: fake_transaction
-  } do
-    transaction = Transaction.start("test", :http_request)
-    arguments = %{conn: conn, transaction: transaction}
-
-    Instrumenter.phoenix_controller_call(:start, nil, arguments)
-    assert "foo#bar" == FakeTransaction.action(fake_transaction)
-  end
-
   test "does not start an event in phoenix_controller_call without a transaction", %{
     conn: conn,
     fake_transaction: fake_transaction

--- a/test/support/appsignal/fake_transaction.ex
+++ b/test/support/appsignal/fake_transaction.ex
@@ -31,6 +31,12 @@ defmodule Appsignal.FakeTransaction do
     transaction
   end
 
+  def finish_event(name, title, body, body_format) do
+    self()
+    |> Appsignal.TransactionRegistry.lookup()
+    |> finish_event(name, title, body, body_format)
+  end
+
   def finish_event(transaction, name, title, body, body_format) do
     Agent.update(__MODULE__, fn state ->
       {_, new_state} =


### PR DESCRIPTION
Instead of having an else-clause in the try-block in the Plug module, https://github.com/appsignal/appsignal-elixir/commit/6e6a9b021ca9c86492b21f7d046516dc53f955a6 added a before_send callback, which is called before sending the response to the client. The callback called ` Appsignal.Plug.finish_with_conn/2`. This worked great for performance samples and regular exceptions, but not for unhandled exits, like process timeouts. That's because an unhandled exit doesn't call out to the before_send callback.

To keep backwards compatibility, the integration will need to pick up these errors. This patch moves the completion of the transaction back to an else-clause, but still sets the action name in the before_send filter. That means the behaviour is now like it was before, while still setting the action name from outside the Phoenix integration.