### PR TITLE
Speed up function arity check in Appsignal.Instrumentation

### DIFF
--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -123,12 +123,6 @@ defmodule Appsignal.Instrumentation do
     |> @span.close()
   end
 
-  defp call_with_optional_argument(fun, argument) do
-    case fun
-         |> :erlang.fun_info()
-         |> Keyword.get(:arity) do
-      0 -> fun.()
-      _ -> fun.(argument)
-    end
-  end
+  defp call_with_optional_argument(fun, _argument) when is_function(fun, 0), do: fun.()
+  defp call_with_optional_argument(fun, argument) when is_function(fun, 1), do: fun.(argument)
 end


### PR DESCRIPTION
I haven't actually benchmarked this :sweat_smile:, but I’m fairly sure that checking one of the two supported arities of a function in a guard is faster than getting the whole keyword list of info and so on. Plus, it's a few less lines of code!

While I got you here, I was reading through the code for `Appsignal.Instrumentation`. Would you folks appreciate some contributions to have guards on all functions and more precise function specs?