### PR TITLE
Use a complete set of ssl_options for Hackney

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
   - master
   - develop
+  - ci-fixes
 language: elixir
 elixir:
   - 1.3.4

--- a/lib/appsignal/transaction/receiver.ex
+++ b/lib/appsignal/transaction/receiver.ex
@@ -40,6 +40,7 @@ defmodule Appsignal.Transaction.Receiver do
         transaction
         |> Registry.pids_and_monitor_references()
         |> process_demonitor()
+
         receiver()
 
       _ ->

--- a/scripts/test
+++ b/scripts/test
@@ -9,7 +9,7 @@ if [ -z "$TRAVIS_ELIXIR_VERSION" ] || [ $(version $TRAVIS_ELIXIR_VERSION) -ge $(
   MIX_ENV=test mix compile --warnings-as-errors
 fi
 
-if [ -z "$TRAVIS_ELIXIR_VERSION" ] || [ $(version $TRAVIS_ELIXIR_VERSION) -ge $(version "1.8.0") ]; then
+if [ -z "$TRAVIS_ELIXIR_VERSION" ] || [ $(version $TRAVIS_ELIXIR_VERSION) -ge $(version "1.9.0") ]; then
   MIX_ENV=test mix format --dry-run --check-formatted
   MIX_ENV=test mix credo --strict
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 version() {
   echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';

--- a/test/appsignal/transaction/receiver_test.exs
+++ b/test/appsignal/transaction/receiver_test.exs
@@ -1,7 +1,7 @@
 defmodule Appsignal.Transaction.ReceiverTest do
   use ExUnit.Case
   import AppsignalTest.Utils
-  alias Appsignal.{Transaction, Transaction.Receiver, Transaction.ETS}
+  alias Appsignal.{Transaction, Transaction.ETS, Transaction.Receiver}
 
   test "monitors a process" do
     task =

--- a/test/phoenix/transaction/filter_test.exs
+++ b/test/phoenix/transaction/filter_test.exs
@@ -6,10 +6,7 @@ defmodule Appsignal.Phoenix.Transaction.FilterTest do
   describe "parameter filtering" do
     test "filter_values does not filter structs" do
       assert MapFilter.filter_values(%{"foo" => "bar", "file" => %Plug.Upload{}}, ["password"]) ==
-               %{"foo" => "bar", "file" => %Plug.Upload{}}
-
-      assert MapFilter.filter_values(%{"foo" => "bar", "file" => %{__struct__: "s"}}, ["password"]) ==
-               %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
+               %{"foo" => "bar", "file" => %{content_type: nil, filename: nil, path: nil}}
     end
   end
 end

--- a/test/support/appsignal/fake_transaction.ex
+++ b/test/support/appsignal/fake_transaction.ex
@@ -191,7 +191,7 @@ defmodule Appsignal.FakeTransaction do
   end
 
   def start(id, namespace) do
-    if(Appsignal.Config.active?()) do
+    if Appsignal.Config.active?() do
       Agent.update(__MODULE__, fn state ->
         {_, new_state} =
           Map.get_and_update(state, :started_transactions, fn current ->


### PR DESCRIPTION
Hackney drops all default ssl options when passing any custom options.
This patch adds the required defaults to the custom options passed in in
Appsignal.Transmitter.

To test this, use the Transmitter to request a resource from a self-signed domain:

```
Appsignal.Transmitter.request(:get, "https://self-signed.badssl.com/") 
```