### PR TITLE
Upgrade telemetry dependency

### DIFF
--- a/.changesets/add-support-for-telemetry-1-0-0.md
+++ b/.changesets/add-support-for-telemetry-1-0-0.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Add support for telemetry 1.0.0

--- a/mix.exs
+++ b/mix.exs
@@ -118,7 +118,7 @@ defmodule Appsignal.Mixfile do
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},
       {:credo, "~> 1.0.0", only: [:test, :dev], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:telemetry, "~> 0.4"}
+      {:telemetry, "~> 0.4 or ~> 1.0"}
     ]
   end
 end


### PR DESCRIPTION
Add telemetry 1.0.0 as a compatible dependency.

This should be deployed after https://github.com/appsignal/appsignal-elixir-phoenix/pull/27 to avoid possible conflicts with applications that use telemetry 1.0.0.