### PR TITLE
Fix extension installer from tmp cached download

### DIFF
--- a/.changesets/fix-extension-installer-from-cached-source.md
+++ b/.changesets/fix-extension-installer-from-cached-source.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix extension installer from cached source in `/tmp` directory. This would cause installation errors of the package if the AppSignal package was reinstalled again on a host that already installed it once.

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -508,12 +508,8 @@ defmodule Mix.Appsignal.Helper do
       }
     } = report
 
-    %{
-      download: %{
-        download_url: download_url,
-        checksum: checksum
-      }
-    } = report
+    %{download: %{checksum: checksum}} = report
+    download_url = Map.get(report.download, :download_url)
 
     download_report = %{
       download: %{


### PR DESCRIPTION
In PR #671 we've added support for agent & extension downloads from
mirrors.

An edge case popped up that failed the installation. This scenario
happens when the installer fetches things from the tmp directory. When
the installer finds a matching agent & extension download in the host's
`/tmp` directory it will use that archive rather than download it again.

When it uses this installation method it does not store a `download_url`
on the `download.report` since PR #671, because it doesn't know which
mirror was originally used to download the archive. When writing the
download report it would error on the missing `download_url` key.

```
could not compile dependency :appsignal, "mix compile" failed. You can
  recompile this dependency with "mix deps.compile appsignal", update it
  with "mix deps.update appsignal" or clean it with "mix deps.clean
  appsignal"
** (KeyError) key :download_url not found in: %{checksum: "verified"}
    mix_helpers.exs:512: Mix.Appsignal.Helper.write_download_report/1
    mix_helpers.exs:495: Mix.Appsignal.Helper.write_report/1
    mix_helpers.exs:248: Mix.Appsignal.Helper.compile/1
    mix_helpers.exs:27: Mix.Appsignal.Helper.install/0
    /integration/appsignal-elixir/mix.exs:6: Mix.Tasks.Compile.Appsignal.run/1
    (mix 1.12.2) lib/mix/task.ex:394: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.12.2) lib/mix/tasks/compile.all.ex:92: Mix.Tasks.Compile.All.run_compiler/2
    (mix 1.12.2) lib/mix/tasks/compile.all.ex:72: Mix.Tasks.Compile.All.compile/4
```

This change fixes that by making the `download_url` key optional, it
will default to `nil` when the key is not found. This way it won't error
in this edge case.

Fixes #672