### PR TITLE
Transaction and channel action decorators only create root spans

### DIFF
--- a/.changesets/only-create-root-spans-from-transaction-and-channel-action-decorators.md
+++ b/.changesets/only-create-root-spans-from-transaction-and-channel-action-decorators.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Only create root spans from transaction and channel action decorators, as they're meant to only be used when no span exists yet.

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -59,6 +59,21 @@ defmodule Appsignal.Instrumentation do
     instrument(name, category, fun)
   end
 
+  def instrument_root(namespace, name, fun) do
+    span = @tracer.create_span("background_job", nil)
+
+    span
+    |> @span.set_name(name)
+    |> @span.set_attribute("appsignal:category", name)
+    |> @span.set_namespace(namespace)
+
+    result = fun.()
+
+    @tracer.close_span(span)
+
+    result
+  end
+
   @spec set_error(Exception.t(), Exception.stacktrace()) :: Appsignal.Span.t() | nil
   @doc """
   Set an error in the current root span.

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -59,13 +59,14 @@ defmodule Appsignal.Instrumentation do
     instrument(name, category, fun)
   end
 
+  @spec instrument_root(String.t(), String.t(), function()) :: any()
+  @doc false
   def instrument_root(namespace, name, fun) do
-    span = @tracer.create_span("background_job", nil)
+    span = @tracer.create_span(namespace, nil)
 
     span
     |> @span.set_name(name)
     |> @span.set_attribute("appsignal:category", name)
-    |> @span.set_namespace(namespace)
 
     result = fun.()
 

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -102,6 +102,12 @@ defmodule Appsignal.Instrumentation.Decorators do
   end
 
   def channel_action(body, %{module: module, args: [action, _payload, _socket]}) do
-    instrument("channel", body, %{module: module, name: action})
+    quote do
+      Appsignal.Instrumentation.instrument_root(
+        "channel",
+        "#{module_name(unquote(module))}.#{unquote(action)}",
+        fn -> unquote(body) end
+      )
+    end
   end
 end

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -80,11 +80,17 @@ defmodule Appsignal.Instrumentation.Decorators do
   end
 
   def transaction(body, context) do
-    instrument(body, context)
+    transaction("background_job", body, context)
   end
 
-  def transaction(namespace, body, context) do
-    instrument(namespace, body, context)
+  def transaction(namespace, body, %{module: module, name: name, arity: arity}) do
+    quote do
+      Appsignal.Instrumentation.instrument_root(
+        unquote(namespace),
+        "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
+        fn -> unquote(body) end
+      )
+    end
   end
 
   def transaction_event(body, context) do

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -83,7 +83,14 @@ defmodule Appsignal.Instrumentation.Decorators do
     transaction("background_job", body, context)
   end
 
-  def transaction(namespace, body, %{module: module, name: name, arity: arity}) do
+  def transaction(namespace, body, context) when is_atom(namespace) do
+    namespace
+    |> Atom.to_string()
+    |> transaction(body, context)
+  end
+
+  def transaction(namespace, body, %{module: module, name: name, arity: arity})
+      when is_binary(namespace) do
     quote do
       Appsignal.Instrumentation.instrument_root(
         unquote(namespace),

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -263,6 +263,34 @@ defmodule Appsignal.InstrumentationTest do
     end
   end
 
+  describe "channel_action/2, with a root span" do
+    setup do
+      Tracer.create_span("http_request")
+
+      %{return: InstrumentedModule.channel_action(:action, [], %{})}
+    end
+
+    test "calls the passed function, and returns its return", %{return: return} do
+      assert return == :ok
+    end
+
+    test "creates a root span" do
+      assert Test.Tracer.get(:create_span) == {:ok, [{"background_job", nil}]}
+    end
+
+    test "sets the span's namespace" do
+      assert {:ok, [{%Span{}, "channel"}]} = Test.Span.get(:set_namespace)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "InstrumentedModule.action"}]} = Test.Span.get(:set_name)
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
   describe "instrument/1" do
     setup do
       %{return: Appsignal.Instrumentation.instrument(fn -> :ok end)}

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -424,6 +424,48 @@ defmodule Appsignal.InstrumentationTest do
     end
   end
 
+  describe "instrument_root/3" do
+    setup do
+      %{
+        return: Appsignal.Instrumentation.instrument_root("background_job", "name", fn -> :ok end)
+      }
+    end
+
+    test "creates a root span" do
+      assert Test.Tracer.get(:create_span) == {:ok, [{"background_job", nil}]}
+    end
+
+    test "calls the passed function, and returns its return", %{return: return} do
+      assert return == :ok
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
+  describe "instrument_root/3, a root span" do
+    setup do
+      Tracer.create_span("root_span")
+
+      %{
+        return: Appsignal.Instrumentation.instrument_root("background_job", "name", fn -> :ok end)
+      }
+    end
+
+    test "creates a root span" do
+      assert Test.Tracer.get(:create_span) == {:ok, [{"background_job", nil}]}
+    end
+
+    test "calls the passed function, and returns its return", %{return: return} do
+      assert return == :ok
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
   describe ".set_error/2, with a root span" do
     setup do
       span = Tracer.create_span("http_request")

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -135,6 +135,30 @@ defmodule Appsignal.InstrumentationTest do
     end
   end
 
+  describe "transaction/2, with a root span" do
+    setup do
+      Tracer.create_span("http_request")
+
+      %{return: InstrumentedModule.transaction()}
+    end
+
+    test "calls the passed function, and returns its return", %{return: return} do
+      assert return == :ok
+    end
+
+    test "creates a root span" do
+      assert Test.Tracer.get(:create_span) == {:ok, [{"background_job", nil}]}
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "InstrumentedModule.transaction/0"}]} = Test.Span.get(:set_name)
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
   describe "transaction/3" do
     setup do
       %{return: InstrumentedModule.background_transaction()}

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -177,10 +177,6 @@ defmodule Appsignal.InstrumentationTest do
                Test.Span.get(:set_name)
     end
 
-    test "sets the span's namespace" do
-      assert {:ok, [{%Span{}, "background_job"}]} = Test.Span.get(:set_namespace)
-    end
-
     test "closes the span" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
     end
@@ -247,11 +243,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "creates a root span" do
-      assert Test.Tracer.get(:create_span) == {:ok, [{"background_job", nil}]}
-    end
-
-    test "sets the span's namespace" do
-      assert {:ok, [{%Span{}, "channel"}]} = Test.Span.get(:set_namespace)
+      assert Test.Tracer.get(:create_span) == {:ok, [{"channel", nil}]}
     end
 
     test "sets the span's name" do
@@ -275,11 +267,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "creates a root span" do
-      assert Test.Tracer.get(:create_span) == {:ok, [{"background_job", nil}]}
-    end
-
-    test "sets the span's namespace" do
-      assert {:ok, [{%Span{}, "channel"}]} = Test.Span.get(:set_namespace)
+      assert Test.Tracer.get(:create_span) == {:ok, [{"channel", nil}]}
     end
 
     test "sets the span's name" do

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -106,7 +106,7 @@ defmodule Appsignal.TracerTest do
 
   describe "create_span/3, when passing a start time" do
     setup do
-      [span: Tracer.create_span("root", nil, start_time: 1_588_936_027_128_939_000)]
+      [span: Tracer.create_span("http_request", nil, start_time: 1_588_936_027_128_939_000)]
     end
 
     test "returns a span", %{span: span} do
@@ -118,7 +118,7 @@ defmodule Appsignal.TracerTest do
     end
 
     test "creates a root span through the Nif" do
-      assert [{"root", 1_588_936_027, 128_939_000}] =
+      assert [{"http_request", 1_588_936_027, 128_939_000}] =
                Test.Nif.get!(:create_root_span_with_timestamp)
     end
   end
@@ -154,7 +154,7 @@ defmodule Appsignal.TracerTest do
 
   describe "current_span/0, when a root span exists" do
     test "returns the created span" do
-      assert Tracer.create_span("current") == Tracer.current_span()
+      assert Tracer.create_span("http_request") == Tracer.current_span()
     end
   end
 
@@ -206,7 +206,7 @@ defmodule Appsignal.TracerTest do
 
   describe "root_span/0, when a root span exists" do
     test "returns the created span" do
-      assert Tracer.create_span("current") == Tracer.root_span()
+      assert Tracer.create_span("http_request") == Tracer.root_span()
     end
   end
 
@@ -383,12 +383,12 @@ defmodule Appsignal.TracerTest do
   end
 
   defp create_child_span(%{span: span}) do
-    [span: Tracer.create_span("child", span), parent: span]
+    [span: Tracer.create_span("http_request", span), parent: span]
   end
 
   defp create_root_span_in_other_process(_context) do
     pid = Process.whereis(Test.Nif)
-    [span: Tracer.create_span("root", nil, pid: pid), pid: pid]
+    [span: Tracer.create_span("http_request", nil, pid: pid), pid: pid]
   end
 
   defp disable_appsignal(_context) do

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -394,6 +394,24 @@ defmodule Appsignal.TracerTest do
     end
   end
 
+  describe "multiple root spans" do
+    test "are created and closed in order" do
+      first = Tracer.create_span("http_request", nil)
+      second = Tracer.create_span("http_request", nil)
+
+      assert Test.Nif.get(:create_root_span) == {:ok, [{"http_request"}, {"http_request"}]}
+      assert Tracer.current_span() == second
+
+      Tracer.close_span(second)
+
+      assert Tracer.current_span() == first
+
+      Tracer.close_span(first)
+
+      assert Tracer.current_span() == nil
+    end
+  end
+
   defp create_root_span(_context) do
     [span: Tracer.create_span("http_request")]
   end

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -68,6 +68,22 @@ defmodule Appsignal.TracerTest do
     end
   end
 
+  describe "create_span/2, with a namespace that doesn't match the current span" do
+    setup [:create_root_span]
+
+    setup %{span: span} do
+      [span: Tracer.create_span("background_job", span), parent: span]
+    end
+
+    test "returns a span", %{span: span} do
+      assert %Span{} = span
+    end
+
+    test "registers the span without overwriting its parent", %{span: span, parent: parent} do
+      assert :ets.lookup(:"$appsignal_registry", self()) == [{self(), parent}, {self(), span}]
+    end
+  end
+
   describe "create_span/2, when ignored" do
     setup [:create_root_span, :ignore_process, :create_child_span]
 


### PR DESCRIPTION
Currently, because the `transaction` and `channel_action` decorators uses the `Appsignal.Instrumentation.Decorators.instrument/2` function, the decorator creates child spans when one already exist.

The `transaction` decorator exists for backward compatibility, and originally only created Transactions, which are now root spans.

This patch makes sure the decorator always creates a root span, even if another span already exists.

Closes https://github.com/appsignal/support/issues/146.