### PR TITLE
Fix Erlang/OTP version usage in CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -100,10 +100,6 @@ blocks:
           commands:
             - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
-        - name: Elixir 1.9.4, OTP 20
-          commands:
-            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 . bin/setup
-            - mix test
       env_vars:
         - name: MIX_ENV
           value: test

--- a/bin/setup
+++ b/bin/setup
@@ -6,9 +6,9 @@ if [[ $ELIXIR_VERSION == "main" ]]; then
   kiex install $ELIXIR_VERSION
 fi
 
+sem-version elixir $ELIXIR_VERSION
 sem-version erlang $ERLANG_VERSION
 erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
-sem-version elixir $ELIXIR_VERSION
 elixir -v
 mix local.rebar --force
 mix local.hex --force

--- a/bin/setup
+++ b/bin/setup
@@ -2,13 +2,10 @@
 
 set -e
 
-if [[ $ELIXIR_VERSION == "main" ]]; then
-  kiex install $ELIXIR_VERSION
-fi
-
-sem-version elixir $ELIXIR_VERSION
 sem-version erlang $ERLANG_VERSION
 erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
+kiex install $ELIXIR_VERSION
+kiex use $ELIXIR_VERSION
 elixir -v
 mix local.rebar --force
 mix local.hex --force

--- a/bin/setup
+++ b/bin/setup
@@ -2,11 +2,33 @@
 
 set -e
 
+elixirs_key="elixir-$ELIXIR_VERSION-erlang-$ERLANG_VERSION-elixirs"
+archives_key="elixir-$ELIXIR_VERSION-erlang-$ERLANG_VERSION-archives"
+
+elixirs_path=~/".kiex/elixirs"
+archives_path=~/".kiex/mix/archives"
+
+rm -rf "$elixirs_path"/*
+rm -rf "$archives_path"/*
+
 sem-version erlang $ERLANG_VERSION
 erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
-kiex install $ELIXIR_VERSION
+
+if [ $ELIXIR_VERSION != "main" ] && \
+   cache has_key "$elixirs_key" && \
+   cache has_key "$archives_key"
+then
+  cache restore "$elixirs_key"
+  cache restore "$archives_key"
+else
+  kiex install $ELIXIR_VERSION
+  cache store "$elixirs_key" "$elixirs_path"
+  cache store "$archives_key" "$archives_path"
+fi
+
 kiex use $ELIXIR_VERSION
 elixir -v
+
 mix local.rebar --force
 mix local.hex --force
 mix deps.get

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,9 +1,8 @@
-:0: Unknown function 'Elixir.Jason':decode/1
-:0: Unknown function 'Elixir.Jason':'decode!'/1
-:0: Unknown function 'Elixir.Jason':encode/1
-:0: Unknown function 'Elixir.Jason':'encode!'/1
-:0: Unknown function 'Elixir.Mix.Project':config/0
-:0: Unknown type 'Elixir.Appsignal.Span':t/0
+lib/appsignal/json.ex:31: Unknown function 'Elixir.Jason':encode/1
+lib/appsignal/json.ex:32: Unknown function 'Elixir.Jason':'encode!'/1
+lib/appsignal/json.ex:33: Unknown function 'Elixir.Jason':decode/1
+lib/appsignal/json.ex:34: Unknown function 'Elixir.Jason':'decode!'/1
+lib/mix/tasks/appsignal.install.ex:51: Unknown function 'Elixir.Mix.Project':config/0
 lib/appsignal.ex:46: The inferred return type of config_change/3 (pid()) has nothing in common with 'ok', which is the expected return type for the callback of the 'Elixir.Application' behaviour
 lib/mix/tasks/appsignal.demo.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available
 lib/mix/tasks/appsignal.diagnose.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available


### PR DESCRIPTION
[skip changeset]

### Use ERLANG_VERSION in CI tests

When running tests on Semaphore, different combinations of Erlang/OTP versions and Elixir versions are tested. This is implemented by calling `sem-version` with the desired Erlang or Elixir version.

However, when `sem-version elixir` is called with an Elixir version that is not installed, it will install and activate the highest Erlang version supported by that Elixir version, as part of the installation process. Since `sem-version erlang` is called before `sem-version elixir`, the desired Erlang version is effectively overriden.

This commit reverses the order in which `sem-version erlang` and `sem-version elixir` are called.

### Build Elixir compatible with Erlang version

When installing a given Elixir version using `sem-version elixir`, it will not directly call `kiex` to install Elixir. Instead, it will download a pre-compiled Elixir version from the Semaphore CDN and place it where the corresponding `kiex` installation would be.

These pre-compiled Elixir versions have been compiled against the highest supported Erlang/OTP version. This makes them incompatible with lower Erlang/OTP versions. To address this, this commit calls `kiex install` and `kiex use` directly, in order to compile an Elixir version compatible with the Erlang version currently in use, instead of using `sem-version`.

### Cache Elixir builds for each version

Building each Elixir version takes over a minute. To mitigate this, this commit uses Semaphore's `cache` to store Elixir builds for a given Elixir and Erlang version between CI runs.

### Fix ignored Dialyzer warnings

For some reason, running Dialyzer on OTP 24 makes it correctly identify the location in the source code where the warnings it is set to ignore take place. This commit changes the entries in `dialyzer.ignore-warnings` to match the warnings emitted with the correct location, making the CI pass succeed in ignoring them.

### Remove OTP 20 checks from CI

This commit removes the checks for OTP 20 on Elixir 1.9, as the tests are not currently passing. [A separate draft PR](https://github.com/appsignal/appsignal-elixir/pull/724) has been created to add them back again and fix them.