### PR TITLE
Use `__STACKTRACE__ /0` on Elixir >= 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
   - master
   - develop
+  - system-stacktrace
 language: elixir
 elixir:
   - 1.10.2

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -177,7 +177,7 @@ defmodule Appsignal do
 
   ## Examples
       Appsignal.send_error(%RuntimeError{})
-      Appsignal.send_error(%RuntimeError{}, "", System.stacktrace())
+      Appsignal.send_error(%RuntimeError{}, "", __STACKTRACE__)
       Appsignal.send_error(%RuntimeError{}, "", [], %{foo: "bar"})
       Appsignal.send_error(%RuntimeError{}, "", [], %{}, %Plug.Conn{})
       Appsignal.send_error(%RuntimeError{}, "", [], %{}, nil, fn(transaction) ->

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -19,7 +19,7 @@ defmodule Appsignal.Demo do
   rescue
     error ->
       create_demo_transaction()
-      |> @transaction.set_error("TestError", error.message, System.stacktrace())
+      |> @transaction.set_error("TestError", error.message, Appsignal.Stacktrace.get())
       |> finish_demo_transaction()
   end
 

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -9,6 +9,7 @@ end
 
 defmodule Appsignal.Demo do
   import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
+  require Appsignal.Stacktrace
   @behaviour Appsignal.DemoBehaviour
   @transaction Application.get_env(:appsignal, :appsignal_transaction, Appsignal.Transaction)
 

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -2,6 +2,7 @@ if Appsignal.phoenix?() do
   defmodule Appsignal.Phoenix.Channel do
     alias Appsignal.{ErrorHandler, Stacktrace, Transaction, TransactionRegistry, Utils.MapFilter}
     import Appsignal.Utils
+    require Appsignal.Stacktrace
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Transaction)
 
     @moduledoc """

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -1,6 +1,6 @@
 if Appsignal.phoenix?() do
   defmodule Appsignal.Phoenix.Channel do
-    alias Appsignal.{ErrorHandler, Transaction, TransactionRegistry, Stacktrace, Utils.MapFilter}
+    alias Appsignal.{ErrorHandler, Stacktrace, Transaction, TransactionRegistry, Utils.MapFilter}
     import Appsignal.Utils
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Transaction)
 

--- a/lib/appsignal/phoenix/channel.ex
+++ b/lib/appsignal/phoenix/channel.ex
@@ -1,6 +1,6 @@
 if Appsignal.phoenix?() do
   defmodule Appsignal.Phoenix.Channel do
-    alias Appsignal.{ErrorHandler, Transaction, TransactionRegistry, Utils.MapFilter}
+    alias Appsignal.{ErrorHandler, Transaction, TransactionRegistry, Stacktrace, Utils.MapFilter}
     import Appsignal.Utils
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Transaction)
 
@@ -99,7 +99,7 @@ if Appsignal.phoenix?() do
         function.()
       catch
         kind, reason ->
-          stacktrace = System.stacktrace()
+          stacktrace = Stacktrace.get()
           ErrorHandler.set_error(transaction, reason, stacktrace)
           finish_with_socket(transaction, socket, params)
           TransactionRegistry.ignore(self())

--- a/lib/appsignal/phoenix/live_view.ex
+++ b/lib/appsignal/phoenix/live_view.ex
@@ -1,6 +1,6 @@
 if Appsignal.live_view?() do
   defmodule Appsignal.Phoenix.LiveView do
-    alias Appsignal.{ErrorHandler, Transaction, TransactionRegistry, Utils.MapFilter}
+    alias Appsignal.{ErrorHandler, Transaction, TransactionRegistry, Stacktrace, Utils.MapFilter}
     import Appsignal.Utils
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Transaction)
 
@@ -84,7 +84,7 @@ if Appsignal.live_view?() do
           function.()
         catch
           kind, reason ->
-            stacktrace = System.stacktrace()
+            stacktrace = Stacktrace.get()
             ErrorHandler.set_error(transaction, reason, stacktrace)
             finish_with_socket(transaction, socket, params)
             TransactionRegistry.ignore(self())

--- a/lib/appsignal/phoenix/live_view.ex
+++ b/lib/appsignal/phoenix/live_view.ex
@@ -2,6 +2,7 @@ if Appsignal.live_view?() do
   defmodule Appsignal.Phoenix.LiveView do
     alias Appsignal.{ErrorHandler, Stacktrace, Transaction, TransactionRegistry, Utils.MapFilter}
     import Appsignal.Utils
+    require Appsignal.Stacktrace
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Transaction)
 
     @moduledoc """

--- a/lib/appsignal/phoenix/live_view.ex
+++ b/lib/appsignal/phoenix/live_view.ex
@@ -1,6 +1,6 @@
 if Appsignal.live_view?() do
   defmodule Appsignal.Phoenix.LiveView do
-    alias Appsignal.{ErrorHandler, Transaction, TransactionRegistry, Stacktrace, Utils.MapFilter}
+    alias Appsignal.{ErrorHandler, Stacktrace, Transaction, TransactionRegistry, Utils.MapFilter}
     import Appsignal.Utils
     @transaction Application.get_env(:appsignal, :appsignal_transaction, Transaction)
 

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -25,7 +25,8 @@ if Appsignal.plug?() do
             try do
               super(conn, opts)
             catch
-              kind, reason -> Appsignal.Plug.handle_error(conn, kind, reason, System.stacktrace())
+              kind, reason ->
+                Appsignal.Plug.handle_error(conn, kind, reason, Appsignal.Stacktrace.get())
             else
               conn -> Appsignal.Plug.finish_with_conn(transaction, conn)
             end

--- a/lib/appsignal/plug.ex
+++ b/lib/appsignal/plug.ex
@@ -7,6 +7,8 @@ if Appsignal.plug?() do
 
     defmacro __using__(_) do
       quote do
+        require Appsignal.Stacktrace
+
         @transaction Application.get_env(
                        :appsignal,
                        :appsignal_transaction,

--- a/lib/appsignal/stacktrace.ex
+++ b/lib/appsignal/stacktrace.ex
@@ -1,5 +1,15 @@
 defmodule Appsignal.Stacktrace do
-  def get do
-    :erlang.get_stacktrace()
+  if Version.compare(System.version(), "1.7.0") == :lt do
+    defmacro get do
+      quote do
+        :erlang.get_stacktrace()
+      end
+    end
+  else
+    defmacro get do
+      quote do
+        __STACKTRACE__
+      end
+    end
   end
 end

--- a/lib/appsignal/stacktrace.ex
+++ b/lib/appsignal/stacktrace.ex
@@ -1,0 +1,5 @@
+defmodule Appsignal.Stacktrace do
+  def get do
+    System.stacktrace()
+  end
+end

--- a/lib/appsignal/stacktrace.ex
+++ b/lib/appsignal/stacktrace.ex
@@ -1,5 +1,5 @@
 defmodule Appsignal.Stacktrace do
   def get do
-    System.stacktrace()
+    :erlang.get_stacktrace()
   end
 end

--- a/test/appsignal/stacktrace_test.ex
+++ b/test/appsignal/stacktrace_test.ex
@@ -1,0 +1,29 @@
+defmodule Appsignal.StacktraceTest do
+  use ExUnit.Case
+  alias Appsignal.Stacktrace
+
+  describe "get/0" do
+    setup do
+      raise "Exception!"
+    catch
+      :error, _ ->
+        %{
+          stack: Stacktrace.get(),
+          elixir_stacktrace: __STACKTRACE__,
+          system_stacktrace: System.stacktrace()
+        }
+    end
+
+    test "returns the stacktrace", %{
+      stack: stack,
+      elixir_stacktrace: elixir_stacktrace,
+      system_stacktrace: system_stacktrace
+    } do
+      assert stack == elixir_stacktrace || stack == system_stacktrace
+    end
+
+    test "does not return an empty list", %{stack: stack} do
+      assert length(stack) > 0
+    end
+  end
+end

--- a/test/appsignal/stacktrace_test.exs
+++ b/test/appsignal/stacktrace_test.exs
@@ -10,17 +10,15 @@ defmodule Appsignal.StacktraceTest do
       :error, _ ->
         %{
           stack: Stacktrace.get(),
-          elixir_stacktrace: __STACKTRACE__,
           system_stacktrace: System.stacktrace()
         }
     end
 
     test "returns the stacktrace", %{
       stack: stack,
-      elixir_stacktrace: elixir_stacktrace,
       system_stacktrace: system_stacktrace
     } do
-      assert stack == elixir_stacktrace || stack == system_stacktrace
+      assert stack == system_stacktrace
     end
 
     test "does not return an empty list", %{stack: stack} do

--- a/test/appsignal/stacktrace_test.exs
+++ b/test/appsignal/stacktrace_test.exs
@@ -1,6 +1,7 @@
 defmodule Appsignal.StacktraceTest do
   use ExUnit.Case
   alias Appsignal.Stacktrace
+  require Appsignal.Stacktrace
 
   describe "get/0" do
     setup do


### PR DESCRIPTION
`System.stacktrace/0` was deprecated and replaced with `__STACKTRACE__/0` in Elixir 1.7. Current versions throw deprecation warnings, so we're moving to using the new method on versions that have it available.