### PR TITLE
Switch to reference-based child Span API

### DIFF
--- a/agent.exs
+++ b/agent.exs
@@ -1,39 +1,39 @@
 defmodule Appsignal.Agent do
-  def version, do: "c55fb2c"
+  def version, do: "e770c84"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "fd287b7efa38d821331d75f4a8d4dd0585f1fc01993406e2c5ebf224d13ac178",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/c55fb2c/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "9a0e4bc02ac0454a3e09a60d145c3415c3de166c0fa4717f143fdde8ec48c1be",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e770c84/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "fd287b7efa38d821331d75f4a8d4dd0585f1fc01993406e2c5ebf224d13ac178",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/c55fb2c/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "9a0e4bc02ac0454a3e09a60d145c3415c3de166c0fa4717f143fdde8ec48c1be",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e770c84/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "c6c0a54524d1b4483aee03677e32969ca896d1a5561e12d9cb3e45fb5c2deeb6",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/c55fb2c/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "688f8fced411c4631b3076e599dcffa994eb2cede839e4f68226e6cf2a41f4e2",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e770c84/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "c6c0a54524d1b4483aee03677e32969ca896d1a5561e12d9cb3e45fb5c2deeb6",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/c55fb2c/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "688f8fced411c4631b3076e599dcffa994eb2cede839e4f68226e6cf2a41f4e2",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e770c84/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "b60e7514677a0622dbd093b75a353a547661734202dbc76c36842848f90f0461",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/c55fb2c/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "c2e990469e990b1368c7f16e7b82adf07d2c08edab7509252029f8277c5512f5",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e770c84/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "69dd6789e1e13177e2e9827a6f1a93d7557cc66d3f4f58a843d46f6d7741eab9",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/c55fb2c/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "e6c46db37fa32b3e21460b779b7c8610e10c89b7ae91e68fa82ea6f1f238d44d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e770c84/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "6a669fe6a894558c83c780f32fb886f4100e1775dcfd490523420c569f315416",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/c55fb2c/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "40084655eff662f85201256ebd143fbf4568f437795952dda5ef7e0fa29a62cd",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e770c84/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "6a669fe6a894558c83c780f32fb886f4100e1775dcfd490523420c569f315416",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/c55fb2c/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "40084655eff662f85201256ebd143fbf4568f437795952dda5ef7e0fa29a62cd",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/e770c84/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -931,18 +931,14 @@ static ERL_NIF_TERM _create_root_span_with_timestamp(ErlNifEnv* env, int argc, c
 }
 
 static ERL_NIF_TERM _create_child_span(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+  span_ptr *parent;
   span_ptr *ptr;
-  ErlNifBinary trace_id;
-  ErlNifBinary span_id;
   ERL_NIF_TERM span_ref;
 
-  if (argc != 2) {
+  if (argc != 1) {
     return enif_make_badarg(env);
   }
-  if(!enif_inspect_iolist_as_binary(env, argv[0], &trace_id)) {
-    return enif_make_badarg(env);
-  }
-  if(!enif_inspect_iolist_as_binary(env, argv[1], &span_id)) {
+  if(!enif_get_resource(env, argv[0], appsignal_span_type, (void**) &parent)) {
     return enif_make_badarg(env);
   }
 
@@ -950,10 +946,7 @@ static ERL_NIF_TERM _create_child_span(ErlNifEnv* env, int argc, const ERL_NIF_T
   if(!ptr)
     return make_error_tuple(env, "no_memory");
 
-  ptr->span = appsignal_create_child_span(
-    make_appsignal_string(trace_id),
-    make_appsignal_string(span_id)
-  );
+  ptr->span = appsignal_create_child_span(parent->span);
 
   span_ref = enif_make_resource(env, ptr);
   enif_release_resource(ptr);
@@ -962,26 +955,22 @@ static ERL_NIF_TERM _create_child_span(ErlNifEnv* env, int argc, const ERL_NIF_T
 }
 
 static ERL_NIF_TERM _create_child_span_with_timestamp(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+  span_ptr *parent;
   span_ptr *ptr;
-  ErlNifBinary trace_id;
-  ErlNifBinary span_id;
   long sec;
   long nsec;
   ERL_NIF_TERM span_ref;
 
-  if (argc != 4) {
+  if (argc != 3) {
     return enif_make_badarg(env);
   }
-  if(!enif_inspect_iolist_as_binary(env, argv[0], &trace_id)) {
+  if(!enif_get_resource(env, argv[0], appsignal_span_type, (void**) &parent)) {
     return enif_make_badarg(env);
   }
-  if(!enif_inspect_iolist_as_binary(env, argv[1], &span_id)) {
+  if(!enif_get_long(env, argv[1], &sec)) {
     return enif_make_badarg(env);
   }
-  if(!enif_get_long(env, argv[2], &sec)) {
-    return enif_make_badarg(env);
-  }
-  if(!enif_get_long(env, argv[3], &nsec)) {
+  if(!enif_get_long(env, argv[2], &nsec)) {
     return enif_make_badarg(env);
   }
 
@@ -989,12 +978,7 @@ static ERL_NIF_TERM _create_child_span_with_timestamp(ErlNifEnv* env, int argc, 
   if(!ptr)
     return make_error_tuple(env, "no_memory");
 
-  ptr->span = appsignal_create_child_span_with_timestamp(
-    make_appsignal_string(trace_id),
-    make_appsignal_string(span_id),
-    sec,
-    nsec
-  );
+  ptr->span = appsignal_create_child_span_with_timestamp(parent->span, sec, nsec);
 
   span_ref = enif_make_resource(env, ptr);
   enif_release_resource(ptr);
@@ -1281,38 +1265,6 @@ static ERL_NIF_TERM _close_span_with_timestamp(ErlNifEnv* env, int argc, const E
     return enif_make_atom(env, "ok");
 }
 
-static ERL_NIF_TERM _trace_id(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-  span_ptr *ptr;
-  appsignal_string_t id;
-
-  if (argc != 1) {
-    return enif_make_badarg(env);
-  }
-  if (!enif_get_resource(env, argv[0], appsignal_span_type, (void**) &ptr)) {
-    return enif_make_badarg(env);
-  }
-
-  id = appsignal_trace_id(ptr->span);
-  return make_ok_tuple(env, make_elixir_string(env,id));
-}
-
-static ERL_NIF_TERM _span_id(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-  span_ptr *ptr;
-  appsignal_string_t id;
-
-  if (argc != 1) {
-    return enif_make_badarg(env);
-  }
-  if (!enif_get_resource(env, argv[0], appsignal_span_type, (void**) &ptr)) {
-    return enif_make_badarg(env);
-  }
-
-  id = appsignal_span_id(ptr->span);
-  return make_ok_tuple(env, make_elixir_string(env,id));
-}
-
 static ERL_NIF_TERM _span_to_json(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   span_ptr *ptr;
   appsignal_string_t json;
@@ -1430,8 +1382,8 @@ static ErlNifFunc nif_funcs[] =
     {"_loaded", 0, _loaded, 0},
     {"_create_root_span", 1, _create_root_span, 0},
     {"_create_root_span_with_timestamp", 3, _create_root_span_with_timestamp, 0},
-    {"_create_child_span", 2, _create_child_span, 0},
-    {"_create_child_span_with_timestamp", 4, _create_child_span_with_timestamp, 0},
+    {"_create_child_span", 1, _create_child_span, 0},
+    {"_create_child_span_with_timestamp", 3, _create_child_span_with_timestamp, 0},
     {"_set_span_name", 2, _set_span_name, 0},
     {"_set_span_namespace", 2, _set_span_namespace, 0},
     {"_set_span_attribute_string", 3, _set_span_attribute_string, 0},
@@ -1443,8 +1395,6 @@ static ErlNifFunc nif_funcs[] =
     {"_add_span_error", 4, _add_span_error, 0},
     {"_close_span", 1, _close_span, 0},
     {"_close_span_with_timestamp", 3, _close_span_with_timestamp, 0},
-    {"_trace_id", 1, _trace_id, 0},
-    {"_span_id", 1, _span_id, 0},
     {"_span_to_json", 1, _span_to_json, 0}
 };
 

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -200,14 +200,6 @@ defmodule Appsignal.Nif do
     _loaded()
   end
 
-  def trace_id(reference) do
-    _trace_id(reference)
-  end
-
-  def span_id(reference) do
-    _span_id(reference)
-  end
-
   def create_root_span(namespace) do
     _create_root_span(namespace)
   end
@@ -216,12 +208,12 @@ defmodule Appsignal.Nif do
     _create_root_span_with_timestamp(namespace, sec, nsec)
   end
 
-  def create_child_span(trace_id, span_id) do
-    _create_child_span(trace_id, span_id)
+  def create_child_span(parent) do
+    _create_child_span(parent)
   end
 
-  def create_child_span_with_timestamp(trace_id, span_id, sec, nsec) do
-    _create_child_span_with_timestamp(trace_id, span_id, sec, nsec)
+  def create_child_span_with_timestamp(parent, sec, nsec) do
+    _create_child_span_with_timestamp(parent, sec, nsec)
   end
 
   def set_span_name(reference, name) do
@@ -448,14 +440,6 @@ defmodule Appsignal.Nif do
     false
   end
 
-  def _trace_id(_reference) do
-    {:ok, 'trace123'}
-  end
-
-  def _span_id(_reference) do
-    {:ok, 'span123'}
-  end
-
   def _create_root_span(_namespace) do
     {:ok, make_ref()}
   end
@@ -464,11 +448,11 @@ defmodule Appsignal.Nif do
     {:ok, make_ref()}
   end
 
-  def _create_child_span(_trace_id, _span_id) do
+  def _create_child_span(_parent) do
     {:ok, make_ref()}
   end
 
-  def _create_child_span_with_timestamp(_trace_id, _span_id, _sec, _nsec) do
+  def _create_child_span_with_timestamp(_parent, _sec, _nsec) do
     {:ok, make_ref()}
   end
 

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -21,40 +21,24 @@ defmodule Appsignal.Span do
     end
   end
 
-  def create_child(parent, pid) do
+  def create_child(%Span{reference: parent}, pid) do
     if Config.active?() do
-      {:ok, trace_id} = Span.trace_id(parent)
-      {:ok, span_id} = Span.span_id(parent)
-      {:ok, reference} = @nif.create_child_span(trace_id, span_id)
+      {:ok, reference} = @nif.create_child_span(parent)
 
       %Span{reference: reference, pid: pid}
     end
   end
 
-  def create_child(parent, pid, start_time) do
+  def create_child(%Span{reference: parent}, pid, start_time) do
     if Config.active?() do
       sec = :erlang.convert_time_unit(start_time, :native, :second)
       nsec = :erlang.convert_time_unit(start_time, :native, :nanosecond) - sec * 1_000_000_000
 
-      {:ok, trace_id} = Span.trace_id(parent)
-      {:ok, span_id} = Span.span_id(parent)
-      {:ok, reference} = @nif.create_child_span_with_timestamp(trace_id, span_id, sec, nsec)
+      {:ok, reference} = @nif.create_child_span_with_timestamp(parent, sec, nsec)
 
       %Span{reference: reference, pid: pid}
     end
   end
-
-  def trace_id(%Span{reference: reference}) do
-    @nif.trace_id(reference)
-  end
-
-  def trace_id(nil), do: {:ok, nil}
-
-  def span_id(%Span{reference: reference}) do
-    @nif.span_id(reference)
-  end
-
-  def span_id(nil), do: {:ok, nil}
 
   def set_name(%Span{reference: reference} = span, name)
       when is_reference(reference) and is_binary(name) do

--- a/test/appsignal/nif_test.exs
+++ b/test/appsignal/nif_test.exs
@@ -57,20 +57,18 @@ defmodule Appsignal.NifTest do
 
   describe "create_child_span/3" do
     test "returns an ok-tuple with a reference to the span" do
-      assert {:ok, ref} = Nif.create_child_span("trace_id", "span_id")
+      {:ok, parent} = Nif.create_root_span("http_request")
+
+      assert {:ok, ref} = Nif.create_child_span(parent)
       assert is_reference(ref)
     end
   end
 
   describe "create_child_span_with_timestamp/2" do
     setup do
-      {:ok, ref} =
-        Nif.create_child_span_with_timestamp(
-          "trace_id",
-          "span_id",
-          1_588_930_137,
-          508_176_000
-        )
+      {:ok, parent} = Nif.create_root_span("http_request")
+
+      {:ok, ref} = Nif.create_child_span_with_timestamp(parent, 1_588_930_137, 508_176_000)
 
       %{ref: ref}
     end

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -90,11 +90,8 @@ defmodule AppsignalSpanTest do
       assert %Span{} = span
     end
 
-    test "creates a child span through the Nif", %{parent: parent} do
-      assert [{parent_trace_id, parent_span_id}] = Test.Nif.get!(:create_child_span)
-
-      assert {:ok, ^parent_trace_id} = Span.trace_id(parent)
-      assert {:ok, ^parent_span_id} = Span.span_id(parent)
+    test "creates a child span through the Nif", %{parent: %Span{reference: parent}} do
+      assert Test.Nif.get!(:create_child_span) == [{parent}]
     end
 
     test "sets the span's reference", %{span: span} do
@@ -113,11 +110,8 @@ defmodule AppsignalSpanTest do
       assert %Span{} = span
     end
 
-    test "creates a child span through the Nif", %{parent: parent} do
-      assert [{parent_trace_id, parent_span_id}] = Test.Nif.get!(:create_child_span)
-
-      assert {:ok, ^parent_trace_id} = Span.trace_id(parent)
-      assert {:ok, ^parent_span_id} = Span.span_id(parent)
+    test "creates a child span through the Nif", %{parent: %Span{reference: parent}} do
+      assert Test.Nif.get!(:create_child_span) == [{parent}]
     end
 
     test "sets the span's reference", %{span: span} do
@@ -159,32 +153,6 @@ defmodule AppsignalSpanTest do
     @tag :skip_env_test_no_nif
     test "sets the start time through the Nif", %{span: span} do
       assert %{"start_time" => 1_588_937_136} = Span.to_map(span)
-    end
-  end
-
-  describe ".trace_id/1" do
-    setup :create_root_span
-
-    test "returns an ok-tuple with the trace_id as a list", %{span: span} do
-      {:ok, trace_id} = Span.trace_id(span)
-      assert is_list(trace_id)
-    end
-
-    test "returns nil when passing a nil-span" do
-      {:ok, nil} = Span.trace_id(nil)
-    end
-  end
-
-  describe ".span_id/1" do
-    setup :create_root_span
-
-    test "returns an ok-tuple with the span_id as a list", %{span: span} do
-      {:ok, span_id} = Span.span_id(span)
-      assert is_list(span_id)
-    end
-
-    test "returns nil when passing a nil-span" do
-      {:ok, nil} = Span.span_id(nil)
     end
   end
 

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -138,8 +138,7 @@ defmodule Appsignal.TracerTest do
     end
 
     test "creates a child span through the Nif" do
-      assert [{_, _, 1_588_936_027, 128_939_000}] =
-               Test.Nif.get!(:create_child_span_with_timestamp)
+      assert [{_, 1_588_936_027, 128_939_000}] = Test.Nif.get!(:create_child_span_with_timestamp)
     end
   end
 

--- a/test/support/appsignal/test_nif.ex
+++ b/test/support/appsignal/test_nif.ex
@@ -15,14 +15,14 @@ defmodule Appsignal.Test.Nif do
     Nif.create_root_span_with_timestamp(namespace, sec, nsec)
   end
 
-  def create_child_span(trace_id, span_id) do
-    add(:create_child_span, {trace_id, span_id})
-    Nif.create_child_span(trace_id, span_id)
+  def create_child_span(parent) do
+    add(:create_child_span, {parent})
+    Nif.create_child_span(parent)
   end
 
-  def create_child_span_with_timestamp(trace_id, span_id, sec, nsec) do
-    add(:create_child_span_with_timestamp, {trace_id, span_id, sec, nsec})
-    Nif.create_child_span_with_timestamp(trace_id, span_id, sec, nsec)
+  def create_child_span_with_timestamp(parent, sec, nsec) do
+    add(:create_child_span_with_timestamp, {parent, sec, nsec})
+    Nif.create_child_span_with_timestamp(parent, sec, nsec)
   end
 
   def set_span_name(reference, name) do


### PR DESCRIPTION
Changes required for https://github.com/appsignal/appsignal-agent/pull/643. This patch fixes the agent CI for that patch: https://appsignal.semaphoreci.com/workflows/a84adb27-c37b-48a9-b288-0c5d02fd2505.