### PR TITLE
Add Linux ARM override value to diagnose report

### DIFF
--- a/.changesets/add-linux-arm-override-to-diagnose-report.md
+++ b/.changesets/add-linux-arm-override-to-diagnose-report.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Add Linux ARM override value to diagnose report. This was omitted from the original implementation of the `APPSIGNAL_BUILD_FOR_LINUX_ARM` flag.

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -188,6 +188,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("    Architecture: #{format_value(build_report["architecture"])}")
     IO.puts("    Target: #{format_value(build_report["target"])}")
     IO.puts("    Musl override: #{format_value(build_report["musl_override"])}")
+    IO.puts("    Linux ARM override: #{format_value(build_report["linux_arm_override"])}")
     IO.puts("    Library type: #{format_value(build_report["library_type"])}")
     host_report = installation_report["host"]
     IO.puts("  Host details")
@@ -207,6 +208,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("    Architecture: #{format_value(download_report["architecture"])}")
     IO.puts("    Target: #{format_value(download_report["target"])}")
     IO.puts("    Musl override: #{format_value(download_report["musl_override"])}")
+    IO.puts("    Linux ARM override: #{format_value(download_report["linux_arm_override"])}")
     IO.puts("    Library type: #{format_value(download_report["library_type"])}")
     IO.puts("    Checksum: #{format_value(download_report["checksum"])}")
   end

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -473,6 +473,7 @@ defmodule Mix.Appsignal.Helper do
         architecture: nil,
         target: os,
         musl_override: force_musl_build?(),
+        linux_arm_override: force_linux_arm_build?(),
         library_type: "static"
       },
       host: %{
@@ -494,6 +495,7 @@ defmodule Mix.Appsignal.Helper do
         architecture: architecture,
         target: target,
         musl_override: musl_override,
+        linux_arm_override: linux_arm_override,
         library_type: library_type
       }
     } = report
@@ -511,6 +513,7 @@ defmodule Mix.Appsignal.Helper do
         architecture: architecture,
         target: target,
         musl_override: musl_override,
+        linux_arm_override: linux_arm_override,
         library_type: library_type,
         download_url: download_url,
         checksum: checksum || "unverified"

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -99,6 +99,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert Enum.member?(valid_architectures, download_report["architecture"])
     assert Enum.member?(valid_targets, download_report["target"])
     assert download_report["musl_override"] == false
+    assert download_report["linux_arm_override"] == false
     assert download_report["library_type"] == "static"
     assert download_report["checksum"] == "verified"
 
@@ -110,6 +111,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert Enum.member?(valid_architectures, build_report["architecture"])
     assert Enum.member?(valid_targets, build_report["target"])
     assert download_report["musl_override"] == false
+    assert download_report["linux_arm_override"] == false
     assert build_report["library_type"] == "static"
   end
 
@@ -1127,6 +1129,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert output =~ ~r{Architecture: "x86(_64)?"}
     assert output =~ ~r{Target: "[\w-]+"}
     assert String.contains?(output, "  Musl override: false")
+    assert String.contains?(output, "  Linux ARM override: false")
     assert String.contains?(output, "  Library type: \"static\"")
     assert output =~ ~r{Checksum: "(verified|unverified)"}
   end


### PR DESCRIPTION
In PR #656 I added the experimental Linux ARM build behind a feature
flag. In the implementation I forgot to add the `linux_arm_override`
value to the diagnose report with which we can detect if this env var
was set during installation. This change adds that value to the report.