### PR TITLE
use get_env/3 to avoid compilation errors

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -118,7 +118,7 @@ defmodule Appsignal.Config do
   """
   @spec debug?() :: boolean
   def debug? do
-    Application.fetch_env!(:appsignal, :config)[:debug] || false
+    Application.get_env(:appsignal, :config, @default_config)[:debug] || false
   end
 
   def request_headers do


### PR DESCRIPTION
closes https://github.com/appsignal/appsignal-elixir/issues/643

I have this working in the example repo described in #643 in this branch: https://github.com/the-mikedavis/appsignal-compile-time-example-repo/compare/fix-pr-bless and I see a successful compile with no configuration! :tada: 