### PR TITLE
Add set_sql method to Span

### DIFF
--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -1045,6 +1045,34 @@ static ERL_NIF_TERM _set_span_attribute_double(ErlNifEnv* env, int argc, const E
     return enif_make_atom(env, "ok");
 }
 
+static ERL_NIF_TERM _set_span_attribute_sql_string(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    span_ptr *ptr;
+    ErlNifBinary key;
+    ErlNifBinary value;
+
+    if (argc != 3) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_get_resource(env, argv[0], appsignal_span_type, (void**) &ptr)) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_inspect_iolist_as_binary(env, argv[1], &key)) {
+        return enif_make_badarg(env);
+    }
+    if(!enif_inspect_iolist_as_binary(env, argv[2], &value)) {
+        return enif_make_badarg(env);
+    }
+
+    appsignal_set_span_attribute_sql_string(
+        ptr->span,
+        make_appsignal_string(key),
+        make_appsignal_string(value)
+    );
+
+    return enif_make_atom(env, "ok");
+}
+
 static ERL_NIF_TERM _set_span_sample_data(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     span_ptr *ptr;

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -236,6 +236,10 @@ defmodule Appsignal.Nif do
     _set_span_attribute_double(reference, key, value)
   end
 
+  def set_span_attribute_sql_string(reference, key, value) do
+    _set_span_attribute_sql_string(reference, key, value)
+  end
+
   def set_span_sample_data(reference, key, value) do
     _set_span_sample_data(reference, key, value)
   end
@@ -461,6 +465,10 @@ defmodule Appsignal.Nif do
   end
 
   def _set_span_attribute_double(_reference, _key, _value) do
+    :ok
+  end
+
+  def _set_span_attribute_sql_string(_reference, _key, _value) do
     :ok
   end
 

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -78,6 +78,13 @@ defmodule Appsignal.Span do
 
   def set_attribute(_span, _key, _value), do: nil
 
+  def set_sql(%Span{reference: reference} = span, body) when is_binary(body) do
+    :ok = Nif.set_span_attribute_sql_string(reference, "appsignal:body", body)
+    span
+  end
+
+  def set_sql(_span, _body), do: nil
+
   def set_sample_data(%Span{reference: reference} = span, key, value)
       when is_binary(key) and is_map(value) do
     data = Appsignal.Utils.DataEncoder.encode(value)


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-agent/pull/525, this adds the `set_sql/1` method to the `Span` module.
