### PR TITLE
Filtered data

### DIFF
--- a/agent.exs
+++ b/agent.exs
@@ -1,47 +1,47 @@
 defmodule Appsignal.Agent do
-  def version, do: "e1f368f"
+  def version, do: "a21a12a"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "951dd5f34dcef9d4c6b9194787535c719e7ad90cbbca0b42f878c7e3310ea810",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "cb527ae259925fc9b34574304aa7c14cfd99d01841a09326d0a6d9afb9b2bf6e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "951dd5f34dcef9d4c6b9194787535c719e7ad90cbbca0b42f878c7e3310ea810",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "cb527ae259925fc9b34574304aa7c14cfd99d01841a09326d0a6d9afb9b2bf6e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "60ada4d99e77409a965dd5ddf142d9147499caa631c793bf1ee6cf9ab88d189e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "74908c9dbe97c5d59543d5a63a8882cb74a4931a361e70d875356f6c984fa350",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "60ada4d99e77409a965dd5ddf142d9147499caa631c793bf1ee6cf9ab88d189e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "74908c9dbe97c5d59543d5a63a8882cb74a4931a361e70d875356f6c984fa350",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-i686-linux-all-static.tar.gz"
       },
       "i686-linux-musl" => %{
-        checksum: "3dc981df4390e67e6f27ec51b59168258ffef597bbd491a7b7ec8e4c1f701db8",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "8214cc5022d1840218d5639c6b04ff2676c7c973de2fb9208b5082cfc6686a40",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86-linux-musl" => %{
-        checksum: "3dc981df4390e67e6f27ec51b59168258ffef597bbd491a7b7ec8e4c1f701db8",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-i686-linux-musl-all-static.tar.gz"
+        checksum: "8214cc5022d1840218d5639c6b04ff2676c7c973de2fb9208b5082cfc6686a40",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-i686-linux-musl-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "5c00340c453ea1a3809015c47e2b5138c38350341424ee10a4eb571f1f77f74c",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "8d5601c1266aba83f4a187801d7389e023883f87f6471bfacc856f0695593d53",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "c238799132e2f9127622e9ca8611ff492d2cdc8c3f82138cd5d00a5ef281b2b4",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "9aa456d9ca09650d3f8ab280e48e928890c08e28372fa2f2ef6546003bee4436",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "a5fd97116f64ea349c1ed4ce9b1dacfe77caf81e2a8491116295fe399aac2af9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "e36c16050c733674a7abe47dff54706738b241158c049947892ec1b413bacf01",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "a5fd97116f64ea349c1ed4ce9b1dacfe77caf81e2a8491116295fe399aac2af9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e1f368f/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "e36c16050c733674a7abe47dff54706738b241158c049947892ec1b413bacf01",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/a21a12a/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -592,6 +592,22 @@ static ERL_NIF_TERM _data_map_new(ErlNifEnv* env, int UNUSED(argc), const ERL_NI
   return make_ok_tuple(env, data_ref);
 }
 
+static ERL_NIF_TERM _data_filtered_map_new(ErlNifEnv* env, int UNUSED(argc), const ERL_NIF_TERM UNUSED(argv[])) {
+  data_ptr *ptr;
+  ERL_NIF_TERM data_ref;
+
+  ptr = enif_alloc_resource(appsignal_data_type, sizeof(data_ptr));
+  if(!ptr)
+    return make_error_tuple(env, "no_memory");
+
+  ptr->data = appsignal_data_filtered_map_new();
+
+  data_ref = enif_make_resource(env, ptr);
+  enif_release_resource(ptr);
+
+  return make_ok_tuple(env, data_ref);
+}
+
 static ERL_NIF_TERM _data_set_string(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   data_ptr *ptr;
   ErlNifBinary key, value;
@@ -1372,6 +1388,7 @@ static ErlNifFunc nif_funcs[] =
     {"_increment_counter", 3, _increment_counter, 0},
     {"_add_distribution_value", 3, _add_distribution_value, 0},
     {"_data_map_new", 0, _data_map_new, 0},
+    {"_data_filtered_map_new", 0, _data_filtered_map_new, 0},
     {"_data_set_string", 3, _data_set_string, 0},
     {"_data_set_string", 2, _data_set_string, 0},
     {"_data_set_integer", 3, _data_set_integer, 0},

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -80,10 +80,14 @@ defmodule Appsignal.Config do
     end
   end
 
-  defp merge_filter_data_keys(map, keys) do
+  defp merge_filter_data_keys(map, keys) when is_list(keys) do
     {_, new_map} = Map.get_and_update(map, :filter_data_keys, &{&1, &1 ++ keys})
 
     new_map
+  end
+
+  defp merge_filter_data_keys(map, _keys) do
+    map
   end
 
   @doc """

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -15,6 +15,7 @@ defmodule Appsignal.Config do
     env: :dev,
     filter_parameters: [],
     filter_session_data: [],
+    filter_data_keys: [],
     ignore_actions: [],
     ignore_errors: [],
     ignore_namespaces: [],
@@ -159,6 +160,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_SEND_PARAMS" => :send_params,
     "APPSIGNAL_FILTER_PARAMETERS" => :filter_parameters,
     "APPSIGNAL_FILTER_SESSION_DATA" => :filter_session_data,
+    "APPSIGNAL_FILTER_DATA_KEYS" => :filter_data_keys,
     "APPSIGNAL_DEBUG" => :debug,
     "APPSIGNAL_DNS_SERVERS" => :dns_servers,
     "APPSIGNAL_LOG" => :log,
@@ -192,8 +194,10 @@ defmodule Appsignal.Config do
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(
-    APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS APPSIGNAL_IGNORE_NAMESPACES
-    APPSIGNAL_DNS_SERVERS APPSIGNAL_FILTER_SESSION_DATA APPSIGNAL_REQUEST_HEADERS
+    APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_FILTER_DATA_KEYS
+    APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS
+    APPSIGNAL_IGNORE_NAMESPACES APPSIGNAL_DNS_SERVERS
+    APPSIGNAL_FILTER_SESSION_DATA APPSIGNAL_REQUEST_HEADERS
   )
 
   defp load_from_environment do

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -47,11 +47,14 @@ defmodule Appsignal.Config do
 
     Application.put_env(:appsignal, :config_sources, sources)
 
-    config =
+    {_, config} =
       sources[:default]
       |> Map.merge(sources[:system])
       |> Map.merge(sources[:file])
       |> Map.merge(sources[:env])
+      |> Map.get_and_update(:filter_data_keys, fn current ->
+        {current, current ++ Application.get_env(:phoenix, :filter_parameters, [])}
+      end)
 
     # Config is valid when we have a push api key
     config =

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -297,6 +297,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_TRANSACTION_DEBUG_MODE", to_string(config[:transaction_debug_mode]))
     Nif.env_put("_APPSIGNAL_WORKING_DIR_PATH", to_string(config[:working_dir_path]))
     Nif.env_put("_APPSIGNAL_WORKING_DIRECTORY_PATH", to_string(config[:working_directory_path]))
+    Nif.env_put("_APPSIGNAL_FILTER_DATA_KEYS", config[:filter_data_keys] |> Enum.join(","))
 
     Nif.env_put(
       "_APPSIGNAL_FILES_WORLD_ACCESSIBLE",

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -136,6 +136,10 @@ defmodule Appsignal.Nif do
     _data_map_new()
   end
 
+  def data_filtered_map_new do
+    _data_filtered_map_new()
+  end
+
   def data_set_string(resource, key, value) do
     _data_set_string(resource, key, value)
   end
@@ -377,6 +381,10 @@ defmodule Appsignal.Nif do
   end
 
   def _data_map_new do
+    {:ok, nil}
+  end
+
+  def _data_filtered_map_new do
     {:ok, nil}
   end
 

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -110,7 +110,11 @@ defmodule Appsignal.Span do
 
   def set_sample_data(%Span{reference: reference} = span, key, value)
       when is_binary(key) and is_map(value) do
-    data = Appsignal.Utils.DataEncoder.encode(value)
+    data =
+      value
+      |> Appsignal.Utils.MapFilter.filter()
+      |> Appsignal.Utils.DataEncoder.encode()
+
     :ok = Nif.set_span_sample_data(reference, key, data)
     span
   end

--- a/lib/appsignal/utils/data_encoder.ex
+++ b/lib/appsignal/utils/data_encoder.ex
@@ -12,7 +12,7 @@ defmodule Appsignal.Utils.DataEncoder do
   end
 
   def encode(data) when is_map(data) do
-    {:ok, resource} = Nif.data_map_new()
+    {:ok, resource} = Nif.data_filtered_map_new()
     Enum.each(data, fn item -> encode(resource, item) end)
     resource
   end

--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -2,132 +2,14 @@ defmodule Appsignal.Utils.MapFilter do
   @moduledoc false
   require Logger
 
-  @doc """
-  Filter parameters based on Appsignal and Phoenix configuration.
-  """
-  def filter_parameters(values), do: filter_values(values, get_filter_parameters())
-
-  @doc """
-  Filter session data based Appsignal configuration.
-  """
-  def filter_session_data(values), do: filter_values(values, get_filter_session_data())
-
-  @doc false
-  def filter_values(values, {:discard, params}), do: discard_values(values, params)
-  def filter_values(values, {:keep, params}), do: keep_values(values, params)
-  def filter_values(values, params), do: discard_values(values, params)
-
-  def get_filter_parameters do
-    merge_filters(
-      Application.get_env(:appsignal, :config)[:filter_parameters],
-      Application.get_env(:phoenix, :filter_parameters, [])
-    )
+  def filter(data) do
+    filter(data, Application.get_env(:phoenix, :filter_parameters, []))
   end
 
-  def get_filter_session_data do
-    Application.get_env(:appsignal, :config)[:filter_session_data] || []
+  defp filter(data, {:keep, keys}) do
+    {filtered, _} = Map.split(data, keys)
+    filtered
   end
 
-  defp discard_values(list, filter_keys) when is_list(list) do
-    discard_values(list, filter_keys, [])
-  end
-
-  defp discard_values(%{__struct__: _} = struct, filter_keys) do
-    struct
-    |> Map.from_struct()
-    |> discard_values(filter_keys)
-  end
-
-  defp discard_values(map, filter_keys) when is_map(map) do
-    map
-    |> Map.to_list()
-    |> discard_values(filter_keys, [])
-    |> Enum.into(%{})
-  end
-
-  defp discard_values(value, _filter_keys), do: value
-
-  defp discard_values([{key, value} | tail], filter_keys, acc) do
-    if (is_binary(key) or is_atom(key)) and to_string(key) in filter_keys do
-      discard_values(tail, filter_keys, [{key, "[FILTERED]"} | acc])
-    else
-      discard_values(tail, filter_keys, [{key, discard_values(value, filter_keys)} | acc])
-    end
-  end
-
-  defp discard_values([value | tail], filter_keys, acc) do
-    discard_values(tail, filter_keys, [discard_values(value, filter_keys) | acc])
-  end
-
-  defp discard_values([], _filter_keys, acc), do: acc
-
-  defp keep_values(list, keep_keys) when is_list(list) do
-    keep_values(list, keep_keys, [])
-  end
-
-  defp keep_values(%{__struct__: _} = struct, keep_keys) do
-    struct
-    |> Map.from_struct()
-    |> keep_values(keep_keys)
-  end
-
-  defp keep_values(map, keep_keys) when is_map(map) do
-    map
-    |> Map.to_list()
-    |> keep_values(keep_keys, [])
-    |> Enum.into(%{})
-  end
-
-  defp keep_values(_value, _keep_keys), do: "[FILTERED]"
-
-  defp keep_values([{key, value} | tail], keep_keys, acc) do
-    if (is_binary(key) or is_atom(key)) and to_string(key) in keep_keys do
-      keep_values(tail, keep_keys, [{key, discard_values(value, [])} | acc])
-    else
-      keep_values(tail, keep_keys, [{key, keep_values(value, keep_keys)} | acc])
-    end
-  end
-
-  defp keep_values([value | tail], keep_keys, acc) do
-    keep_values(tail, keep_keys, [keep_values(value, keep_keys) | acc])
-  end
-
-  defp keep_values([], _keep_keys, acc), do: acc
-
-  defp merge_filters(appsignal, phoenix) when is_list(appsignal) and is_list(phoenix) do
-    appsignal ++ phoenix
-  end
-
-  defp merge_filters({:keep, appsignal}, {:keep, phoenix}), do: {:keep, appsignal ++ phoenix}
-
-  defp merge_filters(appsignal, {:keep, phoenix}) when is_list(appsignal) and is_list(phoenix) do
-    {:keep, phoenix -- appsignal}
-  end
-
-  defp merge_filters({:keep, appsignal}, phoenix) when is_list(appsignal) and is_list(phoenix) do
-    {:keep, appsignal -- phoenix}
-  end
-
-  defp merge_filters(appsignal, phoenix) do
-    Logger.error("""
-    An error occured while merging parameter filters.
-
-    AppSignal expects all parameter_filter values to be either a list of
-    strings (`["email"]`), or a :keep-tuple with a list of strings as its
-    second element (`{:keep, ["email"]}`).
-
-    From the AppSignal configuration:
-
-      #{inspect(appsignal)}
-
-    From the Phoenix configuration:
-
-      #{inspect(phoenix)}
-
-    To ensure no sensitive parameters are sent, all parameters are filtered out
-    for this transaction.
-    """)
-
-    {:keep, []}
-  end
+  defp filter(data, _), do: data
 end

--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -7,8 +7,10 @@ defmodule Appsignal.Utils.MapFilter do
   end
 
   defp filter(data, {:keep, keys}) do
-    {filtered, _} = Map.split(data, keys)
-    filtered
+    Enum.into(data, %{}, fn {key, value} ->
+      new_value = if key in keys, do: value, else: "[FILTERED]"
+      {key, new_value}
+    end)
   end
 
   defp filter(data, _), do: data

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -164,6 +164,8 @@ defmodule Mix.Tasks.Appsignal.Install do
   defp write_config_file(config) do
     IO.write("Writing config file config/appsignal.exs: ")
 
+    File.mkdir_p("config")
+
     case File.open(appsignal_config_file_path(), [:write]) do
       {:ok, file} ->
         case IO.binwrite(file, appsignal_config_file_contents(config)) do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -199,6 +199,16 @@ defmodule Appsignal.ConfigTest do
                with_config(%{filter_data_keys: ~w(password secret)}, &init_config/0)
     end
 
+    test "filter_data_keys loaded from the filter_parameters configuration option" do
+      assert %{filter_data_keys: ~w(password secret)} =
+               with_config(%{filter_parameters: ~w(password secret)}, &init_config/0)
+    end
+
+    test "filter_data_keys loaded from the filter_session_data configuration option" do
+      assert %{filter_data_keys: ~w(password secret)} =
+               with_config(%{filter_session_data: ~w(password secret)}, &init_config/0)
+    end
+
     test "filter_data_keys loaded from Phoenix' filter_parameters configuration option" do
       Application.put_env(:phoenix, :filter_parameters, ~w(token))
 
@@ -395,14 +405,24 @@ defmodule Appsignal.ConfigTest do
       assert with_env(
                %{"APPSIGNAL_FILTER_PARAMETERS" => "password,secret"},
                &init_config/0
-             ) == default_configuration() |> Map.put(:filter_parameters, ~w(password secret))
+             ) ==
+               default_configuration()
+               |> Map.merge(%{
+                 filter_data_keys: ~w(password secret),
+                 filter_parameters: ~w(password secret)
+               })
     end
 
     test "filter_session_data" do
       assert with_env(
                %{"APPSIGNAL_FILTER_SESSION_DATA" => "accept,connection"},
                &init_config/0
-             ) == default_configuration() |> Map.put(:filter_session_data, ~w(accept connection))
+             ) ==
+               default_configuration()
+               |> Map.merge(%{
+                 filter_data_keys: ~w(accept connection),
+                 filter_session_data: ~w(accept connection)
+               })
     end
 
     test "filter_data_keys" do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -741,7 +741,8 @@ defmodule Appsignal.ConfigTest do
           working_directory_path: "/tmp/appsignal",
           files_world_accessible: false,
           revision: "03bd9e",
-          transaction_debug_mode: true
+          transaction_debug_mode: true,
+          filter_data_keys: ["password"]
         },
         fn ->
           without_logger(&write_to_environment/0)
@@ -775,6 +776,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_WORKING_DIRECTORY_PATH") == '/tmp/appsignal'
           assert Nif.env_get("_APPSIGNAL_FILES_WORLD_ACCESSIBLE") == 'false'
           assert Nif.env_get("_APPSIGNAL_TRANSACTION_DEBUG_MODE") == 'true'
+          assert Nif.env_get("_APPSIGNAL_FILTER_DATA_KEYS") == 'password'
           assert Nif.env_get("_APP_REVISION") == '03bd9e'
         end
       )

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -217,6 +217,14 @@ defmodule Appsignal.ConfigTest do
       Application.delete_env(:phoenix, :filter_parameters)
     end
 
+    test "ignores Phoenix' filter_parameters :keep-lists" do
+      Application.put_env(:phoenix, :filter_parameters, {:keep, [:token]})
+
+      assert %{filter_data_keys: []} = init_config()
+
+      Application.delete_env(:phoenix, :filter_parameters)
+    end
+
     test "filter_data_keys merges appsignal and phoenix ignored keys" do
       Application.put_env(:phoenix, :filter_parameters, ~w(token))
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -194,6 +194,11 @@ defmodule Appsignal.ConfigTest do
                with_config(%{filter_session_data: ~w(accept connection)}, &init_config/0)
     end
 
+    test "filter_data_keys" do
+      assert %{filter_data_keys: ~w(password secret)} =
+               with_config(%{filter_data_keys: ~w(password secret)}, &init_config/0)
+    end
+
     test "frontend_error_catching_path" do
       assert %{frontend_error_catching_path: "/appsignal_error_catcher"} =
                with_config(
@@ -381,6 +386,13 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_FILTER_SESSION_DATA" => "accept,connection"},
                &init_config/0
              ) == default_configuration() |> Map.put(:filter_session_data, ~w(accept connection))
+    end
+
+    test "filter_data_keys" do
+      assert with_env(
+               %{"APPSIGNAL_FILTER_DATA_KEYS" => "password,secret"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:filter_data_keys, ~w(password secret))
     end
 
     test "frontend_error_catching_path" do
@@ -849,6 +861,7 @@ defmodule Appsignal.ConfigTest do
       env: :dev,
       filter_parameters: [],
       filter_session_data: [],
+      filter_data_keys: [],
       ignore_actions: [],
       ignore_errors: [],
       ignore_namespaces: [],

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -199,6 +199,23 @@ defmodule Appsignal.ConfigTest do
                with_config(%{filter_data_keys: ~w(password secret)}, &init_config/0)
     end
 
+    test "filter_data_keys loaded from Phoenix' filter_parameters configuration option" do
+      Application.put_env(:phoenix, :filter_parameters, ~w(token))
+
+      assert %{filter_data_keys: ~w(token)} = init_config()
+
+      Application.delete_env(:phoenix, :filter_parameters)
+    end
+
+    test "filter_data_keys merges appsignal and phoenix ignored keys" do
+      Application.put_env(:phoenix, :filter_parameters, ~w(token))
+
+      assert %{filter_data_keys: ~w(password secret token)} =
+               with_config(%{filter_data_keys: ~w(password secret)}, &init_config/0)
+
+      Application.delete_env(:phoenix, :filter_parameters)
+    end
+
     test "frontend_error_catching_path" do
       assert %{frontend_error_catching_path: "/appsignal_error_catcher"} =
                with_config(

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -342,11 +342,17 @@ defmodule AppsignalSpanTest do
   describe ".set_sample_data/3" do
     setup :create_root_span
 
-    test "returns the span", %{span: span} do
-      assert Span.set_sample_data(span, "key", %{param: "value"}) == span
+    setup %{span: span} do
+      [return: Span.set_sample_data(span, "key", %{param: "value"})]
     end
 
-    test "returns nil when passing a nil-span" do
+    test "returns the span", %{span: span, return: return} do
+      assert return == span
+    end
+  end
+
+  describe ".set_sample_data/3, when passing a nil-span" do
+    test "returns nil" do
       assert Span.set_sample_data(nil, "key", %{param: "value"}) == nil
     end
   end

--- a/test/appsignal/utils/map_filter_test.exs
+++ b/test/appsignal/utils/map_filter_test.exs
@@ -1,0 +1,26 @@
+defmodule Appsignal.Utils.MapFilterTest do
+  alias Appsignal.Utils.MapFilter
+  use ExUnit.Case
+
+  describe "filter/1, without filters" do
+    test "returns the map as-is" do
+      assert %{id: 4, name: "David"} = MapFilter.filter(%{id: 4, name: "David"})
+    end
+  end
+
+  describe "filter/1, with a blocklist" do
+    test "returns the map as-is, and leaves filtering to the agent" do
+      Application.put_env(:phoenix, :filter_parameters, ~w(name))
+      assert %{id: 4, name: "David"} = MapFilter.filter(%{id: 4, name: "David"})
+      Application.delete_env(:phoenix, :filter_parameters)
+    end
+  end
+
+  describe "filter/1, with a keeplist" do
+    test "returns the map as-is, and leaves filtering to the agent" do
+      Application.put_env(:phoenix, :filter_parameters, {:keep, [:name]})
+      assert %{name: "David"} = MapFilter.filter(%{id: 4, name: "David"})
+      Application.delete_env(:phoenix, :filter_parameters)
+    end
+  end
+end

--- a/test/appsignal/utils/map_filter_test.exs
+++ b/test/appsignal/utils/map_filter_test.exs
@@ -19,7 +19,7 @@ defmodule Appsignal.Utils.MapFilterTest do
   describe "filter/1, with a keeplist" do
     test "returns the map as-is, and leaves filtering to the agent" do
       Application.put_env(:phoenix, :filter_parameters, {:keep, [:name]})
-      assert %{name: "David"} = MapFilter.filter(%{id: 4, name: "David"})
+      assert %{id: "[FILTERED]", name: "David"} = MapFilter.filter(%{id: 4, name: "David"})
       Application.delete_env(:phoenix, :filter_parameters)
     end
   end


### PR DESCRIPTION
Filters parameters and session data using the agent's data filtering introduced in https://github.com/appsignal/appsignal-agent/pull/530. Filtered keys can be configured using the `:filter_data_keys`/`APPSIGNAL_FILTER_DATA_KEYS` configuration option.

For backwards compatibility, the keys in  `:filter_parameters`/`APPSIGNAL_FILTER_PARAMETERS` and `:filter_session_data`/`APPSIGNAL_FILTER_SESSION_DATA` are automatically added to the filtered data keys.

For more backwards compatibility, this patch supports Phoenix' Logger filter :keep-lists. With configuration like this in a Phoenix app;

```
config :phoenix, :filter_parameters, {:keep, ["name"]}
```

All keys are filtered except for "name" before sending data to the agent.