### PR TITLE
Update Elixir 1.11 and Erlang 23 versions on CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,38 +20,38 @@ blocks:
             - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
         - name: mix compile --warnings-as-errors
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix format --check-formatted
         - name: mix credo --strict
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix credo --strict
         - name: mix dialyzer
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - cache restore dialyzer-plt
             - MIX_ENV=dev mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
             - MIX_ENV=dev mix dialyzer
         - name: Elixir master, OTP 23
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=master . bin/setup
             - mix test
         - name: Elixir master, OTP 23, without the NIF loaded
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=master . bin/setup
             - MIX_ENV=test_no_nif mix test
         - name: Elixir 1.11.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 22
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -45,25 +45,25 @@ blocks:
           commands:
             - ERLANG_VERSION=23.2 ELIXIR_VERSION=master . bin/setup
             - MIX_ENV=test_no_nif mix test
-        - name: Elixir 1.11.3, OTP 23
+        - name: Elixir 1.11.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.11.3 . bin/setup
+            - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 23
           commands:
             - ERLANG_VERSION=23.2 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
-        - name: Elixir 1.11.3, OTP 22
+        - name: Elixir 1.11.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.3 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 22
           commands:
             - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
-        - name: Elixir 1.11.3, OTP 21
+        - name: Elixir 1.11.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.3 . bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 21
           commands:


### PR DESCRIPTION
Update to the newer patch versions for Elixir and Erlang.

*Note*: This patch is based on #666. Please merge that first.