### PR TITLE
Don't register query spans without parents

### DIFF
--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -52,6 +52,12 @@ defmodule Appsignal.Ecto do
   def handle_event(_event, _measurements, %{query: "commit"}, _config), do: :ok
 
   def handle_event(_event, %{total_time: total_time}, %{repo: repo, query: query}, _config) do
+    handle_query(@tracer.current_span(), total_time, repo, query)
+  end
+
+  defp handle_query(nil, _total_time, _repo, _query), do: nil
+
+  defp handle_query(current, total_time, repo, query) do
     time = :os.system_time()
 
     "http_request"


### PR DESCRIPTION
As reported via [support](https://app.intercom.com/a/apps/yzor8gyw/inbox/inbox/conversation/16410700017831).

Since 2.0, we're not dropping Spans anymore when they don't have a parent Span.
While that makes technical sense, users are seeing spikes in usage because
previously ignored queries that happened outside of any web requests are now
instrumented.

This patch reverts that behaviour to how it worked in 1.x. If a query happens
when there's no parent to conatain it, the query isn't instrumented.