### PR TITLE
Print all install report fields in diagnose report

### DIFF
--- a/.changesets/print-dependencies-and-flags-for-install-in-diagnose-report.md
+++ b/.changesets/print-dependencies-and-flags-for-install-in-diagnose-report.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Print the extension installation dependencies and flags in the diagnose report output.

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -195,6 +195,8 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     IO.puts("    Musl override: #{build_report["musl_override"]}")
     IO.puts("    Linux ARM override: #{build_report["linux_arm_override"]}")
     IO.puts("    Library type: #{format_value(build_report["library_type"])}")
+    IO.puts("    Dependencies: #{format_value(build_report["dependencies"])}")
+    IO.puts("    Flags: #{format_value(build_report["flags"])}")
     host_report = installation_report["host"]
     IO.puts("  Host details")
     IO.puts("    Root user: #{format_value(host_report["root_user"])}")


### PR DESCRIPTION
The dependencies and flags fields were missing from the Elixir
integration diagnose report output. It was sent, just not printed.
Now it matches the other integrations output.

Depends on https://github.com/appsignal/diagnose_tests/pull/31