### PR TITLE
Add register stub to deprecated transaction registry

### DIFF
--- a/lib/appsignal/transaction_registry.ex
+++ b/lib/appsignal/transaction_registry.ex
@@ -5,4 +5,8 @@ defmodule Appsignal.TransactionRegistry do
   def lookup(pid) do
     nil
   end
+
+  def register(parent) do
+    nil
+  end
 end


### PR DESCRIPTION
A customer reported that they used this function and that it was a hard fail, add a stub so one would get the deprecation warning instead.