### PR TITLE
Fix SSL options download in installer for mirrors 

### DIFF
--- a/.changesets/update-ssl-configuration-for-otp-23-and-newer.md
+++ b/.changesets/update-ssl-configuration-for-otp-23-and-newer.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Update SSL configuration for OTP 23 and newer to fix the Cloudfront mirror download during installation.

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -233,11 +233,8 @@ defmodule Mix.Appsignal.Helper do
       ssl_options:
         [
           verify: :verify_peer,
-          cacertfile: priv_path("cacert.pem"),
-          depth: 4,
-          ciphers: ciphers(),
-          honor_cipher_order: :undefined
-        ] ++ customize_hostname_check_or_verify_fun()
+          cacertfile: priv_path("cacert.pem")
+        ] ++ tls_options() ++ customize_hostname_check_or_verify_fun()
     ]
 
     case check_proxy() do
@@ -679,6 +676,18 @@ defmodule Mix.Appsignal.Helper do
 
   defp make do
     if System.find_executable("gmake"), do: "gmake", else: "make"
+  end
+
+  if System.otp_release() >= "23" do
+    defp tls_options, do: [versions: [:"tlsv1.3", :"tlsv1.2"]]
+  else
+    defp tls_options do
+      [
+        depth: 4,
+        ciphers: ciphers(),
+        honor_cipher_order: :undefined
+      ]
+    end
   end
 
   if System.otp_release() >= "20.3" do

--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -18,7 +18,23 @@ defmodule Appsignal.TransmitterTest do
 
     assert ssl_options[:verify] == :verify_peer
     assert ssl_options[:cacertfile] == Config.ca_file_path()
-    assert ssl_options[:depth] == 4
+
+    if System.otp_release() >= "23" do
+      assert ssl_options[:versions] == [:"tlsv1.3", :"tlsv1.2"]
+      refute Keyword.has_key?(ssl_options, :depth)
+      refute Keyword.has_key?(ssl_options, :ciphers)
+      refute Keyword.has_key?(ssl_options, :honor_cipher_order)
+    else
+      refute Keyword.has_key?(ssl_options, :versions)
+      assert ssl_options[:depth] == 4
+      assert ssl_options[:honor_cipher_order] == :undefined
+
+      if System.otp_release() >= "20.3" do
+        assert ssl_options[:ciphers] == :ssl.cipher_suites(:default, :"tlsv1.2")
+      else
+        assert ssl_options[:ciphers] == :ssl.cipher_suites()
+      end
+    end
 
     if System.otp_release() >= "21" do
       assert ssl_options[:customize_hostname_check] == [
@@ -27,25 +43,9 @@ defmodule Appsignal.TransmitterTest do
 
       refute Keyword.has_key?(ssl_options, :verify_fun)
     else
-      {fun, pid} = ssl_options[:verify_fun]
-      assert is_function(fun)
-      assert is_pid(pid)
-
+      assert ssl_options[:verify_fun] == (&:ssl_verify_hostname.verify_fun/3)
       refute Keyword.has_key?(ssl_options, :customize_hostname_check)
     end
-
-    cond do
-      System.otp_release() >= "23" ->
-        assert ssl_options[:ciphers] == :ssl.cipher_suites(:default, :"tlsv1.3")
-
-      System.otp_release() >= "20.3" ->
-        assert ssl_options[:ciphers] == :ssl.cipher_suites(:default, :"tlsv1.2")
-
-      true ->
-        assert ssl_options[:ciphers] == :ssl.cipher_suites()
-    end
-
-    assert ssl_options[:honor_cipher_order] == :undefined
   end
 
   test "uses the configured CA certificate" do


### PR DESCRIPTION
When installer can't download the install package from the fastly mirror
it falls back on the cloudfront mirror since PR #671. On newer OTP
versions the cloudfront mirror fails to download the error message
`{:error, :closed}` from hackney, which isn't very descriptive.

After some searching around and trying out different things, I found
that removing the `ciphers` option made the cloudfront mirror download
work. After some more research with the help of @luismiramirez we found
this blog post: https://nts.strzibny.name/hackney-ssl-configuration/
that lists the options I decided to implement in this commit. Added to
the list of versions is also `tlsv1.3` as was previously configured in
the ciphers options as well.

This `versions` option seems like a simpler way to configure these
ciphers on newer OTP versions, than calling `:ssl.cipher_suites` with
different arguments for different OTP versions.

This method doesn't work on older OTP versions, which is why the
original implementation was kept in tact for OTP 22 and lower.

By passing in the `ssl_options` to hackney's `request` function we
override the OTP defaults for SSL, which we then need to set again for
the specific OTP version.

I've updated the mix helper and transmitter to both use the same config,
and use the same config for all OTP versions. I've testing this on the
CI with both the fastly and cloudfront mirror as the download and they
both pass.

This commit itself doesn't test the cloudfront mirror, because it's not
the first mirror used and the first mirror doesn't fail to download. In
the PR for this commit I'll link a CI build that does only use the
cloudfront mirror for testing: https://appsignal.semaphoreci.com/workflows/0fbb5c8b-a3c4-42fe-b419-31615d4f4202

Part of https://github.com/appsignal/appsignal-elixir/issues/683 