### PR TITLE
Set categories from `transaction_event/3` decorator fallback 

### DIFF
--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -19,8 +19,15 @@ defmodule Appsignal.Instrumentation.Decorators do
     |> instrument(body, context)
   end
 
-  def instrument(namespace, body, %{module: module, name: name, arity: arity})
-      when is_binary(namespace) do
+  def instrument(namespace, body, context) when is_binary(namespace) do
+    do_instrument(body, Map.put(context, :namespace, namespace))
+  end
+
+  def instrument(body, context) do
+    do_instrument(body, context)
+  end
+
+  defp do_instrument(body, %{module: module, name: name, arity: arity, namespace: namespace}) do
     quote do
       Appsignal.Instrumentation.instrument(
         "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
@@ -32,7 +39,7 @@ defmodule Appsignal.Instrumentation.Decorators do
     end
   end
 
-  def instrument(body, %{module: module, name: name, arity: arity}) do
+  defp do_instrument(body, %{module: module, name: name, arity: arity}) do
     quote do
       Appsignal.Instrumentation.instrument(
         "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
@@ -41,7 +48,7 @@ defmodule Appsignal.Instrumentation.Decorators do
     end
   end
 
-  def instrument(body, %{module: module, name: name}) do
+  defp do_instrument(body, %{module: module, name: name}) do
     quote do
       Appsignal.Instrumentation.instrument(
         "#{module_name(unquote(module))}.#{unquote(name)}",

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -43,8 +43,8 @@ defmodule Appsignal.Instrumentation.Decorators do
     quote do
       Appsignal.Instrumentation.instrument(
         "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
-	unquote(category),
-	fn -> unquote(body) end
+        unquote(category),
+        fn -> unquote(body) end
       )
     end
   end

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -39,6 +39,16 @@ defmodule Appsignal.Instrumentation.Decorators do
     end
   end
 
+  defp do_instrument(body, %{module: module, name: name, arity: arity, category: category}) do
+    quote do
+      Appsignal.Instrumentation.instrument(
+        "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
+	unquote(category),
+	fn -> unquote(body) end
+      )
+    end
+  end
+
   defp do_instrument(body, %{module: module, name: name, arity: arity}) do
     quote do
       Appsignal.Instrumentation.instrument(
@@ -69,8 +79,8 @@ defmodule Appsignal.Instrumentation.Decorators do
     instrument(body, context)
   end
 
-  def transaction_event(_category, body, context) do
-    instrument(body, context)
+  def transaction_event(category, body, context) do
+    do_instrument(body, Map.put(context, :category, category))
   end
 
   def channel_action(body, %{module: module, args: [action, _payload, _socket]}) do

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -202,7 +202,8 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's category attribute" do
-      assert {:ok, [{%Span{}, "appsignal:category", "call.event"}]} = Test.Span.get(:set_attribute)
+      assert {:ok, [{%Span{}, "appsignal:category", "call.event"}]} =
+               Test.Span.get(:set_attribute)
     end
 
     test "closes the span" do

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -201,6 +201,10 @@ defmodule Appsignal.InstrumentationTest do
                Test.Span.get(:set_name)
     end
 
+    test "sets the span's category attribute" do
+      assert {:ok, [{%Span{}, "appsignal:category", "call.event"}]} = Test.Span.get(:set_attribute)
+    end
+
     test "closes the span" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
     end


### PR DESCRIPTION
To reduce duplication when adding categories to the decorator functions, the
call to `Appsignal.Instrumentation.instrument/2` is moved to
`Decorators.do_instrument/2` to allow adding the namespace to the context map.
This way, the `instrument/2-3` function does not need another public head to
handle categories.

When calling the transaction_event decorator while passing a category, this patch 
makes sure the category is set like it was in the previous versions of the integration.