### PR TITLE
Address "function `ciphers/0` is unused" warning

### DIFF
--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -56,12 +56,12 @@ defmodule Appsignal.Transmitter do
         honor_cipher_order: :undefined
       ]
     end
-  end
 
-  if System.otp_release() >= "20.3" do
-    defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.2")
-  else
-    defp ciphers, do: :ssl.cipher_suites()
+    if System.otp_release() >= "20.3" do
+      defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.2")
+    else
+      defp ciphers, do: :ssl.cipher_suites()
+    end
   end
 
   if System.otp_release() >= "21" do

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -692,12 +692,12 @@ defmodule Mix.Appsignal.Helper do
         honor_cipher_order: :undefined
       ]
     end
-  end
 
-  if System.otp_release() >= "20.3" do
-    defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.2")
-  else
-    defp ciphers, do: :ssl.cipher_suites()
+    if System.otp_release() >= "20.3" do
+      defp ciphers, do: :ssl.cipher_suites(:default, :"tlsv1.2")
+    else
+      defp ciphers, do: :ssl.cipher_suites()
+    end
   end
 
   if System.otp_release() >= "21" do


### PR DESCRIPTION
As part of fixing the SSL options when downloading from mirrors
in the installer (#688), the TLS-related options passed to the
HTTP client were simplified for OTP 23 and above, no longer
requiring the use of the `ciphers/0` function. However, this
function was still defined under OTP 23, leading to a warning
about the function being unused.

This commit addresses the warning by only defining `ciphers/0`
for OTP versions below 23.

[skip changeset]

You can see the warnings this refers to at [this CI build of the main branch](https://appsignal.semaphoreci.com/jobs/d2bdbed6-0fb4-482c-9767-c4a736f7210b#L510-L521).
The warning no longer shows up in [a CI build of this branch](https://appsignal.semaphoreci.com/jobs/178e37ad-6128-44e9-baf3-be31129f64b1#L511-L518).