### PR TITLE
Set Phoenix 1.5 action names in the EventHandler

### DIFF
--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -86,17 +86,9 @@ if Appsignal.plug?() do
       conn
     end
 
-    def try_set_action(transaction, %Plug.Conn{private: %{appsignal_action: action}}) do
-      @transaction.set_action(transaction, action)
-    end
-
     def try_set_action(transaction, conn) do
       action = Appsignal.Plug.extract_action(conn)
       @transaction.set_action(transaction, action)
-    end
-
-    def set_action(conn, name) do
-      Plug.Conn.put_private(conn, :appsignal_action, name)
     end
 
     @doc false

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -51,14 +51,8 @@ if Appsignal.plug?() do
       :erlang.raise(kind, original_reason, stack)
     end
 
-    def handle_error(
-          %Plug.Conn{private: %{appsignal_transaction: transaction}} = conn,
-          kind,
-          reason,
-          stack
-        ) do
+    def handle_error(%Plug.Conn{private: %{appsignal_transaction: _}} = conn, kind, reason, stack) do
       do_handle_error(reason, stack, conn)
-      Appsignal.Plug.finish_with_conn(transaction, conn)
 
       :erlang.raise(kind, reason, stack)
     end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -92,9 +92,17 @@ if Appsignal.plug?() do
       conn
     end
 
+    def try_set_action(transaction, %Plug.Conn{private: %{appsignal_action: action}}) do
+      @transaction.set_action(transaction, action)
+    end
+
     def try_set_action(transaction, conn) do
       action = Appsignal.Plug.extract_action(conn)
       @transaction.set_action(transaction, action)
+    end
+
+    def set_action(conn, name) do
+      Plug.Conn.put_private(conn, :appsignal_action, name)
     end
 
     @doc false

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -11,9 +11,9 @@ defmodule PlugWithAppSignal do
   end
 
   get "/overwritten" do
-    conn
-    |> Appsignal.Plug.set_action("AppsignalPhoenixExample.PageController#overwritten")
-    |> send_resp(200, "Welcome")
+    Appsignal.FakeTransaction.set_action("AppsignalPhoenixExample.PageController#overwritten")
+
+    send_resp(conn, 200, "Welcome")
   end
 
   get "/exception" do

--- a/test/appsignal/plug_test.exs
+++ b/test/appsignal/plug_test.exs
@@ -10,6 +10,12 @@ defmodule PlugWithAppSignal do
     send_resp(conn, 200, "Welcome")
   end
 
+  get "/overwritten" do
+    conn
+    |> Appsignal.Plug.set_action("AppsignalPhoenixExample.PageController#overwritten")
+    |> send_resp(200, "Welcome")
+  end
+
   get "/exception" do
     raise("Exception!")
     send_resp(conn, 200, "Welcome")
@@ -180,6 +186,22 @@ defmodule Appsignal.PlugTest do
 
     test "does not set the transaction's action name", %{fake_transaction: fake_transaction} do
       assert FakeTransaction.action(fake_transaction) == nil
+    end
+  end
+
+  describe "for a transaction with an overwritten action name" do
+    setup do
+      conn =
+        :get
+        |> conn("/overwritten", "")
+        |> PlugWithAppSignal.call([])
+
+      [conn: conn]
+    end
+
+    test "sets the transaction's action name", %{fake_transaction: fake_transaction} do
+      assert "AppsignalPhoenixExample.PageController#overwritten" ==
+               FakeTransaction.action(fake_transaction)
     end
   end
 

--- a/test/phoenix/instrumenter_test.exs
+++ b/test/phoenix/instrumenter_test.exs
@@ -13,12 +13,16 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
     [conn: conn, fake_transaction: fake_transaction]
   end
 
-  test "starts an event in phoenix_controller_call", %{conn: conn} do
+  test "starts an event in phoenix_controller_call", %{
+    conn: conn,
+    fake_transaction: fake_transaction
+  } do
     transaction = Transaction.start("test", :http_request)
-    arguments = %{conn: conn}
 
-    assert {transaction, arguments} ==
-             Instrumenter.phoenix_controller_call(:start, nil, arguments)
+    assert {^transaction, %{conn: _}} =
+             Instrumenter.phoenix_controller_call(:start, nil, %{conn: conn})
+
+    assert [^transaction] = FakeTransaction.started_events(fake_transaction)
   end
 
   test "sets the action name in phoenix_controller_call", %{
@@ -42,12 +46,16 @@ defmodule Appsignal.Phoenix.InstrumenterTest do
     assert [] == FakeTransaction.started_events(fake_transaction)
   end
 
-  test "starts an event in phoenix_controller_render" do
+  test "starts an event in phoenix_controller_render", %{
+    conn: conn,
+    fake_transaction: fake_transaction
+  } do
     transaction = Transaction.start("test", :http_request)
-    arguments = %{foo: "bar"}
 
-    assert {transaction, arguments} ==
-             Instrumenter.phoenix_controller_render(:start, nil, arguments)
+    assert {^transaction, %{conn: _}} =
+             Instrumenter.phoenix_controller_call(:start, nil, %{conn: conn})
+
+    assert [^transaction] = FakeTransaction.started_events(fake_transaction)
   end
 
   test "does not start an event in phoenix_controller_render without a transaction", %{


### PR DESCRIPTION
After #528, which adds Telemetry-based instrumentation to add support for Phoenix 1.5—which removes the `Phoenix.Instrumenter` module we previously relied on—this patch adds an event handler for `[:phoenix, :router_dispatch, :start]` events, which include the controller and action names in their metadata.

Since this event is called before the action is executed, we can set the action name directly on the Nif, and have it be overwritten in the controller action by calling the same function again later. Also, unwrapped errors (like exits) have their action names properly added if they happen in a controller action.

To test this, use a Phoenix 1.5 application and make sure the action names are set correctly and can be overwitten. Also, make sure errors have the correct action names added. A good app to test with is [appsignal_phoenix_example, in the phoenix-1.5 branch](https://github.com/jeffkreeftmeijer/appsignal-phoenix-example/tree/phoenix-1.5), which is updated to Phoenix 1.5 and depends on this branch of AppSignal for Elixir.