### PR TITLE
Fix bin/setup script, exit on failure

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -e
+
 if [[ $ELIXIR_VERSION == "master" ]]; then
   kiex install $ELIXIR_VERSION
 fi


### PR DESCRIPTION
Add the `set -e` options so that the setup script exits with a failure
if any of the commands it runs exits with a failure as well. Otherwise
it will silently fail and go unnoticed.

[skip changeset]
[skip review]