### PR TITLE
Pass Elixir exceptions to `Appsignal.Instrumentation.se(t|nd)_error/2`

### DIFF
--- a/lib/appsignal/error.ex
+++ b/lib/appsignal/error.ex
@@ -1,13 +1,17 @@
 defmodule Appsignal.Error do
   @moduledoc false
-  def metadata(:error, reason, stack) do
-    exception = Exception.normalize(:error, reason, stack)
-
+  def metadata(%_{__exception__: true} = exception, stack) do
     {
       inspect(exception.__struct__),
       Exception.format_banner(:error, exception, stack),
       Appsignal.Stacktrace.format(stack)
     }
+  end
+
+  def metadata(:error, reason, stack) do
+    :error
+    |> Exception.normalize(reason, stack)
+    |> metadata(stack)
   end
 
   def metadata(kind, reason, stack) do

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -52,6 +52,10 @@ defmodule Appsignal.Instrumentation do
     instrument(name, category, fun)
   end
 
+  def set_error(%_{__exception__: true} = exception, stacktrace) do
+    @span.add_error(@tracer.root_span(), exception, stacktrace)
+  end
+
   def set_error(kind, reason, stacktrace) do
     @span.add_error(@tracer.root_span(), kind, reason, stacktrace)
   end

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -60,6 +60,12 @@ defmodule Appsignal.Instrumentation do
     @span.add_error(@tracer.root_span(), kind, reason, stacktrace)
   end
 
+  def send_error(%_{__exception__: true} = exception, stacktrace) do
+    @span.create_root("http_request", self())
+    |> @span.add_error(exception, stacktrace)
+    |> @span.close()
+  end
+
   def send_error(kind, reason, stacktrace) do
     @span.create_root("http_request", self())
     |> @span.add_error(kind, reason, stacktrace)

--- a/lib/appsignal/test/span.ex
+++ b/lib/appsignal/test/span.ex
@@ -8,6 +8,11 @@ defmodule Appsignal.Test.Span do
     Span.create_root(namespace, pid)
   end
 
+  def add_error(span, exception, stacktrace) do
+    add(:add_error, {span, exception, stacktrace})
+    Span.add_error(span, exception, stacktrace)
+  end
+
   def add_error(span, kind, reason, stacktrace) do
     add(:add_error, {span, kind, reason, stacktrace})
     Span.add_error(span, kind, reason, stacktrace)

--- a/test/appsignal/error_test.exs
+++ b/test/appsignal/error_test.exs
@@ -1,6 +1,31 @@
 defmodule Appsignal.ErrorTest do
   use ExUnit.Case
 
+  describe "metadata/2, with an exception" do
+    setup do
+      try do
+        raise "Exception!"
+      rescue
+        exception -> %{metadata: Appsignal.Error.metadata(exception, __STACKTRACE__)}
+      end
+    end
+
+    test "extracts the error's name", %{metadata: metadata} do
+      assert {"RuntimeError", _message, _stack} = metadata
+    end
+
+    test "extracts the error's message", %{metadata: metadata} do
+      assert {_name, "** (RuntimeError) Exception!", _stack} = metadata
+    end
+
+    test "format's the error's stack trace", %{metadata: metadata} do
+      {_name, _message, stack} = metadata
+      assert is_list(stack)
+      assert length(stack) > 0
+      assert Enum.all?(stack, &is_binary(&1))
+    end
+  end
+
   describe "metadata/3, with an exception" do
     setup do
       try do

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -372,6 +372,63 @@ defmodule Appsignal.InstrumentationTest do
     end
   end
 
+  describe ".set_error/2, with a root span" do
+    setup do
+      span = Tracer.create_span("http_request")
+
+      {exception, stack} =
+        try do
+          raise "Exception!"
+        rescue
+          exception -> {exception, __STACKTRACE__}
+        end
+
+      [
+        span: span,
+        exception: exception,
+        stack: stack,
+        return: Appsignal.Instrumentation.set_error(exception, stack)
+      ]
+    end
+
+    test "returns the span", %{span: span, return: return} do
+      assert return == span
+    end
+
+    test "adds the error to the span", %{exception: exception, stack: stack} do
+      assert {:ok, [{%Span{}, ^exception, ^stack}]} = Test.Span.get(:add_error)
+    end
+  end
+
+  describe ".set_error/2, with a child span" do
+    setup do
+      root = Tracer.create_span("http_request")
+      Tracer.create_span("http_request")
+
+      {exception, stack} =
+        try do
+          raise "Exception!"
+        rescue
+          exception -> {exception, __STACKTRACE__}
+        end
+
+      [
+        span: root,
+        exception: exception,
+        stack: stack,
+        return: Appsignal.Instrumentation.set_error(exception, stack)
+      ]
+    end
+
+    test "returns the root span", %{span: span, return: return} do
+      assert return == span
+    end
+
+    test "adds the error to the root span", %{exception: exception, stack: stack} do
+      assert {:ok, [{%Span{}, ^exception, ^stack}]} = Test.Span.get(:add_error)
+    end
+  end
+
   describe ".set_error/3, with a root span" do
     setup do
       span = Tracer.create_span("http_request")


### PR DESCRIPTION
This patch adds `send_error/3` and `set_error/2`, which take an Elixir exception struct instead of a kind and reason:

    try do
      raise "Exception!"
    rescue
      exception -> Appsignal.set_error(exception, __STACKTRACE__)
    end

Part of the improvements we’re making for #610.