### PR TITLE
Implement _set_span_namespace

### DIFF
--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -1022,6 +1022,26 @@ static ERL_NIF_TERM _set_span_name(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
     return enif_make_atom(env, "ok");
 }
 
+static ERL_NIF_TERM _set_span_namespace(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    span_ptr *ptr;
+    ErlNifBinary namespace;
+
+    if (argc != 2) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_get_resource(env, argv[0], appsignal_span_type, (void**) &ptr)) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_inspect_iolist_as_binary(env, argv[1], &namespace)) {
+        return enif_make_badarg(env);
+    }
+
+    appsignal_set_span_namespace(ptr->span, make_appsignal_string(namespace));
+
+    return enif_make_atom(env, "ok");
+}
+
 static ERL_NIF_TERM _set_span_attribute_string(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     span_ptr *ptr;
@@ -1413,6 +1433,7 @@ static ErlNifFunc nif_funcs[] =
     {"_create_child_span", 2, _create_child_span, 0},
     {"_create_child_span_with_timestamp", 4, _create_child_span_with_timestamp, 0},
     {"_set_span_name", 2, _set_span_name, 0},
+    {"_set_span_namespace", 2, _set_span_namespace, 0},
     {"_set_span_attribute_string", 3, _set_span_attribute_string, 0},
     {"_set_span_attribute_int", 3, _set_span_attribute_int, 0},
     {"_set_span_attribute_bool", 3, _set_span_attribute_bool, 0},

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -67,7 +67,7 @@ defmodule Appsignal.Span do
   def set_name(_span, _name), do: nil
 
   def set_namespace(%Span{reference: reference} = span, namespace) when is_binary(namespace) do
-    :ok = Nif.set_span_namespace(reference, namespace)
+    :ok = @nif.set_span_namespace(reference, namespace)
     span
   end
 

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -242,8 +242,16 @@ defmodule AppsignalSpanTest do
   describe ".set_namespace/2" do
     setup :create_root_span
 
-    test "returns the span", %{span: span} do
-      assert Span.set_namespace(span, "test") == span
+    setup %{span: span} do
+      %{return: Span.set_namespace(span, "test")}
+    end
+
+    test "returns the span", %{return: return, span: span} do
+      assert return == span
+    end
+
+    test "sets the namespace through the Nif", %{span: %Span{reference: reference}} do
+      assert [{^reference, "test"}] = Test.Nif.get!(:set_span_namespace)
     end
 
     test "returns nil when passing a nil-span" do

--- a/test/support/appsignal/test_nif.ex
+++ b/test/support/appsignal/test_nif.ex
@@ -30,6 +30,11 @@ defmodule Appsignal.Test.Nif do
     Nif.set_span_name(reference, name)
   end
 
+  def set_span_namespace(reference, namespace) do
+    add(:set_span_namespace, {reference, namespace})
+    Nif.set_span_namespace(reference, namespace)
+  end
+
   def add_span_error(reference, name, message, stacktrace) do
     add(:add_span_error, {reference, name, message, stacktrace})
     Nif.add_span_error(reference, name, message, stacktrace)


### PR DESCRIPTION
Implements `Nif.set_span_namespace/2` to call to the extension instead of the Nif's noop.