### PR TITLE
Link AppSignal config when config/config.exs does not exist

### DIFF
--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -173,14 +173,14 @@ defmodule Mix.Tasks.Appsignal.Install do
             IO.puts("Success!")
 
           {:error, reason} ->
-            IO.puts("Failure! #{reason}")
+            IO.puts("Failure! #{inspect(reason)}")
             exit(:shutdown)
         end
 
         File.close(file)
 
       {:error, reason} ->
-        IO.puts("Failure! #{reason}")
+        IO.puts("Failure! #{inspect(reason)}")
         exit(:shutdown)
     end
   end
@@ -200,7 +200,7 @@ defmodule Mix.Tasks.Appsignal.Install do
           IO.puts("Success!")
 
         {:error, reason} ->
-          IO.puts("Failure! #{reason}")
+          IO.puts("Failure! #{inspect(reason)}")
           exit(:shutdown)
       end
     end
@@ -214,7 +214,7 @@ defmodule Mix.Tasks.Appsignal.Install do
           String.contains?(contents, "import_config '#{appsignal_config_filename()}")
 
       {:error, reason} ->
-        IO.puts("Failure! #{reason}")
+        IO.puts("Failure! #{inspect(reason)}")
         exit(:shutdown)
     end
   end
@@ -263,12 +263,12 @@ defmodule Mix.Tasks.Appsignal.Install do
               IO.puts("Success!")
 
             {:error, reason} ->
-              IO.puts("Failure! #{reason}")
+              IO.puts("Failure! #{inspect(reason)}")
               exit(:shutdown)
           end
 
         {:error, reason} ->
-          IO.puts("Failure! #{reason}")
+          IO.puts("Failure! #{inspect(reason)}")
           exit(:shutdown)
       end
     end

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -192,17 +192,29 @@ defmodule Mix.Tasks.Appsignal.Install do
 
     active_content = "\nimport_config \"#{appsignal_config_filename()}\"\n"
 
-    if appsignal_config_linked?() do
-      IO.puts("Success! (Already linked?)")
-    else
-      case append_to_file(config_file_path(), active_content) do
-        :ok ->
-          IO.puts("Success!")
+    cond do
+      appsignal_config_linked?() ->
+        IO.puts("Success! (Already linked?)")
 
-        {:error, reason} ->
-          IO.puts("Failure! #{inspect(reason)}")
-          exit(:shutdown)
-      end
+      File.exists?(config_file_path()) ->
+        case append_to_file(config_file_path(), active_content) do
+          :ok ->
+            IO.puts("Success!")
+
+          {:error, reason} ->
+            IO.puts("Failure! #{inspect(reason)}")
+            exit(:shutdown)
+        end
+
+      true ->
+        case File.write(config_file_path(), "use Mix.Config\n#{active_content}") do
+          :ok ->
+            IO.puts("Success!")
+
+          {:error, reason} ->
+            IO.puts("Failure! #{inspect(reason)}")
+            exit(:shutdown)
+        end
     end
   end
 
@@ -213,9 +225,8 @@ defmodule Mix.Tasks.Appsignal.Install do
         String.contains?(contents, ~s(import_config "#{appsignal_config_filename()})) ||
           String.contains?(contents, "import_config '#{appsignal_config_filename()}")
 
-      {:error, reason} ->
-        IO.puts("Failure! #{inspect(reason)}")
-        exit(:shutdown)
+      {:error, :enoent} ->
+        false
     end
   end
 

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -250,6 +250,22 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
     end
 
     @tag :file_config
+    test "file based config option creates main config file if it doesn't exist" do
+      File.rm(Path.join(@test_config_directory, "config.exs"))
+      output = run_with_file_config()
+
+      assert String.contains?(
+               output,
+               "Linking config to config/config.exs: Success!"
+             )
+
+      assert String.contains?(
+               File.read!(Path.join(@test_config_directory, "config.exs")),
+               ~s(use Mix.Config\n\nimport_config "appsignal.exs")
+             )
+    end
+
+    @tag :file_config
     test "file based config option doesn't crash if the config file is already linked" do
       @test_config_directory
       |> Path.join("config.exs")


### PR DESCRIPTION
This patch makes sure newer Elixir apps, which don't have a `config/config.exs` file anymore, still get a linked `config/appsignal.exs` file by creating `config/config.exs` if it doesn't exist, instead of trying to append to it.