### PR TITLE
Add `Appsignal.Logger` to only log debug messages when the `:debug` configuration is turned on

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,6 +6,7 @@ if Mix.env() in [:bench, :test, :test_no_nif] do
   config :appsignal, appsignal_diagnose_report: Appsignal.Diagnose.FakeReport
   config :appsignal, appsignal: Appsignal.FakeAppsignal
   config :appsignal, inet: FakeInet
+  config :appsignal, logger: Appsignal.Test.Logger
 
   config :appsignal, appsignal_tracer_nif: Appsignal.Test.Nif
   config :appsignal, appsignal_tracer: Appsignal.Test.Tracer

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -39,7 +39,7 @@ defmodule Appsignal do
 
   @doc false
   def stop(_state) do
-    Logger.debug("AppSignal stopping.")
+    Appsignal.Logger.debug("AppSignal stopping.")
   end
 
   @doc false
@@ -61,12 +61,12 @@ defmodule Appsignal do
         Logger.info("AppSignal disabled.")
 
       {:ok, true} ->
-        Logger.debug("AppSignal starting.")
+        Appsignal.Logger.debug("AppSignal starting.")
         Config.write_to_environment()
         Appsignal.Nif.start()
 
         if Appsignal.Nif.loaded?() do
-          Logger.debug("AppSignal started.")
+          Appsignal.Logger.debug("AppSignal started.")
         else
           Logger.error(
             "Failed to start AppSignal. Please run the diagnose task " <>

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -113,6 +113,14 @@ defmodule Appsignal.Config do
   defp do_active?(%{valid: true, active: true}), do: true
   defp do_active?(_), do: false
 
+  @doc """
+  Returns true if debug mode is turned on, false otherwise.
+  """
+  @spec debug?() :: boolean
+  def debug? do
+    Application.fetch_env!(:appsignal, :config)[:debug] || false
+  end
+
   def request_headers do
     Application.fetch_env!(:appsignal, :config)[:request_headers] || []
   end

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -21,7 +21,7 @@ defmodule Appsignal.Ecto do
 
     case :telemetry.attach({__MODULE__, event}, event, &handle_event/4, :ok) do
       :ok ->
-        Logger.debug("Appsignal.Ecto attached to #{inspect(event)}")
+        Appsignal.Logger.debug("Appsignal.Ecto attached to #{inspect(event)}")
 
       {:error, _} = error ->
         Logger.warn("Appsignal.Ecto not attached to #{inspect(event)}: #{inspect(error)}")

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -12,7 +12,7 @@ defmodule Appsignal.Error.Backend do
   def attach do
     case Logger.add_backend(Appsignal.Error.Backend) do
       {:error, error} -> Logger.warn("Appsignal.Error.Backend not attached to Logger: #{error}")
-      _ -> Logger.debug("Appsignal.Error.Backend attached to Logger")
+      _ -> Appsignal.Logger.debug("Appsignal.Error.Backend attached to Logger")
     end
   end
 

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -1,0 +1,8 @@
+defmodule Appsignal.Logger do
+  require Logger
+  @logger Application.get_env(:appsignal, :logger, Logger)
+
+  def debug(log) do
+    Appsignal.Config.debug?() && @logger.debug(log)
+  end
+end

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -2,7 +2,13 @@ defmodule Appsignal.Logger do
   require Logger
   @logger Application.get_env(:appsignal, :logger, Logger)
 
+  @spec debug(any()) :: :ok
+  @doc """
+  Passes the debug message to `Logger.debug/1` if `Appsignal.Config.debug?/0`
+  is `true`.
+  """
   def debug(log) do
     Appsignal.Config.debug?() && @logger.debug(log)
+    :ok
   end
 end

--- a/lib/appsignal/test/logger.ex
+++ b/lib/appsignal/test/logger.ex
@@ -1,0 +1,10 @@
+defmodule Appsignal.Test.Logger do
+  @moduledoc false
+  use Appsignal.Test.Wrapper
+  require Logger
+
+  def debug(log) do
+    add(:debug, {log})
+    Logger.debug(log)
+  end
+end

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -115,6 +115,20 @@ defmodule Appsignal.ConfigTest do
     end
   end
 
+  describe "debug?" do
+    test "when debug mode is turned on" do
+      assert with_config(%{debug: true}, &Config.debug?/0) == true
+    end
+
+    test "when debug mode is turned off" do
+      assert with_config(%{debug: false}, &Config.debug?/0) == false
+    end
+
+    test "when debug mode is not configured" do
+      assert with_config(%{}, &Config.debug?/0) == false
+    end
+  end
+
   describe "request_headers" do
     test "returns an empty list by default" do
       assert with_config(%{}, &Config.request_headers/0) == []

--- a/test/appsignal/logger_test.exs
+++ b/test/appsignal/logger_test.exs
@@ -8,23 +8,25 @@ defmodule Appsignal.LoggerTest do
   end
 
   test "logs when debug mode is turned on" do
-    with_config(
-      %{debug: true},
-      fn ->
-        Appsignal.Logger.debug("debug!")
-      end
-    )
+    assert :ok ==
+             with_config(
+               %{debug: true},
+               fn ->
+                 Appsignal.Logger.debug("debug!")
+               end
+             )
 
     assert {:ok, [{"debug!"}]} == Appsignal.Test.Logger.get(:debug)
   end
 
   test "logs when debug mode is turned off" do
-    with_config(
-      %{debug: false},
-      fn ->
-        Appsignal.Logger.debug("debug!")
-      end
-    )
+    assert :ok ==
+             with_config(
+               %{debug: false},
+               fn ->
+                 Appsignal.Logger.debug("debug!")
+               end
+             )
 
     assert :error == Appsignal.Test.Logger.get(:debug)
   end

--- a/test/appsignal/logger_test.exs
+++ b/test/appsignal/logger_test.exs
@@ -1,0 +1,31 @@
+defmodule Appsignal.LoggerTest do
+  import AppsignalTest.Utils, only: [with_config: 2]
+  use ExUnit.Case
+
+  setup do
+    start_supervised!(Appsignal.Test.Logger)
+    :ok
+  end
+
+  test "logs when debug mode is turned on" do
+    with_config(
+      %{debug: true},
+      fn ->
+        Appsignal.Logger.debug("debug!")
+      end
+    )
+
+    assert {:ok, [{"debug!"}]} == Appsignal.Test.Logger.get(:debug)
+  end
+
+  test "logs when debug mode is turned off" do
+    with_config(
+      %{debug: false},
+      fn ->
+        Appsignal.Logger.debug("debug!")
+      end
+    )
+
+    assert :error == Appsignal.Test.Logger.get(:debug)
+  end
+end


### PR DESCRIPTION
Adds `Appsignal.Logger.debug/1`, which calls out to `Logger.debug/1`, but only if the `:debug` configuration option is set to `true`.

This is the first part of closing #634, which will require patches to both the Plug and Phoenix packages.