### PR TITLE
Return the Ecto.LogEntry even if the transaction is nil

### DIFF
--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -94,7 +94,7 @@ defmodule Appsignal.Ecto do
     entry
   end
 
-  defp do_log(_transaction, _entry), do: nil
+  defp do_log(_transaction, entry), do: entry
 
   defp convert_time_unit(time) do
     # Converts the native time to a value in nanoseconds.

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -69,6 +69,12 @@ defmodule Appsignal.EctoTest do
     assert [] == FakeTransaction.recorded_events(fake_transaction)
   end
 
+  test "log_event returns the original Ecto.LogEntry without a Transaction", %{fake_transaction: fake_transaction} do
+    assert %{query: _, result: _} = log_event()
+
+    assert [] == FakeTransaction.recorded_events(fake_transaction)
+  end
+
   defp perform_event do
     Appsignal.Ecto.handle_event(
       [:appsignal_phoenix_example, :repo, :query],

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -69,7 +69,9 @@ defmodule Appsignal.EctoTest do
     assert [] == FakeTransaction.recorded_events(fake_transaction)
   end
 
-  test "log_event returns the original Ecto.LogEntry without a Transaction", %{fake_transaction: fake_transaction} do
+  test "log_event returns the original Ecto.LogEntry without a Transaction", %{
+    fake_transaction: fake_transaction
+  } do
     assert %{query: _, result: _} = log_event()
 
     assert [] == FakeTransaction.recorded_events(fake_transaction)


### PR DESCRIPTION
I am using app signal with Ecto 2.2. When Ecto is configured to use both Appsignal and Ecto.LogEntry as its loggers in a specific order (Appsignal first), then it is possible that an incorrect nil entry gets sent to the Ecto.LogEntry logger:

```
config :my_app, MyApp.Repo,
  loggers: [Appsignal.Ecto, Ecto.LogEntry],
  ...
```
This happens in the case where an Appsignal Transaction is not properly created before an Ecto query is made. This results in the Appsignal.Ecto module trying to lookup a transaction, not finding one, then calling `Appsignal.Ecto.do_log(nil, entry)`. This match of this function is currently returning a nil object, however, it appears that Ecto expects all of its loggers to always return an Ecto.LogEntry, since it passes the result of one logger to the next logger.

Sending a nil to Ecto.LogEntry causes an exception, as it doesn't handle that case.

This PR, in the case of a nil transaction, just returns the original entry that was passed in from Ecto.