### PR TITLE
Run Elixir 1.10.0-rc.0 on CI, update tests for 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
   - master
   - develop
+  - elixir-1.10
 language: elixir
 elixir:
   - 1.3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ branches:
   only:
   - master
   - develop
-  - elixir-1.10
 language: elixir
 elixir:
   - 1.3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ elixir:
   - 1.7.4
   - 1.8.2
   - 1.9.1
+  - 1.10.0-rc.0
 otp_release:
   - 22.0
   - 21.3
@@ -36,12 +37,15 @@ matrix:
 
     - otp_release: 20.3.8
       elixir: 1.3.4
+    - otp_release: 20.3.8
+      elixir: 1.10.0-rc.0
 
     - otp_release: 19.3
-      elixir: 1.8.2
-
+      elixir: 1.10.0-rc.0
     - otp_release: 19.3
       elixir: 1.9.1
+    - otp_release: 19.3
+      elixir: 1.8.2
   include:
     - otp_release: 18.3
       elixir: 1.5.3

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -84,7 +84,7 @@ defmodule Appsignal.Diagnose.Agent do
           "config" => %{
             "valid" => %{
               :label => "Configuration",
-              :values => %{true => "valid", false => "invalid"}
+              :values => %{true: "valid", false: "invalid"}
             }
           }
         }
@@ -95,7 +95,7 @@ defmodule Appsignal.Diagnose.Agent do
           "boot" => %{
             "started" => %{
               :label => "Started",
-              :values => %{true => "started", false => "not started"}
+              :values => %{true: "started", false: "not started"}
             }
           },
           "host" => %{
@@ -105,13 +105,13 @@ defmodule Appsignal.Diagnose.Agent do
           "config" => %{
             "valid" => %{
               :label => "Configuration",
-              :values => %{true => "valid", false => "invalid"}
+              :values => %{true: "valid", false: "invalid"}
             }
           },
           "logger" => %{
             "started" => %{
               :label => "Logger",
-              :values => %{true => "started", false => "not started"}
+              :values => %{true: "started", false: "not started"}
             }
           },
           "working_directory_stat" => %{
@@ -122,7 +122,7 @@ defmodule Appsignal.Diagnose.Agent do
           "lock_path" => %{
             "created" => %{
               :label => "Lock path",
-              :values => %{true => "writable", false => "not writable"}
+              :values => %{true: "writable", false: "not writable"}
             }
           }
         }

--- a/scripts/test
+++ b/scripts/test
@@ -9,7 +9,7 @@ if [ -z "$TRAVIS_ELIXIR_VERSION" ] || [ $(version $TRAVIS_ELIXIR_VERSION) -ge $(
   MIX_ENV=test mix compile --warnings-as-errors
 fi
 
-if [ -z "$TRAVIS_ELIXIR_VERSION" ] || [ $(version $TRAVIS_ELIXIR_VERSION) -ge $(version "1.9.0") ]; then
+if [ -z "$TRAVIS_ELIXIR_VERSION" ] || [ $(version $TRAVIS_ELIXIR_VERSION) -ge $(version "1.10.0") ]; then
   MIX_ENV=test mix format --dry-run --check-formatted
   MIX_ENV=test mix credo --strict
 fi

--- a/test/appsignal/backtrace_test.exs
+++ b/test/appsignal/backtrace_test.exs
@@ -15,9 +15,8 @@ defmodule Appsignal.BacktraceTest do
       {:erl_internal, :op_type, [:get_stacktrace, 0], [file: 'erl_internal.erl', line: 212]}
     ]
 
-    assert Appsignal.Backtrace.from_stacktrace(stacktrace) == [
-             "(stdlib) erl_internal.erl:212: :erl_internal.op_type/2"
-           ]
+    [line] = Appsignal.Backtrace.from_stacktrace(stacktrace)
+    assert line =~ ~r{\(stdlib( [\w.-]+)?\) erl_internal.erl:212: :erl_internal.op_type/2}
   end
 
   test "handles lists of binaries" do

--- a/test/appsignal/error_handler/error_matcher_test.exs
+++ b/test/appsignal/error_handler/error_matcher_test.exs
@@ -63,7 +63,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     assert_stacktrace(stacktrace, [
       ~r{test\/appsignal\/error_handler\/error_matcher_test.exs:\d+: anonymous fn\/0 in Appsignal.ErrorHandler.ErrorMatcherTest."?test proc_lib.spawn \+ exit"?/1},
-      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
+      ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -84,7 +84,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     assert_stacktrace(stacktrace, [
       ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest."?test proc_lib.spawn \+ erlang.error"?/1},
-      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
+      ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -104,8 +104,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     assert message == "no function clause matching in Float.ceil/2"
 
     assert_stacktrace(stacktrace, [
-      ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
-      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
+      ~r{\(elixir( [\w.-]+)?\) lib/float.ex:\d+: Float.ceil/2},
+      ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -124,7 +124,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     assert_stacktrace(stacktrace, [
       ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest."?test proc_lib.spawn \+ badmatch error"?/1},
-      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
+      ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -143,8 +143,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     if System.otp_release() >= "20" do
       assert_stacktrace(stacktrace, [
-        ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.handle_common_reply/8},
-        ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
+        ~r{\(stdlib( [\w.-]+)?\) gen_server.erl:\d+: :gen_server.handle_common_reply/8},
+        ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
       ])
     else
       assert_stacktrace(stacktrace, [
@@ -170,9 +170,9 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     if System.otp_release() >= "20" do
       assert_stacktrace(stacktrace, [
         ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2},
-        ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
-        ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.handle_msg/6},
-        ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
+        ~r{\(stdlib( [\w.-]+)?\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
+        ~r{\(stdlib( [\w.-]+)?\) gen_server.erl:\d+: :gen_server.handle_msg/6},
+        ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
       ])
     else
       assert_stacktrace(stacktrace, [
@@ -197,11 +197,11 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     if System.otp_release() >= "20" do
       assert_stacktrace(stacktrace, [
-        ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
+        ~r{\(elixir( [\w.-]+)?\) lib/float.ex:\d+: Float.ceil/2},
         ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: Appsignal.ErrorHandler.ErrorMatcherTest.CrashingGenServer.handle_info/2},
-        ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
-        ~r{\(stdlib\) gen_server.erl:\d+: :gen_server.handle_msg/6},
-        ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
+        ~r{\(stdlib( [\w.-]+)?\) gen_server.erl:\d+: :gen_server.try_dispatch/4},
+        ~r{\(stdlib( [\w.-]+)?\) gen_server.erl:\d+: :gen_server.handle_msg/6},
+        ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
       ])
     else
       assert_stacktrace(stacktrace, [
@@ -230,9 +230,9 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     assert message == "no function clause matching in Float.ceil/2"
 
     assert_stacktrace(stacktrace, [
-      ~r{\(elixir\) lib/float.ex:\d+: Float.ceil/2},
-      ~r{\(elixir\) lib/(task/)?supervised.ex:\d+: Task.Supervised\.\w+/2},
-      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
+      ~r{\(elixir( [\w.-]+)?\) lib/float.ex:\d+: Float.ceil/2},
+      ~r{\(elixir( [\w.-]+)?\) lib/(task/)?supervised.ex:\d+: Task.Supervised\.\w+/2},
+      ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p_do_apply/3}
     ])
   end
 
@@ -255,8 +255,8 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
     assert message =~ ~r{^(E|e)rlang error: {:timeout, {Task, :await, \[%Tas...}
 
     assert_stacktrace(stacktrace, [
-      ~r{\(elixir\) lib/task.ex:\d+: Task.await/2},
-      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
+      ~r{\(elixir( [\w.-]+)?\) lib/task.ex:\d+: Task.await/2},
+      ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 
@@ -282,7 +282,7 @@ defmodule Appsignal.ErrorHandler.ErrorMatcherTest do
 
     assert_stacktrace(stacktrace, [
       ~r{test/appsignal/error_handler/error_matcher_test.exs:\d+: anonymous fn/0 in Appsignal.ErrorHandler.ErrorMatcherTest."?test Plug.Conn.WrapperError"?/1},
-      ~r{\(stdlib\) proc_lib.erl:\d+: :proc_lib.init_p/3}
+      ~r{\(stdlib( [\w.-]+)?\) proc_lib.erl:\d+: :proc_lib.init_p/3}
     ])
   end
 


### PR DESCRIPTION
This patch adds Elixir 1.10 to the build matrix on CI, and makes sure to run the formatter on 1.10 (as it's the latest version). It also fixes some assertions caused by updates in Elixir's backtrace lines:

> Elixir 1.10 adds version numbers in the app names in backtrace lines.
> This patch adds an optional version number to all places where a
> backtrace line is asserted on.