### PR TITLE
Replace decorator slashes with underscores

### DIFF
--- a/.changesets/use-underscores-instead-of-slashes-in-spans-created-from-decorators.md
+++ b/.changesets/use-underscores-instead-of-slashes-in-spans-created-from-decorators.md
@@ -1,0 +1,5 @@
+---
+bump: "minor"
+---
+
+Use underscores instead of slashes in spans created from decorators

--- a/.changesets/use-underscores-instead-of-slashes-in-spans-created-from-decorators.md
+++ b/.changesets/use-underscores-instead-of-slashes-in-spans-created-from-decorators.md
@@ -2,4 +2,4 @@
 bump: "minor"
 ---
 
-Use underscores instead of slashes in spans created from decorators
+Use underscores instead of slashes in spans created from decorators. This will change action naming from `Module.function/1` to `Module.function_1`.

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -30,7 +30,7 @@ defmodule Appsignal.Instrumentation.Decorators do
   defp do_instrument(body, %{module: module, name: name, arity: arity, namespace: namespace}) do
     quote do
       Appsignal.Instrumentation.instrument(
-        "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
+        "#{module_name(unquote(module))}.#{unquote(name)}_#{unquote(arity)}",
         fn span ->
           _ = unquote(@span).set_namespace(span, unquote(namespace))
           unquote(body)
@@ -54,7 +54,7 @@ defmodule Appsignal.Instrumentation.Decorators do
   defp do_instrument(body, %{module: module, name: name, arity: arity, category: category}) do
     quote do
       Appsignal.Instrumentation.instrument(
-        "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
+        "#{module_name(unquote(module))}.#{unquote(name)}_#{unquote(arity)}",
         unquote(category),
         fn -> unquote(body) end
       )
@@ -64,7 +64,7 @@ defmodule Appsignal.Instrumentation.Decorators do
   defp do_instrument(body, %{module: module, name: name, arity: arity}) do
     quote do
       Appsignal.Instrumentation.instrument(
-        "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
+        "#{module_name(unquote(module))}.#{unquote(name)}_#{unquote(arity)}",
         fn -> unquote(body) end
       )
     end
@@ -94,7 +94,7 @@ defmodule Appsignal.Instrumentation.Decorators do
     quote do
       Appsignal.Instrumentation.instrument_root(
         unquote(namespace),
-        "#{module_name(unquote(module))}.#{unquote(name)}/#{unquote(arity)}",
+        "#{module_name(unquote(module))}.#{unquote(name)}_#{unquote(arity)}",
         fn -> unquote(body) end
       )
     end

--- a/test/appsignal/instrumentation_test.exs
+++ b/test/appsignal/instrumentation_test.exs
@@ -74,7 +74,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "InstrumentedModule.instrument/0"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "InstrumentedModule.instrument_0"}]} = Test.Span.get(:set_name)
     end
 
     test "closes the span" do
@@ -96,7 +96,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "InstrumentedModule.background_job/0"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "InstrumentedModule.background_job_0"}]} = Test.Span.get(:set_name)
     end
 
     test "sets the span's namespace" do
@@ -132,7 +132,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "InstrumentedModule.transaction/0"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "InstrumentedModule.transaction_0"}]} = Test.Span.get(:set_name)
     end
 
     test "closes the span" do
@@ -156,7 +156,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "InstrumentedModule.transaction/0"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "InstrumentedModule.transaction_0"}]} = Test.Span.get(:set_name)
     end
 
     test "closes the span" do
@@ -178,7 +178,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "InstrumentedModule.background_transaction/0"}]} =
+      assert {:ok, [{%Span{}, "InstrumentedModule.background_transaction_0"}]} =
                Test.Span.get(:set_name)
     end
 
@@ -201,7 +201,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "InstrumentedModule.background_transaction_with_atom_namespace/0"}]} =
+      assert {:ok, [{%Span{}, "InstrumentedModule.background_transaction_with_atom_namespace_0"}]} =
                Test.Span.get(:set_name)
     end
 
@@ -224,7 +224,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "InstrumentedModule.transaction_event/0"}]} =
+      assert {:ok, [{%Span{}, "InstrumentedModule.transaction_event_0"}]} =
                Test.Span.get(:set_name)
     end
 
@@ -247,7 +247,7 @@ defmodule Appsignal.InstrumentationTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "InstrumentedModule.transaction_event_category/0"}]} =
+      assert {:ok, [{%Span{}, "InstrumentedModule.transaction_event_category_0"}]} =
                Test.Span.get(:set_name)
     end
 


### PR DESCRIPTION
Because the Span API uses a Span's name as what was previously described
as the event name, underscores are no longer supported.

Although this was the (documented) case before, changes in the
processing API caused this to break for people using the decorators
(which are a fallback for users upgrading from 1.0).

This patch changes the slashes in automatically generated span names to
underscores, as that's the only available alternative.

It's marked as a minor patch in the changelog, as this changes some
reported names, causing newly created incidents for insidents that
already existed before.

https://docs.appsignal.com/api/event-names.html#event-namin

Closes https://github.com/appsignal/support/issues/132