### PR TITLE
Implement scheduler utilization metric

### DIFF
--- a/.changesets/add-scheduler-utilization-to-minutely-probes.md
+++ b/.changesets/add-scheduler-utilization-to-minutely-probes.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+Add the Erlang scheduler utilization to the metrics reported by the minutely probes. The metric is
+reported as a percentage value with the name `erlang_scheduler_utilization`, with the tag `type` set to `"scheduler"` and the tag `id` set to the ID of the scheduler in the Erlang VM.

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -85,7 +85,7 @@ defmodule Appsignal do
 
   @doc false
   def add_default_probes do
-    Appsignal.Probes.register(:erlang, &Appsignal.Probes.ErlangProbe.call/0)
+    Appsignal.Probes.register(:erlang, &Appsignal.Probes.ErlangProbe.call/1)
   end
 
   @doc """

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -6,13 +6,14 @@ defmodule Appsignal.Probes.ErlangProbe do
   @appsignal Appsignal.Utils.compile_env(:appsignal, :appsignal, Appsignal)
   @inet Appsignal.Utils.compile_env(:appsignal, :inet, :inet)
 
-  def call do
+  def call(sample \\ nil) do
     io_metrics()
     scheduler_metrics()
     process_metrics()
     memory_metrics()
     atom_metrics()
     run_queue_lengths()
+    scheduler_utilization_metrics(sample)
   end
 
   defp io_metrics do
@@ -71,6 +72,21 @@ defmodule Appsignal.Probes.ErlangProbe do
     set_gauge("total_run_queue_lengths", total, %{type: "total"})
     set_gauge("total_run_queue_lengths", cpu, %{type: "cpu"})
     set_gauge("total_run_queue_lengths", total - cpu, %{type: "io"})
+  end
+
+  defp scheduler_utilization_metrics(sample) do
+    unless is_nil(sample) do
+      utilization = :scheduler.utilization(sample)
+
+      utilization
+      |> Enum.map(&Tuple.to_list/1)
+      |> Enum.filter(fn [type | _] -> type == :normal end)
+      |> Enum.each(fn [_, id, value, _] ->
+        set_gauge("erlang_scheduler_utilization", value * 100, %{type: "scheduler", id: "#{id}"})
+      end)
+    end
+
+    :scheduler.sample()
   end
 
   defp set_gauge(name, value, tags) do

--- a/lib/appsignal/probes/probes.ex
+++ b/lib/appsignal/probes/probes.ex
@@ -7,10 +7,10 @@ defmodule Appsignal.Probes do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def register(name, probe) do
+  def register(name, probe, state \\ nil) do
     if genserver_running?() do
       if is_function(probe) do
-        GenServer.cast(__MODULE__, {name, probe})
+        GenServer.cast(__MODULE__, {:register, {name, probe, state}})
         :ok
       else
         Logger.debug(fn ->
@@ -25,43 +25,78 @@ defmodule Appsignal.Probes do
   end
 
   def unregister(name) do
-    GenServer.cast(__MODULE__, name)
+    GenServer.cast(__MODULE__, {:unregister, name})
     :ok
   end
 
   def init([]) do
     schedule_probes()
-    {:ok, %{}}
+    {:ok, {%{}, %{}}}
   end
 
-  def handle_cast({name, probe}, probes) do
+  def handle_cast({:register, {name, probe, state}}, {probes, states}) do
     if Map.has_key?(probes, name) do
       Logger.debug(fn -> "A probe with name '#{name}' already exists. Overriding that one." end)
     end
 
-    {:noreply, Map.put(probes, name, probe)}
+    {:noreply,
+     {
+       Map.put(probes, name, probe),
+       Map.put(states, name, state)
+     }}
   end
 
-  def handle_cast(name, probes) do
-    {:noreply, Map.delete(probes, name)}
+  def handle_cast({:unregister, name}, {probes, states}) do
+    {:noreply,
+     {
+       Map.delete(probes, name),
+       Map.delete(states, name)
+     }}
   end
 
-  def handle_info(:run_probes, probes) do
-    if Appsignal.Config.minutely_probes_enabled?() do
-      Enum.each(probes, fn {name, probe} ->
-        Task.start(fn ->
-          try do
-            probe.()
-          rescue
-            e ->
-              Logger.error("Error while calling probe #{name}: #{inspect(e)}")
+  def handle_info(:run_probes, {probes, states}) do
+    states =
+      if Appsignal.Config.minutely_probes_enabled?() do
+        stream =
+          Task.async_stream(
+            probes,
+            fn {name, probe} ->
+              state = Map.get(states, name)
+
+              try do
+                {name, call_probe(probe, state)}
+              rescue
+                e ->
+                  Logger.error("Error while calling probe #{name}: #{inspect(e)}")
+                  {name, state}
+              end
+            end,
+            ordered: false,
+            timeout: 30000,
+            on_timeout: :kill_task
+          )
+
+        Enum.reduce(stream, states, fn result, states ->
+          case result do
+            {:ok, {name, state}} -> Map.put(states, name, state)
+            {:exit, :timeout} -> states
           end
         end)
-      end)
-    end
+      else
+        states
+      end
 
     schedule_probes()
-    {:noreply, probes}
+    {:noreply, {probes, states}}
+  end
+
+  defp call_probe(probe, _state) when is_function(probe, 0) do
+    probe.()
+    nil
+  end
+
+  defp call_probe(probe, state) when is_function(probe, 1) do
+    probe.(state)
   end
 
   def child_spec(_) do

--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,10 @@ defmodule Appsignal.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [
+        :logger,
+        :runtime_tools
+      ],
       mod: {Appsignal, []}
     ]
   end

--- a/test/support/fake_probe.ex
+++ b/test/support/fake_probe.ex
@@ -10,7 +10,22 @@ defmodule FakeProbe do
   def fail do
     if alive?() do
       update(__MODULE__, :probe_called, true)
-      raise :nosup
+      raise "Fake probe failed!"
     end
+  end
+
+  def clear do
+    if alive?() do
+      update(__MODULE__, :probe_called, false)
+    end
+  end
+
+  def stateful(state) do
+    if alive?() do
+      update(__MODULE__, :probe_called, true)
+      update(__MODULE__, :probe_state, state)
+    end
+
+    state + 1
   end
 end


### PR DESCRIPTION
This PR is part of #685. It is a re-do of #687, with an approach based on the existing, tried-and-tested `Appsignal.Probes` implementation. The feedback in appsignal/public_config#33 has been taken into account, and the total utilization metric has been removed.

This commit implements the Erlang scheduler utilization metric on the minutely probes.

In order to report on the scheduler utilization, the probe must keep state from its previous execution. That is, to measure the scheduler utilization between points in time A and B, you must call `:scheduler.sample/0` on point A, then pass the sample it returns to `:scheduler.utilization/1 on point B.

To be able to keep state in the probe, we keep a map of states in `Appsignal.Probes` alongside the map of probes. If a probe takes an argument, the state returned by its previous run is retrieved from the states map and passed as the argument, and the probe's return value is stored in the states map to be used as the next run's state.