### PR TITLE
Standardize key validation request 

### DIFF
--- a/.changesets/fix-push-api-key-validator-request-query-params-encoding.md
+++ b/.changesets/fix-push-api-key-validator-request-query-params-encoding.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix the Push API key validator request query params encoding.

--- a/.changesets/standardize-diagnose-validation-error-message.md
+++ b/.changesets/standardize-diagnose-validation-error-message.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Standardize diagnose validation failure message. Explain the diagnose request failed and why.

--- a/lib/appsignal/diagnose/validation.ex
+++ b/lib/appsignal/diagnose/validation.ex
@@ -10,8 +10,11 @@ defmodule Appsignal.Diagnose.Validation do
       {:error, :invalid} ->
         %{push_api_key: "invalid"}
 
+      {:error, status_code} when is_number(status_code) ->
+        %{push_api_key: "Failed to validate: status #{status_code}"}
+
       {:error, reason} ->
-        %{push_api_key: "error: #{inspect(reason)}"}
+        %{push_api_key: "Failed to validate: #{inspect(reason)}"}
     end
   end
 end

--- a/lib/appsignal/utils/push_api_key_validator.ex
+++ b/lib/appsignal/utils/push_api_key_validator.ex
@@ -3,7 +3,8 @@ defmodule Appsignal.Utils.PushApiKeyValidator do
   alias Appsignal.Transmitter
 
   def validate(config) do
-    url = "#{config[:endpoint]}/1/auth?api_key=#{config[:push_api_key]}"
+    params = URI.encode_query(%{"api_key" => config[:push_api_key]})
+    url = "#{config[:endpoint]}/1/auth?#{params}"
 
     case Transmitter.request(:get, url) do
       {:ok, 200, _, _} -> :ok

--- a/lib/appsignal/utils/push_api_key_validator.ex
+++ b/lib/appsignal/utils/push_api_key_validator.ex
@@ -3,10 +3,17 @@ defmodule Appsignal.Utils.PushApiKeyValidator do
   alias Appsignal.Transmitter
 
   def validate(config) do
-    params = URI.encode_query(%{"api_key" => config[:push_api_key]})
+    params =
+      URI.encode_query(%{
+        "api_key" => config[:push_api_key],
+        "name" => config[:name],
+        "environment" => config[:env],
+        "hostname" => config[:hostname]
+      })
+
     url = "#{config[:endpoint]}/1/auth?#{params}"
 
-    case Transmitter.request(:get, url) do
+    case Transmitter.request(:post, url) do
       {:ok, 200, _, _} -> :ok
       {:ok, 401, _, _} -> {:error, :invalid}
       {:ok, status_code, _, _} -> {:error, status_code}

--- a/test/appsignal/utils/push_api_key_validator_test.exs
+++ b/test/appsignal/utils/push_api_key_validator_test.exs
@@ -13,7 +13,7 @@ defmodule Appsignal.Utils.PushApiKeyValidatorTest do
     setup %{bypass: bypass, config: config} do
       Bypass.expect(bypass, fn conn ->
         assert "/1/auth" == conn.request_path
-        assert "GET" == conn.method
+        assert "POST" == conn.method
         Plug.Conn.resp(conn, 200, "")
       end)
 
@@ -29,7 +29,7 @@ defmodule Appsignal.Utils.PushApiKeyValidatorTest do
     setup %{bypass: bypass, config: config} do
       Bypass.expect(bypass, fn conn ->
         assert "/1/auth" == conn.request_path
-        assert "GET" == conn.method
+        assert "POST" == conn.method
         Plug.Conn.resp(conn, 401, "")
       end)
 
@@ -45,7 +45,7 @@ defmodule Appsignal.Utils.PushApiKeyValidatorTest do
     setup %{bypass: bypass, config: config} do
       Bypass.expect(bypass, fn conn ->
         assert "/1/auth" == conn.request_path
-        assert "GET" == conn.method
+        assert "POST" == conn.method
         Plug.Conn.resp(conn, 500, "")
       end)
 

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
     Bypass.expect(auth_bypass, fn conn ->
       assert "/1/auth" == conn.request_path
-      assert "GET" == conn.method
+      assert "POST" == conn.method
       Plug.Conn.resp(conn, 200, "")
     end)
 
@@ -836,7 +836,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
       Bypass.expect(auth_bypass, fn conn ->
         assert "/1/auth" == conn.request_path
-        assert "GET" == conn.method
+        assert "POST" == conn.method
         Plug.Conn.resp(conn, 401, "")
       end)
     end

--- a/test/mix/tasks/appsignal_install_test.exs
+++ b/test/mix/tasks/appsignal_install_test.exs
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
     setup %{bypass: bypass} do
       Bypass.expect(bypass, fn conn ->
         assert "/1/auth" == conn.request_path
-        assert "GET" == conn.method
+        assert "POST" == conn.method
         Plug.Conn.resp(conn, 401, "")
       end)
 
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.Appsignal.InstallTest do
     setup context do
       Bypass.expect(context[:bypass], fn conn ->
         assert "/1/auth" == conn.request_path
-        assert "GET" == conn.method
+        assert "POST" == conn.method
         Plug.Conn.resp(conn, 200, "")
       end)
 


### PR DESCRIPTION
## Fix Push API key validation request param encoding

All the other locations the transmitter is used we encode the params. If
we don't, and a parameter contains spaces, it could cause problems. I
ran into issues in the test suite not registering requests in Bypass
properly when trying to add more query params to this request.

## Standardize key validation request 

Add the other query params to the auth request.

Update the error message to be standard for all integrations. Not all
integrations necessarily have the response status code on error, so
make sure all integrations start with "Failed to validate".

Change the validation request to a POST request, like the other
integrations. Both work, but it's good to all use the same request
method.

Add test for diagnose Push API key output and report.
Update the diagnose tests with tests for the Push API key validation in
the diagnose CLI.
