### PR TITLE
EventHandler handles router_dispatch events with plug_opts

### DIFF
--- a/lib/appsignal/phoenix/event_handler.ex
+++ b/lib/appsignal/phoenix/event_handler.ex
@@ -25,8 +25,13 @@ defmodule Appsignal.Phoenix.EventHandler do
         _measurements,
         %{plug: controller, plug_opts: action},
         _config
-      ) do
+      )
+      when is_atom(controller) and is_atom(action) do
     @transaction.set_action("#{module_name(controller)}##{action}")
+  end
+
+  def handle_event([:phoenix, :router_dispatch, :start], _measurements, _metadata, _config) do
+    :ok
   end
 
   def handle_event(


### PR DESCRIPTION
As reported in #546, mounted plugs have the ability to pass non-atom
plug_opts. This patch makes sure the Phoenix.EventHandler ignores them
instead of trying to convert the options to an action name.