### PR TITLE
Monitor all registered spans

### DIFF
--- a/lib/appsignal/monitor.ex
+++ b/lib/appsignal/monitor.ex
@@ -18,7 +18,7 @@ defmodule Appsignal.Monitor do
   end
 
   def handle_cast({:monitor, pid}, state) do
-    Process.monitor(pid)
+    unless pid in monitors(), do: Process.monitor(pid)
     {:noreply, state}
   end
 
@@ -30,5 +30,10 @@ defmodule Appsignal.Monitor do
   def handle_info({:delete, pid}, state) do
     Tracer.delete(pid)
     {:noreply, state}
+  end
+
+  defp monitors do
+    {:monitors, monitors} = Process.info(self(), :monitors)
+    Enum.map(monitors, fn {:process, process} -> process end)
   end
 end

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -170,6 +170,7 @@ defmodule Appsignal.Tracer do
 
   defp register(%Span{pid: pid} = span) do
     :ets.insert(@table, {pid, span})
+    @monitor.add()
     span
   end
 

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -6,6 +6,7 @@ defmodule AppsignalTest do
     {:ok, _} = start_supervised(Appsignal.Test.Tracer)
     {:ok, _} = start_supervised(Appsignal.Test.Nif)
     {:ok, _} = start_supervised(Appsignal.Test.Span)
+    {:ok, _} = start_supervised(Appsignal.Test.Monitor)
 
     :ok
   end

--- a/test/appsignal/demo_test.exs
+++ b/test/appsignal/demo_test.exs
@@ -6,6 +6,8 @@ defmodule Appsignal.DemoTest do
     start_supervised(Test.Nif)
     start_supervised(Test.Tracer)
     start_supervised(Test.Span)
+    start_supervised(Test.Monitor)
+
     :ok
   end
 

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -31,6 +31,7 @@ defmodule Appsignal.EctoTest do
       Test.Nif.start_link()
       Test.Tracer.start_link()
       Test.Span.start_link()
+      Test.Monitor.start_link()
 
       :telemetry.execute(
         [:appsignal, :test, :repo, :query],
@@ -62,6 +63,7 @@ defmodule Appsignal.EctoTest do
       Test.Nif.start_link()
       Test.Tracer.start_link()
       Test.Span.start_link()
+      Test.Monitor.start_link()
 
       Appsignal.Tracer.create_span("http_request")
 
@@ -118,6 +120,7 @@ defmodule Appsignal.EctoTest do
       Test.Nif.start_link()
       Test.Tracer.start_link()
       Test.Span.start_link()
+      Test.Monitor.start_link()
 
       event = [:appsignal, :test, :repo, :outside]
       :telemetry.attach({__MODULE__, event}, event, &Appsignal.Ecto.handle_event/4, :ok)
@@ -177,6 +180,7 @@ defmodule Appsignal.EctoTest do
       Test.Nif.start_link()
       Test.Tracer.start_link()
       Test.Span.start_link()
+      Test.Monitor.start_link()
 
       :telemetry.execute(
         [:appsignal, :test, :repo, :query],
@@ -207,6 +211,7 @@ defmodule Appsignal.EctoTest do
       Test.Nif.start_link()
       Test.Tracer.start_link()
       Test.Span.start_link()
+      Test.Monitor.start_link()
 
       :telemetry.execute(
         [:appsignal, :test, :repo, :query],

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -50,6 +50,8 @@ defmodule Appsignal.InstrumentationTest do
     start_supervised(Test.Nif)
     start_supervised(Test.Tracer)
     start_supervised(Test.Span)
+    start_supervised(Test.Monitor)
+
     :ok
   end
 

--- a/test/appsignal/monitor_test.exs
+++ b/test/appsignal/monitor_test.exs
@@ -20,6 +20,15 @@ defmodule Appsignal.MonitorTest do
     end)
   end
 
+  test "does not monitor a process more than once" do
+    Monitor.add()
+    Monitor.add()
+
+    until(fn ->
+      assert Process.info(monitor_pid(), :monitors) == {:monitors, [{:process, self()}]}
+    end)
+  end
+
   test "removes entries from the registry when their processes exit" do
     pid =
       spawn(fn ->

--- a/test/appsignal/monitor_test.exs
+++ b/test/appsignal/monitor_test.exs
@@ -32,18 +32,21 @@ defmodule Appsignal.MonitorTest do
   test "removes entries from the registry when their processes exit" do
     pid =
       spawn(fn ->
-        Tracer.create_span("root")
+        :ets.insert(:"$appsignal_registry", {self(), "span"})
         Monitor.add()
-        :timer.sleep(2)
       end)
 
     until(fn ->
-      assert %Span{} = Tracer.current_span(pid)
+      assert lookup(pid) == [{pid, "span"}]
     end)
 
     until(fn ->
-      assert Tracer.current_span(pid) == nil
+      assert lookup(pid) == []
     end)
+  end
+
+  defp lookup(pid) do
+    :ets.lookup(:"$appsignal_registry", pid)
   end
 
   defp monitor_pid do

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -18,6 +18,10 @@ defmodule Appsignal.TracerTest do
     test "registers the span", %{span: span} do
       assert :ets.lookup(:"$appsignal_registry", self()) == [{self(), span}]
     end
+
+    test "creates a process monitor" do
+      assert Test.Monitor.get!(:add) == [{self()}]
+    end
   end
 
   describe "create_span/1, when disabled" do

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -8,6 +8,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
     start_supervised(Test.Tracer)
     start_supervised(Test.Span)
     start_supervised(Test.Nif)
+    start_supervised(Test.Monitor)
 
     bypass = Bypass.open()
 


### PR DESCRIPTION
To make extra-sure spans are cleaned up if their process exits, even if the
span wasn't closed and should be dropped, this patch adds a monitor when
registering a span in the ets table.
