### PR TITLE
Explicitly ignore returns from Span functions 

### DIFF
--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -38,9 +38,10 @@ defmodule Appsignal.Instrumentation do
 
   def instrument(name, category, fun) do
     instrument(fn span ->
-      _ = span
-      |> @span.set_name(name)
-      |> @span.set_attribute("appsignal:category", category)
+      _ =
+        span
+        |> @span.set_name(name)
+        |> @span.set_attribute("appsignal:category", category)
 
       call_with_optional_argument(fun, span)
     end)

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -38,8 +38,10 @@ defmodule Appsignal.Instrumentation do
 
   def instrument(name, category, fun) do
     instrument(fn span ->
-      @span.set_name(span, name)
-      @span.set_attribute(span, "appsignal:category", category)
+      _ = span
+      |> @span.set_name(name)
+      |> @span.set_attribute("appsignal:category", category)
+
       call_with_optional_argument(fun, span)
     end)
   end

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -32,7 +32,7 @@ defmodule Appsignal.Instrumentation.Decorators do
       Appsignal.Instrumentation.instrument(
         "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
         fn span ->
-          unquote(@span).set_namespace(span, unquote(namespace))
+          _ = unquote(@span).set_namespace(span, unquote(namespace))
           unquote(body)
         end
       )


### PR DESCRIPTION
Since the `Span.set_attribute/3` function takes and returns `Span`s and `nil`s,
we don't care about the return value here, as either case is accounted for.

Part of closing https://github.com/appsignal/appsignal-elixir-phoenix/issues/5.