### PR TITLE
Use only supported TLS versions

### DIFF
--- a/.changesets/fix-agent-download-openssl-below-111.md
+++ b/.changesets/fix-agent-download-openssl-below-111.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+Fix the download of the agent during installation when Erlang is
+using an OpenSSL version that does not support TLS 1.3, such as versions below OpenSSL 1.1.1.

--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -47,7 +47,7 @@ defmodule Appsignal.Transmitter do
   end
 
   if System.otp_release() >= "23" do
-    defp tls_options, do: [versions: [:"tlsv1.3", :"tlsv1.2"]]
+    defp tls_options, do: [versions: :ssl.versions()[:supported]]
   else
     defp tls_options do
       [

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -704,7 +704,7 @@ defmodule Mix.Appsignal.Helper do
   end
 
   if System.otp_release() >= "23" do
-    defp tls_options, do: [versions: [:"tlsv1.3", :"tlsv1.2"]]
+    defp tls_options, do: [versions: :ssl.versions()[:supported]]
   else
     defp tls_options do
       [


### PR DESCRIPTION
Ask the SSL module for a list of supported TLS versions for Hackney to attempt to use during the agent download, so that versions that are unsupported by Elixir's currently linked "cryptolib" (that is, OpenSSL) are not listed in the `:versions` option.

This fixes #714, an issue where downloading the agent will fail when using OpenSSL 1.0.2, as the download attempts to use the TLS versions listed in `:versions` _in order_, and errors out when it attempts to use TLS 1.3, which isn't supported by the cryptolib.

The same changes to the TLS options used in the agent download are also applied to `Appsignal.Transmitter`, which is used to validate API keys and send the diagnose report.