### PR TITLE
Fix build against Elixir master branch

### DIFF
--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -63,11 +63,15 @@ defmodule Appsignal.TransmitterTest do
     path = "test/fixtures/does_not_exist.pem"
 
     with_config(%{ca_file_path: path}, fn ->
-      assert capture_log(fn ->
-               assert [_method, _url, _headers, _body, []] =
-                        Transmitter.request(:get, "https://example.com")
-             end) =~
-               "[warn]  Ignoring non-existing or unreadable ca_file_path (test/fixtures/does_not_exist.pem): :enoent"
+      log =
+        capture_log(fn ->
+          assert [_method, _url, _headers, _body, []] =
+                   Transmitter.request(:get, "https://example.com")
+        end)
+
+      # credo:disable-for-lines:2 Credo.Check.Readability.MaxLineLength
+      assert log =~
+               ~r/\[warn(ing)?\](\s{1,2})Ignoring non-existing or unreadable ca_file_path \(test\/fixtures\/does_not_exist\.pem\): :enoent/
     end)
   end
 end


### PR DESCRIPTION
There was a problem with the Elixir master branch build. Something
changed in the logger. It now prints "warning" instead of "warn" and
there's one space less than before between the level indicator and the
message.

```
left:  "\e[33m\n13:57:06.938 [warning] Ignoring non-existing or unreadable ca_file_path (test/fixtures/does_not_exist.pem): :enoent\n\e[0m" 01:42
right: "[warn]  Ignoring non-existing or unreadable ca_file_path (test/fixtures/does_not_exist.pem): :enoent"
```

I chose to disable credo for this (too) long line with the regex
matcher. I made an alternative that spanned multiple lines using
`Regex.compile` with a String, but that did not improve readability with
all the escaping going on. It took me too long to figure out it was
needed to double escape everything in that String before it worked, so I
chose to keep the more straightforward regex solution.

```elixir
regex_string =
  "\\[warn(ing)?\\]\\s{1,2}Ignoring non-existing " <>
    "or unreadable ca_file_path \\(test/fixtures/does_not_exist\\.pem\\): :enoent"

matcher = Regex.compile!(regex_string)
assert log =~ matcher
```

[skip changeset]