### PR TITLE
Add mono to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,64 @@
-# 2.1.7
+# AppSignal for Elixir changelog
+
+## 2.1.7
 - Keep internal list of monitors in Appsignal.Monitor process. PR 648
 
-# 2.1.6
+## 2.1.6
 - Fix `Appsignal.logger` debug level issue on no config present. PR #644
 - Bump agent to d08ae6c. PR #645. Fix span API related issues with empty events
   for error samples and missing incidents.
 
-# 2.1.5
+## 2.1.5
 - Add `Appsignal.Logger` to only log debug messages when the `:debug` configuration is turned on. PR #642
 
-# 2.1.4
+## 2.1.4
 - Ensure the `:request_headers` config returns an empty list by default. PR #637
 
-# 2.1.3
+## 2.1.3
 - Use pid from conn in Error.Backend if available. PR #631
 
-# 2.1.2
+## 2.1.2
 - Make sure Appsignal.se(nd|t)_error is properly delegated. PR #629
 
-# 2.1.1
+## 2.1.1
 - Probes.handle_info/2 handles non-exception errors. PR #626
 
-# 2.1.0
+## 2.1.0
 - Pass functions to set error  PR #622
 - Pass Elixir exceptions to `Appsignal.Instrumentation.se(t|nd)_error/2`. PR #620
 
-# 2.0.8
+## 2.0.8
 - Clear warnings. PR #623
 
-# 2.0.7
+## 2.0.7
 - Let set error use root span. PR (#611)
 - Bump agent to v-44e4d97
   - Implement ignore namespaces for spans. PR #645
 
-# 2.0.6
+## 2.0.6
 - Monitor all registered spans. PR #608
 - Switch to reference-based child Span API, fixes memory leak when using
   child spans. PR #607
 
-# 2.0.5
+## 2.0.5
 - Don't register query spans without parents. PR #600
 
-# 2.0.4
+## 2.0.4
 - Bump agent to v-c55fb2c
   - Fix ignore actions and spans without names bugs. PR #639
 
-# 2.0.3
+## 2.0.3
 - Bump agent to v-f9d2b57
   - Add error counts to map for spans. PR #638
 
-# 2.0.2
+## 2.0.2
 - Use "channel" namespace in channel_action decorator. PR #596
 
-# 2.0.1
+## 2.0.1
 - Ignore unhandled info, code_change and terminate in Error.Backend. PR #594
 - Explicitly ignore returns from Span functions. PR #593
 
-# 2.0.0
+## 2.0.0
 - Set categories from `transaction_event/3` decorator fallback. PR #583
 - Remove Plug and Phoenix fallbacks in favour of post-install message. PR #582
 - Bump agent to v-881e3b3
@@ -92,38 +94,38 @@
 - Split out Phoenix integration into separate library
 - Bump agent to v-a21a12a
 
-# 1.13.5
+## 1.13.5
 - Bump agent to v-20f7d0d
   - Spawn agent without waiting for it. PR #618
   - Agent writes diagnose to file, extension reads from file. PR #628
 
-# 1.13.4
+## 1.13.4
 - Bump agent to v-4548c88
   - Fix issue with host metrics values being reported as "Infinity". PR #572
 
-# 1.13.3
+## 1.13.3
 - Add callback for `TransactionBehaviour.set_sample_data/2`. PR #560
 - Use tls 1.3 cipher suites on OTP 23. PR #571
 
-# 1.13.2
+## 1.13.2
 - Handle non-string-non-atom-non-iteger values in Transaction.to_s/1
   Commit 772cb943b6d545942a50042a268d441973adab23
 
-# 1.13.1
+## 1.13.1
 - Use `__STACKTRACE__ /0` on Elixir >= 1.7. PR 559
 - Relax live_view dependency to allow versions over 0.9. PR #558
 - Bump agent to v-96b684b
   - Check if queued payloads are for correct app and not expired
 
-# 1.13.0
+## 1.13.0
 - Add LiveView instrumentation helpers. PR #549
 - Fix typespec for Appsignal.Phoenix.Channel.channel_action/4. PR #553
 - Add record event callback to TransactionBehaviour. PR #555
 
-# 1.12.1
+## 1.12.1
 - EventHandler handles router_dispatch events with plug_opts #547
 
-# 1.12.0
+## 1.12.0
 - Add explicit error handling for Phoenix channels. PR #527
 - Add Phoenix Telemetry event handler to add Phoenix 1.5 instrumentation. PR #528 & #538
 
@@ -150,19 +152,19 @@
   instrumentation should appear automatically in your samples as an event named
   call.phoenix_endpoint.
 
-# 1.11.8
+## 1.11.8
 - Reduce calls to pids_and_monitor_references/1 and :ets.match/1 #543. PR #543
 
-# 1.11.7
+## 1.11.7
 - Return the Ecto.LogEntry even if the transaction is nil. PR #542
 
-# 1.11.6
+## 1.11.6
 - Call pids_and_monitor_references/1 from TransactionRegistry. PR #541
 
-# 1.11.5
+## 1.11.5
 - Use a complete set of ssl_options for Hackney. PR #534
 
-# 1.11.4
+## 1.11.4
 - Add transaction_debug configuration option. PR #526
 - Bump agent to v-c348132
   - Improve transmitter logging on timeout
@@ -171,18 +173,18 @@
   - Add transaction debug mode
   - Wrap Option in Mutex in TransactionInProgess
 
-# 1.11.3
+## 1.11.3
 - Transaction.set_action/2 returns the Transaction on failure. commit 16e5ecbc90aece993177da7e1b2486fa477e25e8
 - Don't match on :ok on Appsignal.Plug.finish_with_conn/2. commit ebc7dd968a9bbeff3447e8f84dab181205f976ed
 
-# 1.11.2
+## 1.11.2
 - Run receiver monitors in receiver process. PR #525.
 - Move action nil-check to `Appsignal.Transaction.set_action/2`. PR #523.
 
-# 1.11.1
+## 1.11.1
 - Don't match on return from `Transaction.complete/1`. PR #521
 
-# 1.11.0
+## 1.11.0
 - Convert time units for all Ecto callbacks. PR #481
 - Deactivate AppSignal when not active. PR #478
 - Fix FreeBSD compilation. PR #484
@@ -191,19 +193,19 @@
 - Add Erlang Run Queue length metric. PR #492
 - Filter structs in MapFilter. PR #507
 
-# 1.10.13
+## 1.10.13
 - OTP 22.1 hackney workaround for honor_cipher_order. PR #516
 - Bump agent to v-690f4b8 - commit 5245f919d975135d553a89b019c421e1fe27edd3
   - Validate transmission_interval option.
 
-# 1.10.12
+## 1.10.12
 - Bump agent to v-e1c9363
   - Better detect zombie/defunct processes on containers and consider the
     processes dead. This should improve the appsignal-agent start behavior.
   - Detect revision from Heroku dynos automatically when Dyno Metadata is
     turned on.
 
-# 1.10.11
+## 1.10.11
 - Bump agent to v-a718022
   - Fix container CPU runtime metrics.
     See https://github.com/appsignal/probes-rs/pull/38 for more information.
@@ -212,45 +214,45 @@
   - Support Kernel 4.18+ format of /proc/diskstats file parsing.
     See https://github.com/appsignal/probes-rs/pull/39 for more information.
 
-# 1.10.10
+## 1.10.10
 - Restore get_filter_(parameters|session_data) to patch backwards compatibility. PR #500
 
-# 1.10.9
+## 1.10.9
 - Support parameter filtering with {:keep, params}. PR #499
 
-# 1.10.8
+## 1.10.8
 - Handle non-maps in Config.active?/0. PR #495
 - Use Phoenix >= 1.2.0 and < 1.4.0 on Elixir 1.3. PR #496
 
-# 1.10.7
+## 1.10.7
 - Fix musl detection on installation. PR #493
 
-# 1.10.6
+## 1.10.6
 - Use the bundled certificate and ciphers when downloading agent (#491)
 - Explicitly set ciphers in hackney https requests (#489)
 - Remove log statements from TransactionRegisty (#490)
 - Improve ldd version error handling (#487)
 
-# 1.10.5
+## 1.10.5
 - Remove explicit ignore check in TransactionRegistry. PR #480
 - Handle errors in Mix.Appsignal.Helper.uid/0. PR #479
 
-# 1.10.4
+## 1.10.4
 - Handle atom keys in MapFilter.filter_values/2. PR #475
 
-# 1.10.3
+## 1.10.3
 - Track memory metrics of the current process. PR #473
 
-# 1.10.2
+## 1.10.2
 - Fix memory leak in custom metrics key names.
   Commit 91c65e51cc949e66b3f504444f3570858a598352
 
-# 1.10.1
+## 1.10.1
 * Add enable_minutely_probes config option. PR #470
 * Tag hostnames in ErlangProbe. PR #469
 * Don't use fetch_env!/2 in ErlangProbe. PR #471
 
-# 1.10.0
+## 1.10.0
 * Store extension installation details in report. PR #433
 * Fail AppSignal extension installation on warnings
   Commit 7b17a0b86f87ea7097315d1247ccd52c78be8e97
@@ -270,20 +272,20 @@
 * Add Erlang Probe. PR #466
 * Minutely Probing for Custom Metrics. PR #461
 
-# 1.9.4
+## 1.9.4
 - Update Ecto integration to support both Telemetry 0.3.x and 0.4.x. PR #459
 
-# 1.9.3
+## 1.9.3
 - Support send_params option. PR #456
 
-# 1.9.2
+## 1.9.2
 - Fix multi user permission issue for agent directories and files.
   Commit fdd650097b702a8aa60ee90ee93ad4e3e3365d81
 
-# 1.9.1
+## 1.9.1
 * Block on ignoring PIDs in TransactionRegistry. PR #448
 
-# 1.9.0
+## 1.9.0
 * Add missing host OS field to diagnose report. PR #418
 * Link back to AppSignal diagnose report page. PR #420
 * Add `Error.metadata/2` to extract error metadata. PR #423
@@ -295,7 +297,7 @@
 * Change files_world_accessible permissions to not make files executable. PR #431
 * Make agent debug logging for disk IO metrics more robust. PR #431
 
-# 1.8.2
+## 1.8.2
 * Add Appsignal.Ecto.handle_event/4 to support Ecto 3. PR #416
 * Add diagnose command --[no-]send-report option. PR #414
 * Group extension and agent tests in diagnose output. PR #413
@@ -306,52 +308,52 @@
 * Allow Appsignal.send_error/1-7 to be called without a stack trace. PR #400
 * Use `Mix.shell.info` instead of `Logger.info` in mix helpers. PR #399
 
-# 1.8.1
+## 1.8.1
 * Fix linking issues on multi-stage build setups. PR #406
 
-# 1.8.0
+## 1.8.0
 * Add working_directory_path config option. PR #363
 * Use doubles values in custom metrics functions. PR #384
 * Support Elixir 1.7. PR #386
 
-# 1.7.2
+## 1.7.2
 * Ensure ca_file_path is written to agent env. PR #381
 * Use gmake over make when gmake executable exists. PR #382
 
-# 1.7.1
+## 1.7.1
 * Fix absolute path to CA certificate file. PR #380
 
-# 1.7.0
+## 1.7.0
 * Bundle CA certificate. PR #364
 * Add Appsignal.Transaction.set_namespace/1-2. PR #361
 * Use :hackney instead of cURL to download agent. PR #359
 
-# 1.6.7
+## 1.6.7
 * Revert container memory metrics fixes. PR #370
 * Fix _APP_REVISION read logic in extension. PR #370
 * Fix _APPSIGNAL_PROCESS_NAME read logic in extension. PR #370
 
-# 1.6.6
+## 1.6.6
 * Add container memory metrics fixes.
 * Use local agent environment instead of system environment. PR #368
 
-# 1.6.5
+## 1.6.5
 * Allow calling `Transaction.register/1` and `Transaction.complete/1` when the Registry is not alive. PR #356
 
-# 1.6.4
+## 1.6.4
 * Overwrite message for Phoenix.ActionClauseError. PR #355
 
-# 1.6.3
+## 1.6.3
 * Remove script_name, query_string and peer from Plug.extract_sample_data/1. PR #351
 
-# 1.6.2
+## 1.6.2
 * Merge instead of ignore Phoenix's :filter_parameters if also configured in AppSignal. PR #349
 
-# 1.6.1
+## 1.6.1
 * Remove request_headers warning and use sane default. PR #346
 * Fix metrics format for internal agent metrics. PR #347
 
-# 1.6.0
+## 1.6.0
 * Explicit header whitelist in configuration (#336)
 * Add filter_session_data config option (#343)
 * Log with :info level instead of :warn when AppSignal is disabled (#340)
@@ -366,7 +368,7 @@
 * Filter arguments in backtraces (#326)
 * Relax :httpoison dependency to allow ~> 1.0 (#322)
 
-# 1.5.0
+## 1.5.0
 * Add agent.exs file to package in mix.exs (#323)
 * Restore :revision config (#315)
 * Underscored environment variables are always overwritten (#316)
@@ -379,48 +381,48 @@
   - Fix locking issue on diagnose mode run
   - Increase stored length of error messages
 
-# 1.4.10
+## 1.4.10
 * Fix POST parameters in errors, take the Plug.Conn from Plug.Conn.WrapperErrors (#309)
 
-# 1.4.9
+## 1.4.9
 * Add x-real-ip to request header whitelist (#308)
 * ErrorHandler doesn't cause warnings for noise over handle_info (#304)
 
-# 1.4.8
+## 1.4.8
 * Fix transaction metadata for send_error (#303)
 * Use Application.load/1 in diagnose task (#297)
 * Fix DataEncoder.encode error (#293)
 * Update agent to fix locking issue in diagnose (#300)
 
-# 1.4.7
+## 1.4.7
 * Fix compile errors on Elixir 1.6 (#298)
 
-# 1.4.6
+## 1.4.6
 * Wrap WrapperError clause in Appsignal.plug? (#291)
 * Don't use Plug.ErrorHandler.__catch__/4 in Appsignal.Plug (#287)
 
-# 1.4.5
+## 1.4.5
 * Ensure the appsignal application is started when running diagnose (#286)
 
-# 1.4.4
+## 1.4.4
 * ErrorHandler unwraps Plug.Conn.WrapperError (#281)
 * Fetch request_id in Appsignal.Plug.extract_meta_data/1 (#283)
 
-# 1.4.3
+## 1.4.3
 * Fix dialyzer linting violations. (#271)
 * Fix logger error on failed installation. (#275)
 * Reuse Appsignal.agent module by unloading it after use in `mix.exs`. (#277)
 
-# 1.4.2
+## 1.4.2
 * Change log level from info to debug for value comparing failures.
   Commit 76fafebba5e37cfd2c303c286271f4616cf63bd3
 * Collect free memory host metric.
   Commit 76fafebba5e37cfd2c303c286271f4616cf63bd3
 
-# 1.4.1
+## 1.4.1
 * Use musl build for older systems (#274)
 
-# 1.4.0
+## 1.4.0
 * Add separate GNU linux build. PR #265 and
   Commit b9546cae01cd89d597586ad6c7dc4b5213fe2fca
 * Add separate FreeBSD build
@@ -428,34 +430,34 @@
 * Auto restart agent when none is running
   Commit b9546cae01cd89d597586ad6c7dc4b5213fe2fca
 
-# 1.3.6
+## 1.3.6
 * Fix crashes when using a transaction from multiple processes in an unsupported way.
   Commit b9546cae01cd89d597586ad6c7dc4b5213fe2fca
 * Allow string values in atom config fields (#269)
 
-# 1.3.5
+## 1.3.5
 * Allow multiple calls to `send_error` in one Transaction (#260)
 
-# 1.3.4
+## 1.3.4
 * Allow configuration of permissions of working directory. (#246)
 * Fix locking bug that delayed extension shutdown.
   Commit 1953b2abced8c477af3eb973cc71b98c20761b51
 * Log extension start with app revision if present
   Commit 1953b2abced8c477af3eb973cc71b98c20761b51
 
-# 1.3.3
+## 1.3.3
 * No channel payloads in the channel_action decorator (#255)
 * Add architecture for elixir:alpine Docker image (#256)
 
-# 1.3.2
+## 1.3.2
 * Don't crash with unbound channel payloads (#253)
 
-# 1.3.1
+## 1.3.1
 
 * Appsignal.Phoenix.Channel.channel_action/5 includes channel parameters (#251)
 * Add files world accessible option to config (#246)
 
-# 1.3.0
+## 1.3.0
 
 * Plug support without Phoenix
 * Transaction.set_request_metadata sets path and method
@@ -464,41 +466,41 @@
 * Add ignore_namespaces option
 * Whitelist request headers
 
-# 1.2.3
+## 1.2.3
 
 * Add architecture mappings for 32bit systems. (#229)
 
-# 1.2.2
+## 1.2.2
 
 * Better backtraces for linked processes (#207)
 * Backtrace.format_stacktrace handles lists of binaries (#214)
 
-# 1.2.1
+## 1.2.1
 
 * Allow nil transaction in instrumentation (#198)
 * ErrorHandler handles errors in tuples (#201)
 * Set `env: Mix.env` in generated config.exs (#203)
 * Improve registry lookup performance (#205)
 
-# 1.2.0
+## 1.2.0
 
 * Catch and handle errors in the Plug using Plug.ErrorHandler instead of
   in Appsignal.ErrorHandler (#187 & #193)
 
-# 1.1.1
+## 1.1.1
 * Fix unpacking agent tar as root (#179)
 * Add Instrumentation.Helpers.instrument/3
 * Add Appsignal.Backtrace, deprecate ErrorHandler.format_stack/1
 
-# 1.1.0
+## 1.1.0
 * Depend on Phoenix >= 1.2.0 instead of ~> 1.2.0 (#167)
 * Reload the config in a separate process (#166)
 * Add action names to exceptions (#162)
 
-# 1.0.4
+## 1.0.4
 * Fix propagation of transaction decorator return value (#164)
 
-# 1.0.3
+## 1.0.3
 * Force the agent to run in diagnostics mode even if the app's config doesn't
   have AppSignal marked as active. (#132 and #160)
 * Remove duplicate config file linking output in installer (#159)
@@ -506,32 +508,32 @@
   env (#159)
 * Print missing APPSIGNAL_APP_ENV env var in installation instructions. (#161)
 
-# 1.0.2
+## 1.0.2
 * Remove extra comma from generated config/appsignal.exs (#158)
 
-# 1.0.1
+## 1.0.1
 * Remove (confusing revision logic) (#154)
 
-# 1.0.0
+## 1.0.0
 * Bump to 1.0.0 🎉
 
-# 0.13.0
+## 0.13.0
 * Send demo samples on install (#136)
 * Make mix tasks available in releases (#146)
 * Rename Phoenix framework event names (#148)
 * Open and close Transactions in Appsignal.Phoenix.Plug.call/2 (#131)
 
-# 0.12.3
+## 0.12.3
 * Move package version to a module attribute (#143)
 
-# 0.12.2
+## 0.12.2
 * Bump agent to 5464697
 * Check agent version in Mix.Appsignal.Helper.ensure_downloaded/1 (#141)
 
-# 0.12.1
+## 0.12.1
 * Upgrade HTTPoison and allow more versions
 
-# 0.12.0
+## 0.12.0
 * Add mix appsignal.diagnose task (#81)
 * Auto activate when push_api_key in env, not always (#89)
 * Bump agent to f81fe90
@@ -541,26 +543,26 @@
 * DataEncoder encodes bignums as strings (#88)
 * Remove automatic :running_in_container setting (moved to agent)
 
-# 0.11.6
+## 0.11.6
 * Send body->data instead of body to appsignal_finish_event
 
-# 0.11.5
+## 0.11.5
 * Bump agent to version with extra null pointer protection
 
-# 0.11.4
+## 0.11.4
 * Bump agent (360f06b)
 
-# 0.11.3
+## 0.11.3
 * Update musl version to fix DNS search issue (a8e6f23)
 
-# 0.11.2
+## 0.11.2
 * Add support for non-strings as map values in DataEncoder.encode/1 (#83)
 
-# 0.11.1
+## 0.11.1
 * Add phoenix as optional dependency to :prod (#80)
 * Add the module name to the transaction action while using decorators (#79)
 
-# 0.11.0
+## 0.11.0
 * Re-initialize Appsignal's config after a hot code upgrade. (#71)
 * Send all request headers (#75)
 * Add ErrorHandler.normalize_reason (#78)
@@ -570,7 +572,7 @@
 * Add appsignal.demo mix task (#69)
 * Drop Phoenix dependency #61
 
-# 0.10.0
+## 0.10.0
 * Check Appsignal.started?/1 in TransactionRegistry.lookup/2 (#54)
 * Various configuration fixes (#55)
 * Use APPSIGNAL_APP_ENV instead of APPSIGNAL_ENVIRONMENT (#56)
@@ -585,16 +587,16 @@
 * Add suport to refs and pids inside payloads (#57)
 * Add centos/redhat support for agent installation (#48)
 
-# 0.9.2
+## 0.9.2
 * Fix Makefile for spaces in path names
 * Set APPSIGNAL_IGNORE_ACTIONS from config (#41)
 * Send metadata in Appsignal.ErrorHandler.submit_transaction/6 (#40)
 * Add a section suggesting active: false in test env (#35)
 
-# 0.9.1
+## 0.9.1
 * Appsignal.Helpers has been moved to Appsignal.Instrumentation.Helpers
 
-# 0.9.0
+## 0.9.0
 * Remove instrumentation macros, switch to decorators
 * Update channel decorators documentation
 * Documentation on instrumentation decorators
@@ -603,7 +605,7 @@
 * Add documentation for filtered parameters (#28)
 * Appsignal.Utils.ParamsEncoder.preprocess/1 handles structs (#30)
 
-# 0.8.0
+## 0.8.0
 * Experimental support for channels
 * Add instrument_def macro for defining a single instrumented function
 * Document that we are using a NIF and how it is used
@@ -611,11 +613,10 @@
 * Don't warn about missing config when running tests
 * remember original stacktrace in phoenix endpoint (#26)
 
-# 0.7.0
+## 0.7.0
 * Allow Phoenix filter parameters and/or OS env variable to be used
 * Send Phoenix session information
 * Simplify Transaction API: Default to the current process transaction
 * Add Transaction.filter_values/2
 * Transaction.set_request_metadata/2 filters parameters
 * Fix host metrics config key in GettingStarted
-

--- a/README.md
+++ b/README.md
@@ -43,10 +43,14 @@ documentation](http://docs.appsignal.com/elixir/configuration/).
 Before you can start developing on the AppSignal for Elixir project make sure
 you have [Elixir installed](http://elixir-lang.org/install.html).
 
+This repository is managed by [mono](https://github.com/appsignal/mono/).
+Nstall mono on your local machine by [following the mono installation
+steps](https://github.com/appsignal/mono/#installation).
+
 Then make sure you have all the project's dependencies installed by running the
 following command:
 
-    $ mix deps.get
+    $ mono bootstrap
 
 ### Testing
 
@@ -54,6 +58,8 @@ Testing is done with ExUnit and can be run with the `mix test` command. You can
 also supply a path to a specific file path you want to test and even a specific
 line on which the test you want to run is defined.
 
+    $ mono test
+    # The original command can still be used
     $ mix test
     $ mix test test/appsignal/some_test.ex:123
 
@@ -81,14 +87,20 @@ library. The `develop` branch is used for development of features that
 will end up in the next minor release. If you fix a bug open a pull
 request on `main`, if it's a new feature on `develop`.
 
+### Making changes
+
+When making changes to the project that require a release, [add a
+changeset](https://github.com/appsignal/mono/#changeset-add) that will be used
+to update the generated `CHANGELOG.md` file upon
+[release](#publishing-new-version).
+
+    $ mono changeset add
+
 ### Publishing new versions
 
 1. Merge the `develop` branch to `main` if necessary.
--  Update the version number in `mix.exs`, e.g. `1.2.3`
--  Commit the change.
--  Tag the commit with the version number: `git tag 1.2.3`
--  Push the changes: `git push origin main 1.2.3`
--  Publish the package: `mix hex.publish`
+-  Run [`mono publish`](https://github.com/appsignal/mono/#publish) and follow
+   the instructions.
 
 ## Contributing
 

--- a/mono.yml
+++ b/mono.yml
@@ -1,0 +1,7 @@
+---
+language: elixir
+repo: "https://github.com/appsignal/appsignal-elixir"
+clean:
+  post: |
+    rm -rf c_src/appsignal-agent c_src/appsignal.* c_src/libappsignal.*
+    rm -rf priv/appsignal-agent priv/appsignal_extension.* priv/appsignal.version priv/*.report priv/libappsignal.*

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eu
+
+# Change version number to a release/tag available on the mono repo to update it
+# https://github.com/appsignal/mono/releases
+MONO_VERSION="v0.5.6"
+
+MONO_PATH="$HOME/mono"
+
+has_cache=false
+if which cache >/dev/null; then
+  has_cache=true
+fi
+
+if $has_cache; then
+  echo "Restoring mono cache"
+  cache restore mono-$MONO_VERSION
+fi
+
+# Download mono if the cache restored nothing
+if [ ! -d $MONO_PATH ]; then
+  mkdir -p $MONO_PATH
+  curl --location https://github.com/appsignal/mono/archive/refs/tags/$MONO_VERSION.tar.gz | \
+    tar -xz --strip-components=1 --directory $MONO_PATH
+  if $has_cache; then
+    echo "Storing mono cache"
+    cache store mono-$MONO_VERSION $MONO_PATH
+  fi
+fi
+
+cd $MONO_PATH
+# Install mono always as it adds itself to the PATH
+script/setup


### PR DESCRIPTION
Use our own tooling for development in the Elixir integration repos.
https://github.com/appsignal/mono/
Follow the instructions on the mono README to install it locally.

Mono is also installed on the CI using the `script/setup` script
which is run before every job. The mono download is cached between
jobs so we don't download it for every job fresh. Update the version
variable `MONO_VERSION` to update the mono install on the CI.
This `setup` script will check the existence of the `cache` command, if
not it will skip it. This allows it to be reused in the test-setups
repo.

Mono repo support for Elixir isn't 100% feature complete yet so we're
first adding it to every repo separately.

I didn't add mono to the Semaphore CI test setup as it doesn't really
add anything there at this point. I also didn't add it to the Ruby gem
CI yet either.