### PR TITLE
Fix Apple ARM detection

### DIFF
--- a/.changesets/apple-arm-detection.md
+++ b/.changesets/apple-arm-detection.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix Apple ARM detection. It wasn't properly detected as an Apple ARM host because the installer did not account for an architecture String a without 32/64-bit indicator.

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -305,6 +305,7 @@ defmodule Mix.Appsignal.Helper do
     defp map_arch('amd64-' ++ _, platform), do: build_for("x86_64", platform)
     defp map_arch('x86_64-' ++ _, platform), do: build_for("x86_64", platform)
     defp map_arch('aarch64-' ++ _, platform), do: build_for("aarch64", platform)
+    defp map_arch('arm-' ++ _, platform), do: build_for("aarch64", platform)
   end
 
   defp map_arch(arch, platform), do: {:error, {:unknown, {arch, platform}}}


### PR DESCRIPTION
According to support issue #150
https://github.com/appsignal/support/issues/150 the String reported by
Elixir as the system architecture is `arm-apple-darwin20.2.0` by
`:erlang.system_info(:system_architecture)`.

There are two problems with that String:

The first issue is that the `arm` String was not accounted for, only
the `aarch64` String. By adding the `arm` String we can also match ARM
architectures that report themselves as `arm`.

Secondly, it uses `arm` and not `arm64`, so we don't know which
architecture it could be. This is more of a problem for other
(non-darwin) hosts that may have 32-bit architecture. I decided not to
account for this, I don't know how, and it will fail later on in the
installation process with an architecture mismatch.