### PR TITLE
source_ref needs 'v' prepended since tagging now has 'v' prepended

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Appsignal.Mixfile do
       docs: [
         main: "readme",
         logo: "logo.png",
-        source_ref: @version,
+        source_ref: "v#{@version}",
         source_url: @source_url,
         extras: ["README.md", "CHANGELOG.md"]
       ],


### PR DESCRIPTION
visiting the source link from the hosted docs are broken because of the new Git tagging format which prepends `v` at the front.

following the prophet's footstep:
https://github.com/elixir-lang/ex_doc/blame/fcfd2b9256fec710ce96d3b4a713a36cf57f34ad/mix.exs#L89
just prepend `v` in `source_ref`