### PR TITLE
Clear warnings

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,6 +11,10 @@ blocks:
         commands:
           - checkout
       jobs:
+        - name: mix compile --warnings-as-errors
+          commands:
+            - ERLANG_VERSION=23.1 ELIXIR_VERSION=1.10.4 . bin/setup
+            - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
             - ERLANG_VERSION=23.1 ELIXIR_VERSION=1.10.4 . bin/setup

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -26,9 +26,9 @@ defmodule Appsignal do
     Appsignal.Ecto.attach()
 
     children = [
-      worker(Appsignal.Tracer, []),
-      worker(Appsignal.Monitor, []),
-      worker(Appsignal.Probes, [])
+      {Appsignal.Tracer, []},
+      {Appsignal.Monitor, []},
+      {Appsignal.Probes, []}
     ]
 
     result = Supervisor.start_link(children, strategy: :one_for_one, name: Appsignal.Supervisor)

--- a/lib/appsignal/instrumentation/helpers.ex
+++ b/lib/appsignal/instrumentation/helpers.ex
@@ -2,6 +2,9 @@ defmodule Appsignal.Instrumentation.Helpers do
   defdelegate instrument(fun), to: Appsignal.Instrumentation
   defdelegate instrument(name, fun), to: Appsignal.Instrumentation
   defdelegate instrument(name, title, fun), to: Appsignal.Instrumentation
+
   @deprecated "Use Appsignal.instrument/3 instead."
-  defdelegate instrument(transaction, name, title, fun), to: Appsignal.Instrumentation
+  def instrument(_transaction, name, title, fun) do
+    Appsignal.Instrumentation.instrument(name, title, fun)
+  end
 end

--- a/lib/appsignal/monitor.ex
+++ b/lib/appsignal/monitor.ex
@@ -36,4 +36,11 @@ defmodule Appsignal.Monitor do
     {:monitors, monitors} = Process.info(self(), :monitors)
     Enum.map(monitors, fn {:process, process} -> process end)
   end
+
+  def child_spec(_) do
+    %{
+      id: Appsignal.Monitor,
+      start: {Appsignal.Monitor, :start_link, []}
+    }
+  end
 end

--- a/lib/appsignal/probes/probes.ex
+++ b/lib/appsignal/probes/probes.ex
@@ -64,6 +64,13 @@ defmodule Appsignal.Probes do
     {:noreply, probes}
   end
 
+  def child_spec(_) do
+    %{
+      id: Appsignal.Probes,
+      start: {Appsignal.Probes, :start_link, []}
+    }
+  end
+
   defp genserver_running? do
     pid = Process.whereis(__MODULE__)
     !is_nil(pid) && Process.alive?(pid)

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -98,6 +98,13 @@ defmodule Appsignal.Tracer do
     |> root()
   end
 
+  def child_spec(_) do
+    %{
+      id: Appsignal.Tracer,
+      start: {Appsignal.Tracer, :start_link, []}
+    }
+  end
+
   defp current({_pid, :ignore}), do: nil
 
   defp current({_pid, span}), do: span


### PR DESCRIPTION
Fixes compiler warnings and adds a `--warnings-as-errors` check to CI.

Closes #592.
Closes https://github.com/orgs/appsignal/projects/35#card-52652361.
