### PR TITLE
Track erlang atom metrics

### DIFF
--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -8,6 +8,7 @@ defmodule Appsignal.Probes.ErlangProbe do
     scheduler_metrics()
     process_metrics()
     memory_metrics()
+    atom_metrics()
     run_queue_lengths()
   end
 
@@ -39,6 +40,11 @@ defmodule Appsignal.Probes.ErlangProbe do
     Enum.each(memory, fn {key, value} ->
       set_gauge("erlang_memory", Kernel.div(value, 1024), %{type: to_string(key)})
     end)
+  end
+
+  defp atom_metrics do
+    set_gauge("erlang_atoms", :erlang.system_info(:atom_limit), %{type: "limit"})
+    set_gauge("erlang_atoms", :erlang.system_info(:atom_count), %{type: "count"})
   end
 
   defp run_queue_lengths do

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -212,6 +212,34 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
+    test "gathers atom metrics", %{fake_appsignal: fake_appsignal} do
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_atoms")
+
+      assert Enum.any?(
+               metrics,
+               &match?(
+                 %{
+                   key: "erlang_atoms",
+                   tags: %{type: "count", hostname: "Bobs-MBP.example.com"},
+                   value: _
+                 },
+                 &1
+               )
+             )
+
+      assert Enum.any?(
+               metrics,
+               &match?(
+                 %{
+                   key: "erlang_atoms",
+                   tags: %{type: "limit", hostname: "Bobs-MBP.example.com"},
+                   value: _
+                 },
+                 &1
+               )
+             )
+    end
+
     test "gathers run queue lengths", %{fake_appsignal: fake_appsignal} do
       metrics = FakeAppsignal.get_gauges(fake_appsignal, "total_run_queue_lengths")
 


### PR DESCRIPTION
As requested in https://github.com/appsignal/support/issues/136, track
the atom limit and current atom count. This way users can set up alerts
based on if they (start to) reach the upper limit.

I've added this as their own `erlang_atom` metric with the `limit` and
`count` type tag values, like how do create metrics for the
`process_limit` and `process_count`.

Closes https://github.com/appsignal/support/issues/136