### PR TITLE
Deprecate and replace `set_sample_data`

### DIFF
--- a/.changesets/deprecate-set-sample-data.md
+++ b/.changesets/deprecate-set-sample-data.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Deprecate the `Appsignal.Span.set_sample_data/3` method, which will be removed in the next major release. Use the `set_environment/1`, `set_session_data/1`, `set_params/1`, `set_tags/1` or `set_custom_data/1` methods on `Appsignal.Tracer` instead.

--- a/.changesets/fix-phoenix-filter-parameters.md
+++ b/.changesets/fix-phoenix-filter-parameters.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix a bug where setting the `:phoenix, :filter_parameters` configuration key to an allow-list of the form `{:keep, [keys]}` would apply this filtering to all sample data maps.

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -10,13 +10,15 @@ defmodule Appsignal.Demo do
   require Appsignal.Utils
 
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
 
   def send_performance_sample do
     instrument("DemoController#hello", "call.phoenix", fn span ->
       span
       |> @span.set_namespace("http_request")
       |> @span.set_attribute("demo_sample", true)
-      |> @span.set_sample_data("environment", %{"method" => "GET", "request_path" => "/"})
+
+      @tracer.set_environment(%{"method" => "GET", "request_path" => "/"})
 
       instrument("call.phoenix_endpoint", fn ->
         :timer.sleep(100)
@@ -44,8 +46,9 @@ defmodule Appsignal.Demo do
         span
         |> @span.set_namespace("http_request")
         |> @span.set_attribute("demo_sample", true)
-        |> @span.set_sample_data("environment", %{"method" => "GET", "request_path" => "/"})
         |> @span.add_error(kind, reason, __STACKTRACE__)
+
+        @tracer.set_environment(%{"method" => "GET", "request_path" => "/"})
       end)
   end
 end

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -28,9 +28,9 @@ defmodule Appsignal.Instrumentation do
   When passing a function that takes an argument, the function is called with
   the created span to allow adding extra information.
 
-      def call(params) do
+      def call do
         Appsignal.instrument("foo.bar", fn span ->
-          Appsignal.Span.set_sample_data(span, "params", params)
+          Appsignal.Span.set_attribute(span, "expected_sleep", 1000)
           :timer.sleep(1000)
         end)
       end

--- a/lib/appsignal/test/span.ex
+++ b/lib/appsignal/test/span.ex
@@ -28,11 +28,6 @@ defmodule Appsignal.Test.Span do
     Span.set_namespace(span, name)
   end
 
-  def set_sample_data(span, key, value) do
-    add(:set_sample_data, {span, key, value})
-    Span.set_sample_data(span, key, value)
-  end
-
   def set_attribute(span, key, value) do
     add(:set_attribute, {span, key, value})
     Span.set_attribute(span, key, value)

--- a/lib/appsignal/test/tracer.ex
+++ b/lib/appsignal/test/tracer.ex
@@ -25,6 +25,21 @@ defmodule Appsignal.Test.Tracer do
     Tracer.create_span(namespace, parent, options)
   end
 
+  def set_environment(value) do
+    add(:set_environment, {value})
+    Tracer.set_environment(value)
+  end
+
+  def set_params(value) do
+    add(:set_params, {value})
+    Tracer.set_params(value)
+  end
+
+  def set_session_data(value) do
+    add(:set_session_data, {value})
+    Tracer.set_session_data(value)
+  end
+
   def close_span(span) do
     add(:close_span, {span})
     Tracer.close_span(span)

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -138,6 +138,86 @@ defmodule Appsignal.Tracer do
 
   defp root(_), do: nil
 
+  @spec set_tags(map()) :: nil
+  @doc """
+  Sets tags for the root span. Previously set tags are overriden.
+
+  ## Example
+      Appsignal.Tracer.set_tags(%{"id" => 123})
+
+  """
+  def set_tags(value) when is_map(value) do
+    Span.do_set_sample_data(root_span(), "tags", value)
+    nil
+  end
+
+  def set_tags(_value), do: nil
+
+  @spec set_params(map()) :: nil
+  @doc """
+  Sets request parameters for the root span. Previously set request
+  parameters are overriden.
+
+  ## Example
+      Appsignal.Tracer.set_params(%{"id" => 123})
+
+  """
+  def set_params(value) when is_map(value) do
+    Span.do_set_sample_data(root_span(), "params", value)
+    nil
+  end
+
+  def set_params(_value), do: nil
+
+  @spec set_environment(map()) :: nil
+  @doc """
+  Sets the request environment data for the root span. This usually
+  includes the request headers. Previously set request environment
+  data is overriden.
+
+  ## Example
+      Appsignal.Tracer.set_environment(%{"req_headers.x-request-id" => "a1b2c3"})
+
+  """
+  def set_environment(value) when is_map(value) do
+    Span.do_set_sample_data(root_span(), "environment", value)
+    nil
+  end
+
+  def set_environment(_value), do: nil
+
+  @spec set_session_data(map()) :: nil
+  @doc """
+  Sets session data for the root span. Previously set session data
+  is overriden.
+
+  ## Example
+      Appsignal.Tracer.set_session_data(%{"admin" => false})
+
+  """
+  def set_session_data(value) when is_map(value) do
+    Span.do_set_sample_data(root_span(), "session_data", value)
+    nil
+  end
+
+  def set_session_data(_value), do: nil
+
+  @spec set_custom_data(map()) :: nil
+  @doc """
+  Sets custom data for the root span. Previously set custom data
+  is overriden.
+
+  ## Example
+      Appsignal.Tracer.set_custom_data(%{"locale" => "en_GB"})
+
+  """
+  def set_custom_data(value) when is_map(value) do
+    Span.do_set_sample_data(root_span(), "custom_data", value)
+    nil
+  end
+
+  def set_custom_data(_value), do: nil
+
   @spec close_span(Span.t() | nil) :: :ok | nil
   @doc """
   Closes a span and deregisters it.

--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -1,4 +1,7 @@
 defmodule Appsignal.Utils.MapFilter do
+  # TO-DO: Move this module to the Phoenix package, affter
+  # `Appsignal.Span.set_sample_data/3` is removed.
+
   @moduledoc false
   require Logger
 

--- a/test/appsignal/demo_test.exs
+++ b/test/appsignal/demo_test.exs
@@ -58,7 +58,7 @@ defmodule Appsignal.DemoTest do
     end
 
     test "sets the span's sample data" do
-      assert_sample_data("environment", %{
+      assert_environment(%{
         "method" => "GET",
         "request_path" => "/"
       })
@@ -99,7 +99,7 @@ defmodule Appsignal.DemoTest do
     end
 
     test "sets the span's sample data" do
-      assert_sample_data("environment", %{
+      assert_environment(%{
         "method" => "GET",
         "request_path" => "/"
       })
@@ -108,14 +108,6 @@ defmodule Appsignal.DemoTest do
     test "closes all spans" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
     end
-  end
-
-  defp assert_sample_data(asserted_key, asserted_data) do
-    {:ok, sample_data} = Test.Span.get(:set_sample_data)
-
-    assert Enum.any?(sample_data, fn {%Span{}, key, data} ->
-             key == asserted_key and data == asserted_data
-           end)
   end
 
   defp attributes(asserted_key) do
@@ -132,5 +124,13 @@ defmodule Appsignal.DemoTest do
     Enum.any?(attributes, fn {%Span{}, key, data} ->
       key == asserted_key and data == asserted_data
     end)
+  end
+
+  defp assert_environment(asserted_data) do
+    {:ok, environment} = Test.Tracer.get(:set_environment)
+
+    assert Enum.any?(environment, fn {data} ->
+             data == asserted_data
+           end)
   end
 end

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -1,4 +1,4 @@
-defmodule AppsignalSpanTest do
+defmodule Appsignal.SpanTest do
   use ExUnit.Case
   alias Appsignal.{Span, Test}
 
@@ -421,11 +421,19 @@ defmodule AppsignalSpanTest do
     test "returns the span", %{span: span, return: return} do
       assert return == span
     end
+
+    test "sets the sample data through the Nif", %{span: %Span{reference: reference}} do
+      assert [{^reference, "key", _}] = Test.Nif.get!(:set_span_sample_data)
+    end
   end
 
   describe ".set_sample_data/3, when passing a nil-span" do
     test "returns nil" do
       assert Span.set_sample_data(nil, "key", %{param: "value"}) == nil
+    end
+
+    test "does not set the sample data through the Nif" do
+      assert Test.Nif.get(:set_span_sample_data) == :error
     end
   end
 

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -250,6 +250,91 @@ defmodule Appsignal.TracerTest do
     end
   end
 
+  describe ".set_environment/1" do
+    setup :create_root_span
+
+    test "sets the environment sample data through the Nif",
+         %{span: %Span{reference: span_reference}} do
+      Tracer.set_environment(%{param: "value"})
+      assert [{^span_reference, "environment", _}] = Test.Nif.get!(:set_span_sample_data)
+    end
+  end
+
+  describe ".set_environment/1, when there is no root span" do
+    test "does not set the environment sample data through the Nif" do
+      Tracer.set_environment(%{param: "value"})
+      assert Test.Nif.get(:set_span_sample_data) == :error
+    end
+  end
+
+  describe ".set_params/1" do
+    setup :create_root_span
+
+    test "sets the params sample data through the Nif",
+         %{span: %Span{reference: span_reference}} do
+      Tracer.set_params(%{param: "value"})
+      assert [{^span_reference, "params", _}] = Test.Nif.get!(:set_span_sample_data)
+    end
+  end
+
+  describe ".set_params/1, when there is no root span" do
+    test "does not set the params sample data through the Nif" do
+      Tracer.set_params(%{param: "value"})
+      assert Test.Nif.get(:set_span_sample_data) == :error
+    end
+  end
+
+  describe ".set_session_data/1" do
+    setup :create_root_span
+
+    test "sets the session sample data through the Nif",
+         %{span: %Span{reference: span_reference}} do
+      Tracer.set_session_data(%{param: "value"})
+      assert [{^span_reference, "session_data", _}] = Test.Nif.get!(:set_span_sample_data)
+    end
+  end
+
+  describe ".set_session_data/1, when there is no root span" do
+    test "does not set the session sample data through the Nif" do
+      Tracer.set_session_data(%{param: "value"})
+      assert Test.Nif.get(:set_span_sample_data) == :error
+    end
+  end
+
+  describe ".set_custom_data/1" do
+    setup :create_root_span
+
+    test "sets the custom sample data through the Nif",
+         %{span: %Span{reference: span_reference}} do
+      Tracer.set_custom_data(%{param: "value"})
+      assert [{^span_reference, "custom_data", _}] = Test.Nif.get!(:set_span_sample_data)
+    end
+  end
+
+  describe ".set_custom_data/1, when there is no root span" do
+    test "does not set the custom sample data through the Nif" do
+      Tracer.set_custom_data(%{param: "value"})
+      assert Test.Nif.get(:set_span_sample_data) == :error
+    end
+  end
+
+  describe ".set_tags/1" do
+    setup :create_root_span
+
+    test "sets the custom sample data through the Nif",
+         %{span: %Span{reference: span_reference}} do
+      Tracer.set_tags(%{param: "value"})
+      assert [{^span_reference, "tags", _}] = Test.Nif.get!(:set_span_sample_data)
+    end
+  end
+
+  describe ".set_tags/1, when there is no root span" do
+    test "does not set the custom sample data through the Nif" do
+      Tracer.set_tags(%{param: "value"})
+      assert Test.Nif.get(:set_span_sample_data) == :error
+    end
+  end
+
   describe "close_span/1, when passing a nil" do
     test "returns nil" do
       assert Tracer.close_span(nil) == nil

--- a/test/appsignal/utils/map_filter_test.exs
+++ b/test/appsignal/utils/map_filter_test.exs
@@ -17,7 +17,7 @@ defmodule Appsignal.Utils.MapFilterTest do
   end
 
   describe "filter/1, with a keeplist" do
-    test "returns the map as-is, and leaves filtering to the agent" do
+    test "filters out the values for keys not present in the keeplist" do
       Application.put_env(:phoenix, :filter_parameters, {:keep, [:name]})
       assert %{id: "[FILTERED]", name: "David"} = MapFilter.filter(%{id: 4, name: "David"})
       Application.delete_env(:phoenix, :filter_parameters)

--- a/test/support/appsignal/test_nif.ex
+++ b/test/support/appsignal/test_nif.ex
@@ -35,6 +35,11 @@ defmodule Appsignal.Test.Nif do
     Nif.set_span_namespace(reference, namespace)
   end
 
+  def set_span_sample_data(reference, key, data) do
+    add(:set_span_sample_data, {reference, key, data})
+    Nif.set_span_sample_data(reference, key, data)
+  end
+
   def add_span_error(reference, name, message, stacktrace) do
     add(:add_span_error, {reference, name, message, stacktrace})
     Nif.add_span_error(reference, name, message, stacktrace)


### PR DESCRIPTION
This PR is part of [integration-guide#80](https://github.com/appsignal/integration-guide/issues/80).
Fixes #649.

This commit deprecates the `Appsignal.Span.set_sample_data/3` method, replacing it with the `set_params/2`, `set_environment/2`, `set_session_data/2` and `set_custom_data/2` methods.

Before sending the data to the extension, allow-list filtering is applied if the `:phoenix, :filter_parameters` config key is set to `{:keep, keys}`, where `keys` is a list of keys to allow through. Before this change, this filtering would be applied to any data passing through `set_sample_data/3`. Out of the newly implemented functions, only data passing through `set_params/2` has this filtering applied to it.