### PR TITLE
Remove dot prefix from bin/setup script in CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,82 +16,82 @@ blocks:
             - script/lint_git
         - name: mix compile --warnings-as-errors
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 bin/setup
             - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 bin/setup
             - mix format --check-formatted
         - name: mix credo --strict
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 bin/setup
             - mix credo --strict
         - name: mix dialyzer
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.10.4 bin/setup
             - cache restore dialyzer-plt
             - MIX_ENV=dev mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
             - MIX_ENV=dev mix dialyzer
         - name: Elixir master, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master bin/setup
             - mix test
         - name: Elixir master, OTP 24, without the NIF loaded
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master bin/setup
             - MIX_ENV=test_no_nif mix test
         - name: Elixir 1.12.2, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
         - name: Elixir 1.12.2, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
         - name: Elixir 1.12.2, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 20
           commands:
-            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 . bin/setup
+            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
       env_vars:
         - name: MIX_ENV


### PR DESCRIPTION
The dot is not necessary to run the `bin/setup` script, remove it.  With
the dot present the scripts will not fail the build if they exit with a
failure. So removing them actually highlights which jobs failed.  It
only appears to be a problem for the "mix compile --warnings-as-errors",
"mix format", credo and dialyzer builds for some reason.

[skip review]
[skip changeset]