### PR TITLE
Replacing AppSignal.Monitor's list state with a MapSet

### DIFF
--- a/test/appsignal/monitor_test.exs
+++ b/test/appsignal/monitor_test.exs
@@ -50,22 +50,22 @@ defmodule Appsignal.MonitorTest do
     GenServer.cast(Appsignal.Monitor, {:monitor, pid})
 
     until(fn ->
-      assert :sys.get_state(Appsignal.Monitor) == []
+      assert MapSet.size(:sys.get_state(Appsignal.Monitor)) == 0
     end)
   end
 
   test "syncs the monitors list" do
     Monitor.add()
-    :sys.replace_state(Appsignal.Monitor, fn _ -> [] end)
+    :sys.replace_state(Appsignal.Monitor, fn _ -> MapSet.new() end)
 
     until(fn ->
-      assert :sys.get_state(Appsignal.Monitor) == []
+      assert MapSet.size(:sys.get_state(Appsignal.Monitor)) == 0
     end)
 
     send(Appsignal.Monitor, :sync)
 
     until(fn ->
-      assert :sys.get_state(Appsignal.Monitor) == [self()]
+      assert MapSet.member?(:sys.get_state(Appsignal.Monitor), self())
     end)
   end
 


### PR DESCRIPTION
The `Appsignal.Monitor` GenServer was storing a list of pids, but since uniqueness is guaranteed (you can't monitor a particular pid more than once), MapSet is a better data structure to store this information, since all its operations are constant-time instead of linear-time. 

Considering that this GenServer was previously a performance bottleneck in v2.1.6, I think this incremental improvement makes sense to curb potential future performance issues.