### PR TITLE
Add OTP 24 to CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,31 +20,35 @@ blocks:
             - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
         - name: mix compile --warnings-as-errors
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix format --check-formatted
         - name: mix credo --strict
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix credo --strict
         - name: mix dialyzer
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 . bin/setup
             - cache restore dialyzer-plt
             - MIX_ENV=dev mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
             - MIX_ENV=dev mix dialyzer
-        - name: Elixir master, OTP 23
+        - name: Elixir master, OTP 24
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
             - mix test
-        - name: Elixir master, OTP 23, without the NIF loaded
+        - name: Elixir master, OTP 24, without the NIF loaded
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
             - MIX_ENV=test_no_nif mix test
+        - name: Elixir 1.11.4, OTP 24
+          commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 . bin/setup
+            - mix test
         - name: Elixir 1.11.4, OTP 23
           commands:
             - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 . bin/setup


### PR DESCRIPTION
Run linters and Elixir 1.11.4 on OTP 24 on CI.

*Note*: This patch is based on #667. Please merge that first.