### PR TITLE
Pass fun to set error

### DIFF
--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -61,8 +61,13 @@ defmodule Appsignal.Instrumentation do
   end
 
   def send_error(%_{__exception__: true} = exception, stacktrace) do
+    send_error(exception, stacktrace, &Function.identity/1)
+  end
+
+  def send_error(%_{__exception__: true} = exception, stacktrace, fun) when is_function(fun) do
     @span.create_root("http_request", self())
     |> @span.add_error(exception, stacktrace)
+    |> fun.()
     |> @span.close()
   end
 

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -61,7 +61,7 @@ defmodule Appsignal.Instrumentation do
   end
 
   def send_error(%_{__exception__: true} = exception, stacktrace) do
-    send_error(exception, stacktrace, &Function.identity/1)
+    send_error(exception, stacktrace, & &1)
   end
 
   def send_error(%_{__exception__: true} = exception, stacktrace, fun) when is_function(fun) do
@@ -72,7 +72,7 @@ defmodule Appsignal.Instrumentation do
   end
 
   def send_error(kind, reason, stacktrace) do
-    send_error(kind, reason, stacktrace, &Function.identity/1)
+    send_error(kind, reason, stacktrace, & &1)
   end
 
   def send_error(kind, reason, stacktrace, fun) do

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -67,8 +67,13 @@ defmodule Appsignal.Instrumentation do
   end
 
   def send_error(kind, reason, stacktrace) do
+    send_error(kind, reason, stacktrace, &Function.identity/1)
+  end
+
+  def send_error(kind, reason, stacktrace, fun) do
     @span.create_root("http_request", self())
     |> @span.add_error(kind, reason, stacktrace)
+    |> fun.()
     |> @span.close()
   end
 

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -563,4 +563,42 @@ defmodule Appsignal.InstrumentationTest do
       assert {:ok, [{%Span{}}]} = Test.Span.get(:close)
     end
   end
+
+  describe ".send_error/4, when passing a function" do
+    setup do
+      {kind, reason, stack} =
+        try do
+          raise "Exception!"
+        catch
+          kind, reason -> {kind, reason, __STACKTRACE__}
+        end
+
+      return = Appsignal.Instrumentation.send_error(kind, reason, stack, fn(span) ->
+        Appsignal.Test.Span.set_attribute(span, "key", "value")
+      end)
+
+      [
+        kind: kind,
+        reason: reason,
+        stack: stack,
+        return: return
+      ]
+    end
+
+    test "creates a root span" do
+      assert Test.Span.get(:create_root) == {:ok, [{"http_request", self()}]}
+    end
+
+    test "adds the error to the span", %{reason: reason, stack: stack} do
+      assert {:ok, [{%Span{}, :error, ^reason, ^stack}]} = Test.Span.get(:add_error)
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Span.get(:close)
+    end
+
+    test "runs the function" do
+      assert {:ok, [{%Appsignal.Span{}, "key", "value"}]}  = Test.Span.get(:set_attribute)
+    end
+  end
 end

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -564,6 +564,44 @@ defmodule Appsignal.InstrumentationTest do
     end
   end
 
+  describe ".send_error/3, when passing a function" do
+    setup do
+      {exception, stack} =
+        try do
+          raise "Exception!"
+        rescue
+          exception -> {exception, __STACKTRACE__}
+        end
+
+      return =
+        Appsignal.Instrumentation.send_error(exception, stack, fn span ->
+          Appsignal.Test.Span.set_attribute(span, "key", "value")
+        end)
+
+      [
+        exception: exception,
+        stack: stack,
+        return: return
+      ]
+    end
+
+    test "creates a root span" do
+      assert Test.Span.get(:create_root) == {:ok, [{"http_request", self()}]}
+    end
+
+    test "adds the error to the span", %{exception: exception, stack: stack} do
+      assert {:ok, [{%Span{}, ^exception, ^stack}]} = Test.Span.get(:add_error)
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Span.get(:close)
+    end
+
+    test "runs the function" do
+      assert {:ok, [{%Appsignal.Span{}, "key", "value"}]} = Test.Span.get(:set_attribute)
+    end
+  end
+
   describe ".send_error/4, when passing a function" do
     setup do
       {kind, reason, stack} =
@@ -573,9 +611,10 @@ defmodule Appsignal.InstrumentationTest do
           kind, reason -> {kind, reason, __STACKTRACE__}
         end
 
-      return = Appsignal.Instrumentation.send_error(kind, reason, stack, fn(span) ->
-        Appsignal.Test.Span.set_attribute(span, "key", "value")
-      end)
+      return =
+        Appsignal.Instrumentation.send_error(kind, reason, stack, fn span ->
+          Appsignal.Test.Span.set_attribute(span, "key", "value")
+        end)
 
       [
         kind: kind,
@@ -598,7 +637,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "runs the function" do
-      assert {:ok, [{%Appsignal.Span{}, "key", "value"}]}  = Test.Span.get(:set_attribute)
+      assert {:ok, [{%Appsignal.Span{}, "key", "value"}]} = Test.Span.get(:set_attribute)
     end
   end
 end


### PR DESCRIPTION
`send_error/2-4` takes a function as the last argument to add extra metadata.

```
try do
  raise "Exception!"
rescue
  exception ->
    Appsignal.send_error(exception, __STACKTRACE__, fn(span) ->
      Appsignal.Span.set_attribute(span, "key", "value")
    end)
end
```
