### PR TITLE
Let set error use root span

### DIFF
--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -53,8 +53,7 @@ defmodule Appsignal.Instrumentation do
   end
 
   def set_error(kind, reason, stacktrace) do
-    span = @tracer.current_span()
-    @span.add_error(span, kind, reason, stacktrace)
+    @span.add_error(@tracer.root_span(), kind, reason, stacktrace)
   end
 
   def send_error(kind, reason, stacktrace) do


### PR DESCRIPTION
Set error used the current span, which caused errors to not be tracked. Always use the root span instead.