### PR TITLE
Improve error names

### DIFF
--- a/lib/appsignal/error.ex
+++ b/lib/appsignal/error.ex
@@ -1,9 +1,11 @@
 defmodule Appsignal.Error do
   @moduledoc false
   def metadata(%_{__exception__: true} = exception, stack) do
+    banner = Exception.format_banner(:error, exception, stack)
+
     {
-      inspect(exception.__struct__),
-      Exception.format_banner(:error, exception, stack),
+      name(banner, exception.__struct__),
+      banner,
       Appsignal.Stacktrace.format(stack)
     }
   end
@@ -15,10 +17,20 @@ defmodule Appsignal.Error do
   end
 
   def metadata(kind, reason, stack) do
+    banner = Exception.format_banner(kind, reason, stack)
+
     {
-      inspect(kind),
-      Exception.format_banner(kind, reason, stack),
+      name(banner, kind),
+      banner,
       Appsignal.Stacktrace.format(stack)
     }
+  end
+
+  defp name(banner, type) do
+    if String.contains?(banner, inspect(type)) do
+      banner
+    else
+      type <> " " <> banner
+    end
   end
 end

--- a/test/appsignal/error_test.exs
+++ b/test/appsignal/error_test.exs
@@ -11,7 +11,7 @@ defmodule Appsignal.ErrorTest do
     end
 
     test "extracts the error's name", %{metadata: metadata} do
-      assert {"RuntimeError", _message, _stack} = metadata
+      assert {"** (RuntimeError) Exception!", _message, _stack} = metadata
     end
 
     test "extracts the error's message", %{metadata: metadata} do
@@ -36,7 +36,7 @@ defmodule Appsignal.ErrorTest do
     end
 
     test "extracts the error's name", %{metadata: metadata} do
-      assert {"RuntimeError", _message, _stack} = metadata
+      assert {"** (RuntimeError) Exception!", _message, _stack} = metadata
     end
 
     test "extracts the error's message", %{metadata: metadata} do
@@ -61,7 +61,7 @@ defmodule Appsignal.ErrorTest do
     end
 
     test "extracts the error's name", %{metadata: metadata} do
-      assert {"ArgumentError", _message, _stack} = metadata
+      assert {"** (ArgumentError) argument error", _message, _stack} = metadata
     end
 
     test "extracts the error's message", %{metadata: metadata} do
@@ -86,7 +86,7 @@ defmodule Appsignal.ErrorTest do
     end
 
     test "extracts the error's name", %{metadata: metadata} do
-      assert {":exit", _message, _stack} = metadata
+      assert {"** (exit) :exited", _message, _stack} = metadata
     end
 
     test "extracts the error's message", %{metadata: metadata} do

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -246,7 +246,7 @@ defmodule AppsignalSpanTest do
     end
 
     test "sets the error through the Nif", %{span: %Span{reference: reference}} do
-      assert [{^reference, "RuntimeError", "** (RuntimeError) Exception!", _}] =
+      assert [{^reference, "** (RuntimeError) Exception!", "** (RuntimeError) Exception!", _}] =
                Test.Nif.get!(:add_span_error)
     end
   end
@@ -270,8 +270,10 @@ defmodule AppsignalSpanTest do
     end
 
     test "sets the error through the Nif", %{span: %Span{reference: reference}} do
-      assert [{^reference, "ArgumentError", "** (ArgumentError) argument error", _}] =
-               Test.Nif.get!(:add_span_error)
+      assert [
+               {^reference, "** (ArgumentError) argument error",
+                "** (ArgumentError) argument error", _}
+             ] = Test.Nif.get!(:add_span_error)
     end
   end
 
@@ -338,7 +340,7 @@ defmodule AppsignalSpanTest do
     end
 
     test "sets the error through the Nif", %{span: %Span{reference: reference}} do
-      assert [{^reference, "RuntimeError", "** (RuntimeError) Exception!", _}] =
+      assert [{^reference, "** (RuntimeError) Exception!", "** (RuntimeError) Exception!", _}] =
                Test.Nif.get!(:add_span_error)
     end
   end
@@ -362,8 +364,10 @@ defmodule AppsignalSpanTest do
     end
 
     test "sets the error through the Nif", %{span: %Span{reference: reference}} do
-      assert [{^reference, "ArgumentError", "** (ArgumentError) argument error", _}] =
-               Test.Nif.get!(:add_span_error)
+      assert [
+               {^reference, "** (ArgumentError) argument error",
+                "** (ArgumentError) argument error", _}
+             ] = Test.Nif.get!(:add_span_error)
     end
   end
 


### PR DESCRIPTION
Right now, all error events on the Incidents -> Errors -> Issues List page are slotted into a few large error buckets, such as `FunctionClauseError`, `CastError`, `ErlangError`, etc... This is because the "name" is simply the struct name of the Exception module. The problem with this is that you could have dozens of different `FunctionClauseError`s, each needing to be triaged, submitted to you ticketing system, and tracked independently. This is not possible to do currently, as they all show up as different "samples" of the same Error. This PR integrates the beginning of the actual error message in the error name, causing same error structs with different causes to be tracked independently.