### PR TITLE
Show only failure message on install failure

### DIFF
--- a/.changesets/fix-mixed-install-result-message.md
+++ b/.changesets/fix-mixed-install-result-message.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix install result message to no longer show a success message when an installation failure occurred.


### PR DESCRIPTION
When the extension installation would fail, the installer would first
print a failure message and then a success message.

```
AppSignal installation failed: Could not download archive from any of our mirrors.
# Long error message

09:08:07.699 [debug] AppSignal for Elixir 2.2.3 succesfully installed!
```

This happened because the result of `download_and_compile` was not
checked, and not handled different if it ran into an error.

I updated the `download_and_compile` to not call `abort_installation`
directly, but instead let the parent function handle that, along with
the success scenario.

Now all the failure scenarios (that eventually call)
`abort_installation` are handled in the same way.

Fixes #686