### PR TITLE
Bump agent to 0f40689

### DIFF
--- a/.changesets/bump-agent-to-0f40689.md
+++ b/.changesets/bump-agent-to-0f40689.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+---
+
+Bump agent to 0f40689
+
+- Add Apple Darwin ARM alias.
+- Improve appsignal.h documentation.
+- Improve transaction debug log for errors.
+- Fix agent zombie/defunct issue on containers without process reaping.

--- a/agent.exs
+++ b/agent.exs
@@ -1,51 +1,55 @@
 defmodule Appsignal.Agent do
-  def version, do: "891c6b0"
+  def version, do: "0f40689"
 
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "17203c5edae2463684f271216d32c9d5c57923c9730254b4a050392fea4e74a8",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "a2b46f8b5446a95878a023e1f5a0b8aaefc04f3fdd14875edc6cd0ae0c1bc6ca",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "17203c5edae2463684f271216d32c9d5c57923c9730254b4a050392fea4e74a8",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-x86_64-darwin-all-static.tar.gz"
+        checksum: "a2b46f8b5446a95878a023e1f5a0b8aaefc04f3fdd14875edc6cd0ae0c1bc6ca",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "70db73144a1ee9475636512e6f55b0c7189ee6d2d390341d33fcaaece10b5a13",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-aarch64-darwin-all-static.tar.gz"
+        checksum: "f5dced4eb1064cfe3a080164859bdb5cb7dc316c95c8ca606fb4dd3dae441020",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "70db73144a1ee9475636512e6f55b0c7189ee6d2d390341d33fcaaece10b5a13",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-aarch64-darwin-all-static.tar.gz"
+        checksum: "f5dced4eb1064cfe3a080164859bdb5cb7dc316c95c8ca606fb4dd3dae441020",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-aarch64-darwin-all-static.tar.gz"
+      },
+      "arm-darwin" => %{
+        checksum: "f5dced4eb1064cfe3a080164859bdb5cb7dc316c95c8ca606fb4dd3dae441020",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "0ff967bd1d2d117cdc5a988adfd6083352f0ff3e3a18d8e85360b998ed08997e",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-aarch64-linux-all-static.tar.gz"
+        checksum: "db2242050c5b99a6eb6aaafbb571f65e4a5ac08a08c25a009f992d8240864b27",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "5653c81adebbf7533a714556efae82bd6ed538e3fa44e880aa5630b72d266668",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "6f952674ef7c0d7444c69991619e75bd244232b009617491d09b3f58a2939c9a",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "5653c81adebbf7533a714556efae82bd6ed538e3fa44e880aa5630b72d266668",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-i686-linux-all-static.tar.gz"
+        checksum: "6f952674ef7c0d7444c69991619e75bd244232b009617491d09b3f58a2939c9a",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "b07919c0a18c8ed1b658dbf2717268d61ab88d1cc4665438e68d73a54334e1f8",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-x86_64-linux-all-static.tar.gz"
+        checksum: "85a719387ea6052f50396f932d924efb8b572face63d9f3610c72aeeb4c75e9e",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "23dc0715fed704ef65365cbc385aa8135c317d53844e3102e989dd8144b37039",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-x86_64-linux-musl-all-static.tar.gz"
+        checksum: "221add79e8216bf21c98af54c6eb0010c7b0cc77e7f8690e260c6d8e0e8d763d",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "c9758318ea45461f3cede1d232f730914eb115ea2c34199cf9031a45af8d2776",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "5d28a24eecc59cab62ecfce460ac83a4f783556efe060dccc740c5c651edb728",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "c9758318ea45461f3cede1d232f730914eb115ea2c34199cf9031a45af8d2776",
-        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/891c6b0/appsignal-x86_64-freebsd-all-static.tar.gz"
+        checksum: "5d28a24eecc59cab62ecfce460ac83a4f783556efe060dccc740c5c651edb728",
+        download_url: "https://appsignal-agent-releases.global.ssl.fastly.net/0f40689/appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }
   end


### PR DESCRIPTION
- Add Apple Darwin ARM alias.
- Improve appsignal.h documentation.
- Improve transaction debug log for errors.
- Fix agent zombie/defunct issue on containers without process reaping.

[skip review]