### PR TITLE
Use tls 1.3 cipher suites on OTP 23

### DIFF
--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -54,10 +54,15 @@ defmodule Appsignal.Transmitter do
     Path.join(:code.priv_dir(:appsignal), "cacert.pem")
   end
 
-  if System.otp_release() >= "20.3" do
-    defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.2")
-  else
-    defp ciphers, do: :ssl.cipher_suites()
+  cond do
+    System.otp_release() >= "23" ->
+      defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.3")
+
+    System.otp_release() >= "20.3" ->
+      defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.2")
+
+    true ->
+      defp ciphers, do: :ssl.cipher_suites()
   end
 
   if System.otp_release() >= "21" do


### PR DESCRIPTION
As part of https://github.com/appsignal/appsignal-elixir/issues/562, we've seen issues on OTP 23 when trying to send the diagnose report when running `mix diagnose --send-report`.


```
Send diagnostics report to AppSignal? (Y/n): y
  Transmitting diagnostics report
16:36:35.835 [info]  TLS :client: In state :hello received SERVER ALERT: Fatal - Handshake Failure
  Error: Something went wrong while submitting the report to AppSignal.
** (Protocol.UndefinedError) protocol String.Chars not implemented for {:tls_alert, {:handshake_failure, 'TLS client: In state hello received SERVER ALERT: Fatal - Handshake Failure\n '}} of type Tuple
```


This patch switches to tls 1.3 (which is the default on OTP 23) ciphers on OTP 23 to fix this issue.