### PR TITLE
Use pid from conn in Error.Backend if available

### DIFF
--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -42,6 +42,12 @@ defmodule Appsignal.Error.Backend do
     end
   end
 
+  defp handle_report(%{crash_reason: {reason, stacktrace}, pid: pid}) do
+    pid
+    |> @tracer.lookup()
+    |> do_handle_report(pid, reason, stacktrace)
+  end
+
   defp do_handle_report([{_pid, :ignore}], _, _, _) do
     :ok
   end

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -48,6 +48,10 @@ defmodule Appsignal.Error.Backend do
     |> do_handle_report(pid, reason, stacktrace)
   end
 
+  defp handle_report(_) do
+    :ok
+  end
+
   defp do_handle_report([{_pid, :ignore}], _, _, _) do
     :ok
   end

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -17,7 +17,7 @@ defmodule Appsignal.Error.Backend do
   end
 
   def handle_event({:error, gl, {_, _, _, metadata}}, state) when node(gl) == node() do
-    pid = metadata[:pid]
+    pid = extract_pid(metadata)
 
     case Keyword.get(metadata, :crash_reason) do
       {reason, stacktrace} ->
@@ -60,6 +60,18 @@ defmodule Appsignal.Error.Backend do
 
   def terminate(_reason, _state) do
     :ok
+  end
+
+  defp extract_pid([{:conn, %{owner: pid}} | _tail]) do
+    pid
+  end
+
+  defp extract_pid([{:pid, pid} | _tail]) do
+    pid
+  end
+
+  defp extract_pid([_ | tail]) do
+    extract_pid(tail)
   end
 
   defp set_error_data(span, reason, stacktrace) do

--- a/test/appsignal/error/backend_test.exs
+++ b/test/appsignal/error/backend_test.exs
@@ -24,6 +24,11 @@ defmodule Murphy do
     {:ok, chardata, metadata} = Logger.Translator.translate(min_level, level, kind, data)
     {:ok, chardata, metadata ++ [pid: "", conn: %{owner: self()}]}
   end
+
+  def from_cowboy(min_level, level, kind, data) do
+    {:ok, chardata, metadata} = Logger.Translator.translate(min_level, level, kind, data)
+    {:ok, chardata, metadata ++ [domain: [:cowboy]]}
+  end
 end
 
 defmodule Appsignal.Error.BackendTest do
@@ -121,6 +126,22 @@ defmodule Appsignal.Error.BackendTest do
       end)
 
       Logger.remove_translator({Murphy, :with_conn})
+    end
+
+    test "does not create a span" do
+      assert Test.Tracer.get(:create_span) == :error
+    end
+  end
+
+  describe "handle_event/3 from the cowboy domain, without a conn" do
+    setup %{pid: pid} do
+      Logger.add_translator({Murphy, :from_cowboy})
+
+      Murphy.call(pid, fn ->
+        raise "Exception"
+      end)
+
+      Logger.remove_translator({Murphy, :from_cowboy})
     end
 
     test "does not create a span" do

--- a/test/appsignal/error/backend_test.exs
+++ b/test/appsignal/error/backend_test.exs
@@ -20,7 +20,7 @@ defmodule Murphy do
     end)
   end
 
-  def translate(min_level, level, kind, data) do
+  def with_conn(min_level, level, kind, data) do
     {:ok, chardata, metadata} = Logger.Translator.translate(min_level, level, kind, data)
     {:ok, chardata, metadata ++ [pid: "", conn: %{owner: self()}]}
   end
@@ -113,14 +113,14 @@ defmodule Appsignal.Error.BackendTest do
 
   describe "handle_event/3 with a conn, with an ignored process" do
     setup %{pid: pid} do
-      Logger.add_translator({Murphy, :translate})
+      Logger.add_translator({Murphy, :with_conn})
 
       Murphy.call(pid, fn ->
         Tracer.ignore()
         raise "Exception"
       end)
 
-      Logger.remove_translator({Murphy, :translate})
+      Logger.remove_translator({Murphy, :with_conn})
     end
 
     test "does not create a span" do

--- a/test/appsignal/error/backend_test.exs
+++ b/test/appsignal/error/backend_test.exs
@@ -19,6 +19,11 @@ defmodule Murphy do
       end
     end)
   end
+
+  def translate(min_level, level, kind, data) do
+    {:ok, chardata, metadata} = Logger.Translator.translate(min_level, level, kind, data)
+    {:ok, chardata, metadata ++ [pid: "", conn: %{owner: self()}]}
+  end
 end
 
 defmodule Appsignal.Error.BackendTest do
@@ -99,6 +104,23 @@ defmodule Appsignal.Error.BackendTest do
       end)
 
       :ok
+    end
+
+    test "does not create a span" do
+      assert Test.Tracer.get(:create_span) == :error
+    end
+  end
+
+  describe "handle_event/3 with a conn, with an ignored process" do
+    setup %{pid: pid} do
+      Logger.add_translator({Murphy, :translate})
+
+      Murphy.call(pid, fn ->
+        Tracer.ignore()
+        raise "Exception"
+      end)
+
+      Logger.remove_translator({Murphy, :translate})
     end
 
     test "does not create a span" do


### PR DESCRIPTION
Appsignal.Plug [ignores](https://github.com/appsignal/appsignal-elixir-plug/blob/6eda8784eb27365077f3dce6b75983eec6d02b22/lib/appsignal_plug.ex#L61) the current process whenever it catches an exception. That’s done to allow `Appsignal.Error.Backend` to [drop](https://github.com/appsignal/appsignal-elixir/blob/main/lib/appsignal/error/backend.ex#L25-L26) any error reports that came from that process, as those were already handled by `Appsignal.Plug`.

Since plug_cowboy 2.0.2 (https://github.com/elixir-plug/plug_cowboy/commit/6513e38529324283dc7ac430e9f8a3107dbd936d, to be exact), the pid that’s sent to the error logger doesn’t match the pid we’re ignoring. This causes duplicate errors, where one is logged to the “web” namespace (the one caught by `Appsignal.Plug`) and another is logged in the “background” namespace (the one from `Appsignal.Error.Backend`).

Since https://github.com/elixir-plug/plug_cowboy/commit/1f2850086d5f26115878d65dccfd41b2b0ebcaa1, the `conn` is added to the report, allowing us to fetch the pid through the `conn`’s `owner` instead. This patch uses that instead of the `pid` if it’s available. This would still allow us to get errors from the `:cowboy` domain, just not from errors we’ve already caught elsewhere.

~Note: this is only available in a yet-to-be-released version of plug_cowboy.~ No longer true, this patch works without it as well: https://github.com/appsignal/appsignal-elixir/pull/631#issuecomment-768224900

Closes https://github.com/appsignal/support/issues/107.