### PR TITLE
Keep internal list of monitors in `Appsignal.Monitor` process

### DIFF
--- a/lib/appsignal/monitor.ex
+++ b/lib/appsignal/monitor.ex
@@ -36,10 +36,19 @@ defmodule Appsignal.Monitor do
     {:noreply, List.delete(monitors, pid)}
   end
 
+  def handle_info(:sync, _monitors) do
+    {:noreply, monitored_pids()}
+  end
+
   def child_spec(_) do
     %{
       id: Appsignal.Monitor,
       start: {Appsignal.Monitor, :start_link, []}
     }
+  end
+
+  defp monitored_pids do
+    {:monitors, monitors} = Process.info(self(), :monitors)
+    Enum.map(monitors, fn {:process, process} -> process end)
   end
 end

--- a/test/appsignal/monitor_test.exs
+++ b/test/appsignal/monitor_test.exs
@@ -54,6 +54,21 @@ defmodule Appsignal.MonitorTest do
     end)
   end
 
+  test "syncs the monitors list" do
+    Monitor.add()
+    :sys.replace_state(Appsignal.Monitor, fn _ -> [] end)
+
+    until(fn ->
+      assert :sys.get_state(Appsignal.Monitor) == []
+    end)
+
+    send(Appsignal.Monitor, :sync)
+
+    until(fn ->
+      assert :sys.get_state(Appsignal.Monitor) == [self()]
+    end)
+  end
+
   defp lookup(pid) do
     :ets.lookup(:"$appsignal_registry", pid)
   end

--- a/test/appsignal/monitor_test.exs
+++ b/test/appsignal/monitor_test.exs
@@ -45,6 +45,15 @@ defmodule Appsignal.MonitorTest do
     end)
   end
 
+  test "automatically removes pids that don't exist from the monitor list" do
+    pid = :erlang.list_to_pid('<0.999.0>')
+    GenServer.cast(Appsignal.Monitor, {:monitor, pid})
+
+    until(fn ->
+      assert :sys.get_state(Appsignal.Monitor) == []
+    end)
+  end
+
   defp lookup(pid) do
     :ets.lookup(:"$appsignal_registry", pid)
   end


### PR DESCRIPTION
As reported through [support](https://app.intercom.com/a/apps/yzor8gyw/inbox/inbox/conversation/16410700035905#part_id=comment-16410700035905-8913685523) (private Intercom link), we’ve had a customer report message queue buildups in `Appsignal.Monitor` for their high-throughput app caused by our use  of `Process.info(self(), :monitors)`.

This patch moves off calling to `Process.info/2` for every created monitor, and instead keeps an internal list. It’s updated to match the actual list every 60 seconds automatically, although we haven’t found a way to get non-existent pids into the list with the current API.

Closes https://github.com/appsignal/support/issues/128.