### PR TITLE
Remove valid config opt

### DIFF
--- a/.changesets/remove-valid-option-from-diagnose-output.md
+++ b/.changesets/remove-valid-option-from-diagnose-output.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+---
+
+
+Remove the `valid` key from the diagnose output. It's not a configuration option that
+can be configured, but an internal state check if the configuration was considered valid.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -54,13 +54,11 @@ defmodule Appsignal.Config do
       |> Map.merge(sources[:file])
       |> Map.merge(sources[:env])
 
-    # Config is valid when we have a push api key
     config =
       config
       |> merge_filter_data_keys(Application.get_env(:phoenix, :filter_parameters, []))
       |> merge_filter_data_keys(config[:filter_parameters])
       |> merge_filter_data_keys(config[:filter_session_data])
-      |> Map.put(:valid, !empty?(config[:push_api_key]))
 
     if !empty?(config[:working_dir_path]) do
       Logger.warn(fn ->
@@ -72,7 +70,8 @@ defmodule Appsignal.Config do
 
     Application.put_env(:appsignal, :config, config)
 
-    case config[:valid] do
+    # Config is valid when we have a push api key
+    case !empty?(config[:push_api_key]) do
       true ->
         :ok
 
@@ -111,7 +110,7 @@ defmodule Appsignal.Config do
     |> do_active?
   end
 
-  defp do_active?(%{valid: true, active: true}), do: true
+  defp do_active?(%{active: true}), do: true
   defp do_active?(_), do: false
 
   @doc """

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -70,8 +70,7 @@ defmodule Appsignal.Config do
 
     Application.put_env(:appsignal, :config, config)
 
-    # Config is valid when we have a push api key
-    case !empty?(config[:push_api_key]) do
+    case valid?() do
       true ->
         :ok
 
@@ -100,6 +99,17 @@ defmodule Appsignal.Config do
   end
 
   @doc """
+  Returns true if the configuration is valid. Configuration is considered
+  valid if there's an push API key set.
+  """
+  @spec valid?() :: boolean
+  def valid? do
+    Application.get_env(:appsignal, :config)[:push_api_key]
+    |> empty?
+    |> Kernel.not()
+  end
+
+  @doc """
   Returns true if the configuration is valid and the AppSignal agent is
   configured to start on application launch.
   """
@@ -110,7 +120,7 @@ defmodule Appsignal.Config do
     |> do_active?
   end
 
-  defp do_active?(%{active: true}), do: true
+  defp do_active?(%{active: true}), do: valid?()
   defp do_active?(_), do: false
 
   @doc """

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -22,9 +22,7 @@ defmodule Appsignal.ConfigTest do
     test "stores sources in Application" do
       init_config()
 
-      default =
-        default_configuration()
-        |> Map.delete(:valid)
+      default = default_configuration()
 
       assert Application.get_env(:appsignal, :config_sources) == %{
                default: default,
@@ -72,37 +70,30 @@ defmodule Appsignal.ConfigTest do
   describe "configured_as_active?" do
     test "when active" do
       assert with_config(
-               %{active: true, valid: true},
+               %{active: true},
                &Config.configured_as_active?/0
              )
     end
 
     test "when not active" do
       refute with_config(
-               %{active: false, valid: true},
+               %{active: false},
                &Config.configured_as_active?/0
              )
     end
   end
 
   describe "active?" do
-    test "when active and valid" do
+    test "when active" do
       assert with_config(
-               %{active: true, valid: true},
+               %{active: true},
                &Config.active?/0
              )
     end
 
-    test "when active but not valid" do
+    test "when not active" do
       refute with_config(
-               %{active: true, valid: false},
-               &Config.active?/0
-             )
-    end
-
-    test "when not active and not valid" do
-      refute with_config(
-               %{active: false, valid: true},
+               %{active: false},
                &Config.active?/0
              )
     end
@@ -973,7 +964,6 @@ defmodule Appsignal.ConfigTest do
       send_params: true,
       skip_session_data: false,
       files_world_accessible: true,
-      valid: false,
       log: "file",
       request_headers: ~w(
         accept accept-charset accept-encoding accept-language cache-control
@@ -988,7 +978,6 @@ defmodule Appsignal.ConfigTest do
   defp valid_configuration do
     default_configuration()
     |> Map.put(:active, true)
-    |> Map.put(:valid, true)
     |> Map.put(:push_api_key, "00000000-0000-0000-0000-000000000000")
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -67,6 +67,22 @@ defmodule Appsignal.ConfigTest do
     assert default_configuration() == init_config()
   end
 
+  describe "valid?" do
+    test "when a push api key is set up" do
+      assert with_config(
+               %{push_api_key: "00000000-0000-0000-0000-000000000000"},
+               &Config.valid?/0
+             )
+    end
+
+    test "when no push api key is set up" do
+      refute with_config(
+               %{push_api_key: nil},
+               &Config.valid?/0
+             )
+    end
+  end
+
   describe "configured_as_active?" do
     test "when active" do
       assert with_config(
@@ -84,16 +100,23 @@ defmodule Appsignal.ConfigTest do
   end
 
   describe "active?" do
-    test "when active" do
+    test "when active and valid" do
       assert with_config(
-               %{active: true},
+               %{active: true, push_api_key: "00000000-0000-0000-0000-000000000000"},
                &Config.active?/0
              )
     end
 
-    test "when not active" do
+    test "when active and not valid" do
       refute with_config(
-               %{active: false},
+               %{push_api_key: nil, active: true},
+               &Config.active?/0
+             )
+    end
+
+    test "when not active and not valid" do
+      refute with_config(
+               %{push_api_key: nil, active: false},
                &Config.active?/0
              )
     end

--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -53,8 +53,7 @@ defmodule Appsignal.ReleaseUpgradeTest do
       name: "AppSignal test suite app v1",
       push_api_key: "00000000-0000-0000-0000-000000000000",
       send_params: true,
-      skip_session_data: false,
-      valid: false
+      skip_session_data: false
     }
   end
 end

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -34,7 +34,6 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
     setup_with_config(%{
       active: true,
-      valid: true,
       name: "AppSignal test suite app v0",
       env: "test",
       push_api_key: "foo",


### PR DESCRIPTION
## Remove valid config opt

`valid` should not be a config option and should not be printed nor sent
in the diagnose report. The config initialization considers that it's
valid if there's a push api key present. Now, the validation is still
being done but not stored as a config option.

## Add valid config helper function

As `valid` is no longer an accessible config option, a new helper
function (`Config.valid?/0`) will tell if the configuration is valid.