### PR TITLE
Ignore unhandled info, code_change and terminate in Error.Backend

### DIFF
--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -50,6 +50,18 @@ defmodule Appsignal.Error.Backend do
     {:ok, :ok, state}
   end
 
+  def handle_info(_message, state) do
+    {:ok, state}
+  end
+
+  def code_change(_old_vsn, state, _extra) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
   defp set_error_data(span, reason, stacktrace) do
     span
     |> @span.add_error(:error, reason, stacktrace)

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -10,9 +10,9 @@ defmodule Appsignal.Error.Backend do
   def init(opts), do: {:ok, opts}
 
   def attach do
-    case ok?(Logger.add_backend(Appsignal.Error.Backend)) do
-      :ok -> Logger.debug("Appsignal.Error.Backend attached to Logger")
-      error -> Logger.warn("Appsignal.Error.Backend not attached to Logger: #{inspect(error)}")
+    case Logger.add_backend(Appsignal.Error.Backend) do
+      {:error, error} -> Logger.warn("Appsignal.Error.Backend not attached to Logger: #{error}")
+      _ -> Logger.debug("Appsignal.Error.Backend attached to Logger")
     end
   end
 
@@ -67,8 +67,4 @@ defmodule Appsignal.Error.Backend do
     |> @span.add_error(:error, reason, stacktrace)
     |> @tracer.close_span()
   end
-
-  defp ok?({:ok, _, _}), do: :ok
-  defp ok?({:ok, _}), do: :ok
-  defp ok?(error), do: error
 end

--- a/test/appsignal/error/backend_test.exs
+++ b/test/appsignal/error/backend_test.exs
@@ -162,4 +162,22 @@ defmodule Appsignal.Error.BackendTest do
       assert Backend.handle_call(:call, %{}) == {:ok, :ok, %{}}
     end
   end
+
+  describe "handle_info/2" do
+    test "returns {:ok, state}" do
+      assert Backend.handle_info({:io_reply, make_ref(), :ok}, %{}) == {:ok, %{}}
+    end
+  end
+
+  describe "code_change/3" do
+    test "returns {:ok, state}" do
+      assert Backend.code_change(123, %{}, :extra) == {:ok, %{}}
+    end
+  end
+
+  describe "terminate/2" do
+    test "returns :ok" do
+      assert Backend.terminate(:shutdown, %{}) == :ok
+    end
+  end
 end


### PR DESCRIPTION
Closes #590.

Based on the work done by @anronin in #591, this patch also includes a fix for the Dialyzer issue caused by the `ok?/1` helper function. 