### PR TITLE
Update Elixir master to main

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,13 +44,13 @@ blocks:
             - git submodule init
             - git submodule update
             - test/integration/diagnose/bin/test
-        - name: Elixir master, OTP 24
+        - name: Elixir main, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
             - mix test
-        - name: Elixir master, OTP 24, without the NIF loaded
+        - name: Elixir main, OTP 24, without the NIF loaded
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
             - MIX_ENV=test_no_nif mix test
         - name: Elixir 1.12.2, OTP 24
           commands:

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ $ELIXIR_VERSION == "master" ]]; then
+if [[ $ELIXIR_VERSION == "main" ]]; then
   kiex install $ELIXIR_VERSION
 fi
 


### PR DESCRIPTION
The Elixir language repository has updated the default branch to `main`,
from `master`. When kiex now tries to install the `master` branch we get
this error:

```
Unknown Elixir 'master' ☹
Try
	kiex list known -- known releases
	kiex list branches -- current branches
bash: pop_scope: head of shell_variables not a temporary environment scope
```

This change updates it to the new `main` default branch.

[skip changeset]
[skip review]