### PR TITLE
Call pids_and_monitor_references/1 from TransactionRegistry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
   - master
   - develop
   - ci-fixes
-  - receiver-references
 language: elixir
 elixir:
   - 1.3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
   - master
   - develop
   - ci-fixes
+  - receiver-references
 language: elixir
 elixir:
   - 1.3.4

--- a/lib/appsignal/transaction/receiver.ex
+++ b/lib/appsignal/transaction/receiver.ex
@@ -6,7 +6,6 @@ defmodule Appsignal.Transaction.Receiver do
   # use Task, restart: :permanent
 
   alias Appsignal.Transaction.ETS
-  alias Appsignal.TransactionRegistry, as: Registry
 
   if Mix.env() in [:test, :test_phoenix, :test_no_nif] do
     @deletion_delay 50
@@ -36,10 +35,8 @@ defmodule Appsignal.Transaction.Receiver do
         send(pid, {:reference, reference})
         receiver()
 
-      {:demonitor, transaction} ->
-        transaction
-        |> Registry.pids_and_monitor_references()
-        |> process_demonitor()
+      {:demonitor, pids_and_monitor_references} ->
+        process_demonitor(pids_and_monitor_references)
 
         receiver()
 

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -78,7 +78,10 @@ defmodule Appsignal.TransactionRegistry do
   @spec remove_transaction(Transaction.t()) :: :ok | {:error, :not_found} | {:error, :no_receiver}
   def remove_transaction(%Transaction{} = transaction) do
     if receiver_alive?() do
-      Receiver.demonitor(transaction)
+      transaction
+      |> pids_and_monitor_references()
+      |> Receiver.demonitor()
+
       remove(transaction)
     else
       {:error, :no_receiver}

--- a/test/appsignal/transaction/receiver_test.exs
+++ b/test/appsignal/transaction/receiver_test.exs
@@ -31,7 +31,7 @@ defmodule Appsignal.Transaction.ReceiverTest do
     end)
   end
 
-  def monitored_processes() do
+  defp monitored_processes do
     {:monitors, monitors} =
       Receiver
       |> Process.whereis()


### PR DESCRIPTION
In #525, which moved the monitors in Transaction.Receiver to their own
processes, the call to demonitor processes was made asyncronous.

Because of this, calling Registry.pids_and_monitor_references/1 from the
Transaction.Receiver could cause a race condition where the entry was
removed from ets before the Receiver could get the monitor references
from the table, preventing monitors from being removed.

For high-throughput apps with multiple Transactions created from the
same process through custom instrumentation, this could cause slow
memory increases because of piling up process monitors.

This patch moves the call to pids_and_monitor_references/1 to the
Registry, making it run synchronously before calling out to the
Receiver, ensuring the record exists when demonitoring processes.

Closes #540.