### PR TITLE
Update APPSIGNAL_BUILD_FOR_MUSL flag behavior

### DIFF
--- a/.changesets/musl-flag.md
+++ b/.changesets/musl-flag.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Update `APPSIGNAL_BUILD_FOR_MUSL` behavior to only listen to the values `1` and `true`. This way `APPSIGNAL_BUILD_FOR_MUSL=false` is not interpreted to install the musl build.

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -627,7 +627,8 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp force_musl_build? do
-    !is_nil(System.get_env("APPSIGNAL_BUILD_FOR_MUSL"))
+    env = System.get_env("APPSIGNAL_BUILD_FOR_MUSL")
+    env == "1" || env == "true"
   end
 
   defp make do

--- a/test/mix/helpers_test.exs
+++ b/test/mix/helpers_test.exs
@@ -16,8 +16,20 @@ defmodule Mix.Appsignal.HelperTest do
       assert Mix.Appsignal.Helper.agent_platform() == "linux"
     end
 
-    test "returns the musl build when using the APPSIGNAL_BUILD_FOR_MUSL env var" do
+    test "does not return the musl build when using the APPSIGNAL_BUILD_FOR_MUSL=='' env var" do
+      with_env(%{"APPSIGNAL_BUILD_FOR_MUSL" => ""}, fn ->
+        assert Mix.Appsignal.Helper.agent_platform() != "linux-musl"
+      end)
+    end
+
+    test "returns the musl build when using the APPSIGNAL_BUILD_FOR_MUSL==1 env var" do
       with_env(%{"APPSIGNAL_BUILD_FOR_MUSL" => "1"}, fn ->
+        assert Mix.Appsignal.Helper.agent_platform() == "linux-musl"
+      end)
+    end
+
+    test "returns the musl build when using the APPSIGNAL_BUILD_FOR_MUSL==true env var" do
+      with_env(%{"APPSIGNAL_BUILD_FOR_MUSL" => "true"}, fn ->
         assert Mix.Appsignal.Helper.agent_platform() == "linux-musl"
       end)
     end


### PR DESCRIPTION
Currently the APPSIGNAL_BUILD_FOR_MUSL flag listens to any value and
accepts that as meaning that the user intends to install the Linux musl
build.

The defined behavior in the integrations guide specifies that the
APPSIGNAL_BUILD_FOR_MUSL env var should listen to the `1` or `true`
values.

Source:
https://github.com/appsignal/integration-guide/blob/9b6fb1491e3aab87cb29b732470c8162f9cd080b/build/installation.md#appsignal_build_for_musl

Update the APPSIGNAL_BUILD_FOR_MUSL flag to listen to only the `1` and
`true` values as agreed upon.