### PR TITLE
Reduce calls to pids_and_monitor_references/1 and :ets.match/1

### DIFF
--- a/bench/transaction_match.exs
+++ b/bench/transaction_match.exs
@@ -1,0 +1,15 @@
+alias Appsignal.{Transaction}
+
+1..100_000
+|> Enum.each(fn _ ->
+  Transaction.generate_id()
+  |> Transaction.start(:benchmark)
+end)
+
+Benchee.run(%{
+  "match" => fn ->
+    Transaction.generate_id()
+    |> Transaction.start(:benchmark)
+    |> Transaction.complete()
+  end
+})

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -144,6 +144,6 @@ defmodule Appsignal.TransactionRegistry do
   end
 
   def pids_and_monitor_references(transaction) do
-    ETS.match({:"$1", transaction, :"$2"}) ++ ETS.match({:"$1", transaction})
+    ETS.match({:"$1", transaction, :"$2"})
   end
 end

--- a/lib/appsignal/transaction/registry.ex
+++ b/lib/appsignal/transaction/registry.ex
@@ -78,18 +78,17 @@ defmodule Appsignal.TransactionRegistry do
   @spec remove_transaction(Transaction.t()) :: :ok | {:error, :not_found} | {:error, :no_receiver}
   def remove_transaction(%Transaction{} = transaction) do
     if receiver_alive?() do
-      transaction
-      |> pids_and_monitor_references()
-      |> Receiver.demonitor()
+      pids_and_monitor_references = pids_and_monitor_references(transaction)
 
-      remove(transaction)
+      Receiver.demonitor(pids_and_monitor_references)
+      remove(pids_and_monitor_references)
     else
       {:error, :no_receiver}
     end
   end
 
-  defp remove(transaction) do
-    case pids_and_monitor_references(transaction) do
+  defp remove(pids_and_monitor_references) do
+    case pids_and_monitor_references do
       [[_pid, _reference] | _] = pids_and_refs ->
         delete(pids_and_refs)
 

--- a/test/appsignal/transaction/registry_test.exs
+++ b/test/appsignal/transaction/registry_test.exs
@@ -45,14 +45,6 @@ defmodule Appsignal.Transaction.RegistryTest do
     end
   end
 
-  describe "lookup/1, with an existing transaction without a monitor" do
-    setup :register_transaction_without_monitor
-
-    test "finds an existing transaction by pid", %{transaction: transaction} do
-      assert TransactionRegistry.lookup(self()) == transaction
-    end
-  end
-
   describe "ignore/1" do
     test "is not ignored by default" do
       refute TransactionRegistry.lookup(:c.pid(0, 990, 0)) == :ignored
@@ -118,15 +110,6 @@ defmodule Appsignal.Transaction.RegistryTest do
     end
   end
 
-  describe "remove_transaction/1, with an existing transaction without a monitor" do
-    setup :register_transaction_without_monitor
-
-    test "removes the transaction from the registry", %{transaction: transaction} do
-      assert TransactionRegistry.remove_transaction(transaction) == :ok
-      assert TransactionRegistry.lookup(self()) == nil
-    end
-  end
-
   describe "remove_transaction/1, when the registry is not running" do
     setup [:register_transaction, :terminate_registry]
 
@@ -138,13 +121,6 @@ defmodule Appsignal.Transaction.RegistryTest do
   defp register_transaction(_) do
     transaction = %Transaction{id: Transaction.generate_id()}
     TransactionRegistry.register(transaction)
-
-    [transaction: transaction]
-  end
-
-  def register_transaction_without_monitor(_) do
-    transaction = %Transaction{id: Transaction.generate_id()}
-    true = :ets.insert(:"$appsignal_transaction_registry", {self(), transaction})
 
     [transaction: transaction]
   end


### PR DESCRIPTION
To reduce the time spent looking up Transactions in ETS, this pull request removes backwards compatibility fixes introduced in e8c481f905736ed54402dc5304efd3269cda1574 back in 2018. 

From my testing, this branch speeds the creation and removal of a transaction up to 30K per second, which is a 50% speedup compared to 1.11.7.