### PR TITLE
Ensure the `:request_headers` config returns an empty list by default

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -114,7 +114,7 @@ defmodule Appsignal.Config do
   defp do_active?(_), do: false
 
   def request_headers do
-    Application.fetch_env!(:appsignal, :config)[:request_headers]
+    Application.fetch_env!(:appsignal, :config)[:request_headers] || []
   end
 
   def ca_file_path do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -608,6 +608,18 @@ defmodule Appsignal.ConfigTest do
              ) == default_configuration() |> Map.put(:request_headers, ~w(accept accept-charset))
     end
 
+    test "request_headers overwrites file configuration" do
+      assert with_env(
+               %{"APPSIGNAL_REQUEST_HEADERS" => "accept,accept-charset"},
+               fn ->
+                 with_config(
+                   %{request_headers: []},
+                   &init_config/0
+                 )
+               end
+             ) == default_configuration() |> Map.put(:request_headers, ~w(accept accept-charset))
+    end
+
     test "revision" do
       assert with_env(
                %{"APP_REVISION" => "03bd9e"},

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -116,8 +116,8 @@ defmodule Appsignal.ConfigTest do
   end
 
   describe "request_headers" do
-    test "is nil by default" do
-      assert with_config(%{}, &Config.request_headers/0) == nil
+    test "returns an empty list by default" do
+      assert with_config(%{}, &Config.request_headers/0) == []
     end
 
     test "returns the request_headers config" do


### PR DESCRIPTION
As discussed in https://appsignal.slack.com/archives/CNPP953E2/p1614000314014300.