### PR TITLE
Update `credo` to version 1.5.6

### DIFF
--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -6,7 +6,10 @@ end
 defmodule Appsignal.Demo do
   @moduledoc false
   import Appsignal.Instrumentation, only: [instrument: 2, instrument: 3]
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+
+  require Appsignal.Utils
+
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   def send_performance_sample do
     instrument("DemoController#hello", "call.phoenix", fn span ->

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -1,6 +1,9 @@
 defmodule Appsignal.Diagnose.Agent do
   @moduledoc false
-  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+  require Appsignal.Utils
+
+  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   def report do
     if @nif.loaded?() do

--- a/lib/appsignal/diagnose/host.ex
+++ b/lib/appsignal/diagnose/host.ex
@@ -1,7 +1,10 @@
 defmodule Appsignal.Diagnose.Host do
   @moduledoc false
-  @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
-  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+
+  require Appsignal.Utils
+
+  @system Appsignal.Utils.compile_env(:appsignal, :appsignal_system, Appsignal.System)
+  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   def info do
     {_, os} = :os.type()

--- a/lib/appsignal/diagnose/library.ex
+++ b/lib/appsignal/diagnose/library.ex
@@ -1,8 +1,11 @@
 defmodule Appsignal.Diagnose.Library do
   @moduledoc false
+
+  require Appsignal.Utils
+
   @appsignal_version Mix.Project.config()[:version]
   @agent_version Appsignal.Nif.agent_version()
-  @nif Application.get_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   def info do
     %{

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -1,6 +1,8 @@
 defmodule Appsignal.Ecto do
-  @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+  require Appsignal.Utils
+
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   import Appsignal.Utils, only: [module_name: 1]
 
   require Logger

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -1,7 +1,10 @@
 defmodule Appsignal.Error.Backend do
   @moduledoc false
-  @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+
+  require Appsignal.Utils
+
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @behaviour :gen_event
 

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -1,6 +1,8 @@
 defmodule Appsignal.Instrumentation do
-  @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+  require Appsignal.Utils
+
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @spec instrument(function()) :: any()
   @doc false

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -1,6 +1,9 @@
 defmodule Appsignal.Instrumentation.Decorators do
   @moduledoc false
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+
+  require Appsignal.Utils
+
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   use Decorator.Define,
     instrument: 0,

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -1,6 +1,8 @@
 defmodule Appsignal.Logger do
   require Logger
-  @logger Application.get_env(:appsignal, :logger, Logger)
+  require Appsignal.Utils
+
+  @logger Appsignal.Utils.compile_env(:appsignal, :logger, Logger)
 
   @spec debug(any()) :: :ok
   @doc """

--- a/lib/appsignal/monitor.ex
+++ b/lib/appsignal/monitor.ex
@@ -1,7 +1,10 @@
 defmodule Appsignal.Monitor do
   @moduledoc false
-  @deletion_delay Application.get_env(:appsignal, :deletion_delay, 5_000)
-  @sync_interval Application.get_env(:appsignal, :sync_interval, 60_000)
+
+  require Appsignal.Utils
+
+  @deletion_delay Appsignal.Utils.compile_env(:appsignal, :deletion_delay, 5_000)
+  @sync_interval Appsignal.Utils.compile_env(:appsignal, :sync_interval, 60_000)
 
   use GenServer
   alias Appsignal.Tracer

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -1,7 +1,10 @@
 defmodule Appsignal.Probes.ErlangProbe do
   @moduledoc false
-  @appsignal Application.get_env(:appsignal, :appsignal, Appsignal)
-  @inet Application.get_env(:appsignal, :inet, :inet)
+
+  require Appsignal.Utils
+
+  @appsignal Appsignal.Utils.compile_env(:appsignal, :appsignal, Appsignal)
+  @inet Appsignal.Utils.compile_env(:appsignal, :inet, :inet)
 
   def call do
     io_metrics()

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -1,7 +1,11 @@
 defmodule Appsignal.Span do
   alias Appsignal.{Config, Nif, Span}
+
   defstruct [:reference, :pid]
-  @nif Application.get_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
+
+  require Appsignal.Utils
+
+  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
 
   @type t() :: %__MODULE__{
           reference: reference(),

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -1,7 +1,9 @@
 defmodule Appsignal.Tracer do
   alias Appsignal.Span
 
-  @monitor Application.get_env(:appsignal, :appsignal_monitor, Appsignal.Monitor)
+  require Appsignal.Utils
+
+  @monitor Appsignal.Utils.compile_env(:appsignal, :appsignal_monitor, Appsignal.Monitor)
   @table :"$appsignal_registry"
 
   @type option :: {:pid, pid} | {:start_time, integer}

--- a/lib/appsignal/utils.ex
+++ b/lib/appsignal/utils.ex
@@ -18,4 +18,16 @@ defmodule Appsignal.Utils do
   def module_name(module) when is_binary(module), do: module
 
   def module_name(module), do: module |> to_string() |> module_name()
+
+  defmacro compile_env(app, key, default \\ nil) do
+    if Version.match?(System.version(), ">= 1.10.0") do
+      quote do
+        Application.compile_env(unquote(app), unquote(key), unquote(default))
+      end
+    else
+      quote do
+        Application.get_env(unquote(app), unquote(key), unquote(default))
+      end
+    end
+  end
 end

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -3,8 +3,14 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   alias Appsignal.Config
   alias Appsignal.Diagnose
 
-  @system Application.get_env(:appsignal, :appsignal_system, Appsignal.System)
-  @report Application.get_env(:appsignal, :appsignal_diagnose_report, Appsignal.Diagnose.Report)
+  require Appsignal.Utils
+
+  @system Appsignal.Utils.compile_env(:appsignal, :appsignal_system, Appsignal.System)
+  @report Appsignal.Utils.compile_env(
+            :appsignal,
+            :appsignal_diagnose_report,
+            Appsignal.Diagnose.Report
+          )
 
   @shortdoc "Starts and tests AppSignal while validating the configuration"
 

--- a/mix.exs
+++ b/mix.exs
@@ -122,7 +122,7 @@ defmodule Appsignal.Mixfile do
       {:plug_cowboy, "~> 1.0", only: [:test, :test_no_nif]},
       {:bypass, "~> 0.6.0", only: [:test, :test_no_nif]},
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},
-      {:credo, "~> 1.0.0", only: [:test, :dev], runtime: false},
+      {:credo, "~> 1.5.6", only: [:test, :dev], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:telemetry, "~> 0.4 or ~> 1.0"}
     ] ++ mime_dependency

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -1,11 +1,28 @@
 {_, _} = Code.eval_file("agent.exs")
 
+defmodule Mix.Appsignal.Utils do
+  defmacro compile_env(app, key, default \\ nil) do
+    if Version.match?(System.version(), ">= 1.10.0") do
+      quote do
+        Application.compile_env(unquote(app), unquote(key), unquote(default))
+      end
+    else
+      quote do
+        Application.get_env(unquote(app), unquote(key), unquote(default))
+      end
+    end
+  end
+end
+
 defmodule Mix.Appsignal.Helper do
   @moduledoc """
   Helper functions for downloading and compiling the AppSignal agent library.
   """
-  @os Application.get_env(:appsignal, :os, :os)
-  @system Application.get_env(:appsignal, :mix_system, System)
+
+  require Mix.Appsignal.Utils
+
+  @os Mix.Appsignal.Utils.compile_env(:appsignal, :os, :os)
+  @system Mix.Appsignal.Utils.compile_env(:appsignal, :mix_system, System)
 
   @proxy_env_vars [
     "APPSIGNAL_HTTP_PROXY",

--- a/test/support/test_agent.ex
+++ b/test/support/test_agent.ex
@@ -23,7 +23,7 @@ defmodule TestAgent do
         Agent.update(pid_or_module, &Map.put(&1, key, value))
       end
 
-      def alive?() do
+      def alive? do
         !!Process.whereis(__MODULE__)
       end
 


### PR DESCRIPTION
This commit updates the version of the `credo` linter to `1.5.6`. It also addresses the new warnings given by the linter, most of which relate to the use of `Application.get_env/3` in module attributes, which are evaluated at compile time. Using `Application.compile_env/3` instead removes the warning.

Since `compile_env` is not available in Elixir versions below 1.10, a helper macro is added to `Appsignal.Utils` and used to conditionally call `get_env` or `compile_env` depending on the Elixir version.

In order to use this macro from within the `mix_helpers.exs` file, its code is duplicated within that file as `Mix.Appsignal.Utils`.

[skip changeset]

Closes #691.