### PR TITLE
Split filter parameters and session data options

### DIFF
--- a/.changesets/bump-agent-to-v-5b63505.md
+++ b/.changesets/bump-agent-to-v-5b63505.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+---
+
+Bump agent to v-5b63505
+
+- Only filter parameters with the `filter_parameters` config option.
+- Only filter session data with the `filter_session_data` config option.

--- a/.changesets/improve-parameter-and-session-data-filtering-options.md
+++ b/.changesets/improve-parameter-and-session-data-filtering-options.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Improve parameter and session data filtering options. Previously all filtering was done with one combined denylist of parameters and session data. Now `filter_parameters` only applies to parameters, and `filter_session_data` only applies to session data.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "09308fb"
+  def version, do: "5b63505"
 
   def mirrors do
     [
@@ -16,51 +16,51 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "72e3e84ce59f4b84287f0d72ec567447a28e42fb758eb27dd7676cd7613eb2e9",
+        checksum: "122bbf4a5931f850644853a80b3fc929db93e18d32c2c75d487f5dc6a17358f7",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "72e3e84ce59f4b84287f0d72ec567447a28e42fb758eb27dd7676cd7613eb2e9",
+        checksum: "122bbf4a5931f850644853a80b3fc929db93e18d32c2c75d487f5dc6a17358f7",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df",
+        checksum: "b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df",
+        checksum: "b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df",
+        checksum: "b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "d14ed2b2ba05b7a0a229eaba8ee710c35ff0c8681084ec5d0650fb53dae7b3d3",
+        checksum: "d2eeac3b67e6629b43965f5056131b79dc9dd5ac3767951c79c9e2d8f7aca8c3",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "18cd5ef04e547dcc522faa0a462a00bac27e9bd221bd4dd8e6e2e934d4afd5b7",
+        checksum: "5a292e5a14e737a0a3756573b264ab749f211ff370717b80f9812e837e09392d",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "18cd5ef04e547dcc522faa0a462a00bac27e9bd221bd4dd8e6e2e934d4afd5b7",
+        checksum: "5a292e5a14e737a0a3756573b264ab749f211ff370717b80f9812e837e09392d",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "98aaa72590d45b8a6aec3d8222468d1875f8fc798f1d891b6424749102d0b0f0",
+        checksum: "3a2688cf0e645d1d881f535ffbcf9602f626d7cc426591c605d89eeabd66d5f7",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "1e2685775d45299e6f6b7439f44586c87fcb6ae14e3eb4f2ed0034b5ffed4d42",
+        checksum: "0cab0c9dadd9a9d48df0e35a8e8e1896edad1678d04bb7b5742d571c5fbff4f9",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "7ffd025a7dccca6f6730df2146faeb541fb0a4659fb802e88587471cd625ca94",
+        checksum: "3f470aaeb68fca7a7e2a7d36f557f23c72056807efc429f2ceef8922e73e8ca2",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "7ffd025a7dccca6f6730df2146faeb541fb0a4659fb802e88587471cd625ca94",
+        checksum: "3f470aaeb68fca7a7e2a7d36f557f23c72056807efc429f2ceef8922e73e8ca2",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -592,22 +592,6 @@ static ERL_NIF_TERM _data_map_new(ErlNifEnv* env, int UNUSED(argc), const ERL_NI
   return make_ok_tuple(env, data_ref);
 }
 
-static ERL_NIF_TERM _data_filtered_map_new(ErlNifEnv* env, int UNUSED(argc), const ERL_NIF_TERM UNUSED(argv[])) {
-  data_ptr *ptr;
-  ERL_NIF_TERM data_ref;
-
-  ptr = enif_alloc_resource(appsignal_data_type, sizeof(data_ptr));
-  if(!ptr)
-    return make_error_tuple(env, "no_memory");
-
-  ptr->data = appsignal_data_filtered_map_new();
-
-  data_ref = enif_make_resource(env, ptr);
-  enif_release_resource(ptr);
-
-  return make_ok_tuple(env, data_ref);
-}
-
 static ERL_NIF_TERM _data_set_string(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   data_ptr *ptr;
   ErlNifBinary key, value;
@@ -1360,7 +1344,6 @@ static ErlNifFunc nif_funcs[] =
     {"_increment_counter", 3, _increment_counter, 0},
     {"_add_distribution_value", 3, _add_distribution_value, 0},
     {"_data_map_new", 0, _data_map_new, 0},
-    {"_data_filtered_map_new", 0, _data_filtered_map_new, 0},
     {"_data_set_string", 3, _data_set_string, 0},
     {"_data_set_string", 2, _data_set_string, 0},
     {"_data_set_integer", 3, _data_set_integer, 0},

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -16,7 +16,6 @@ defmodule Appsignal.Config do
     env: :dev,
     filter_parameters: [],
     filter_session_data: [],
-    filter_data_keys: [],
     ignore_actions: [],
     ignore_errors: [],
     ignore_namespaces: [],
@@ -56,9 +55,7 @@ defmodule Appsignal.Config do
 
     config =
       config
-      |> merge_filter_data_keys(Application.get_env(:phoenix, :filter_parameters, []))
-      |> merge_filter_data_keys(config[:filter_parameters])
-      |> merge_filter_data_keys(config[:filter_session_data])
+      |> merge_filter_parameters(Application.get_env(:phoenix, :filter_parameters, []))
 
     if !empty?(config[:working_dir_path]) do
       Logger.warn(fn ->
@@ -79,13 +76,13 @@ defmodule Appsignal.Config do
     end
   end
 
-  defp merge_filter_data_keys(map, keys) when is_list(keys) do
-    {_, new_map} = Map.get_and_update(map, :filter_data_keys, &{&1, &1 ++ keys})
+  defp merge_filter_parameters(map, keys) when is_list(keys) do
+    {_, new_map} = Map.get_and_update(map, :filter_parameters, &{&1, &1 ++ keys})
 
     new_map
   end
 
-  defp merge_filter_data_keys(map, _keys) do
+  defp merge_filter_parameters(map, _keys) do
     map
   end
 
@@ -192,7 +189,6 @@ defmodule Appsignal.Config do
     "APPSIGNAL_SEND_PARAMS" => :send_params,
     "APPSIGNAL_FILTER_PARAMETERS" => :filter_parameters,
     "APPSIGNAL_FILTER_SESSION_DATA" => :filter_session_data,
-    "APPSIGNAL_FILTER_DATA_KEYS" => :filter_data_keys,
     "APPSIGNAL_DEBUG" => :debug,
     "APPSIGNAL_DNS_SERVERS" => :dns_servers,
     "APPSIGNAL_LOG" => :log,
@@ -229,7 +225,7 @@ defmodule Appsignal.Config do
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(
-    APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_ECTO_REPOS APPSIGNAL_FILTER_DATA_KEYS
+    APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_ECTO_REPOS
     APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS
     APPSIGNAL_IGNORE_NAMESPACES APPSIGNAL_DNS_SERVERS
     APPSIGNAL_FILTER_SESSION_DATA APPSIGNAL_REQUEST_HEADERS
@@ -332,7 +328,8 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_TRANSACTION_DEBUG_MODE", to_string(config[:transaction_debug_mode]))
     Nif.env_put("_APPSIGNAL_WORKING_DIR_PATH", to_string(config[:working_dir_path]))
     Nif.env_put("_APPSIGNAL_WORKING_DIRECTORY_PATH", to_string(config[:working_directory_path]))
-    Nif.env_put("_APPSIGNAL_FILTER_DATA_KEYS", config[:filter_data_keys] |> Enum.join(","))
+    Nif.env_put("_APPSIGNAL_FILTER_PARAMETERS", config[:filter_parameters] |> Enum.join(","))
+    Nif.env_put("_APPSIGNAL_FILTER_SESSION_DATA", config[:filter_session_data] |> Enum.join(","))
 
     Nif.env_put(
       "_APPSIGNAL_FILES_WORLD_ACCESSIBLE",

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -134,10 +134,6 @@ defmodule Appsignal.Nif do
     _data_map_new()
   end
 
-  def data_filtered_map_new do
-    _data_filtered_map_new()
-  end
-
   def data_set_string(resource, key, value) do
     _data_set_string(resource, key, value)
   end
@@ -371,10 +367,6 @@ defmodule Appsignal.Nif do
   end
 
   def _data_map_new do
-    {:ok, nil}
-  end
-
-  def _data_filtered_map_new do
     {:ok, nil}
   end
 

--- a/lib/appsignal/utils/data_encoder.ex
+++ b/lib/appsignal/utils/data_encoder.ex
@@ -12,7 +12,7 @@ defmodule Appsignal.Utils.DataEncoder do
   end
 
   def encode(data) when is_map(data) do
-    {:ok, resource} = Nif.data_filtered_map_new()
+    {:ok, resource} = Nif.data_map_new()
     Enum.each(data, fn item -> encode(resource, item) end)
     resource
   end


### PR DESCRIPTION
Instead of using `filter_data_keys` (`_APPSIGNAL_FILTER_DATA_KEYS`) to
filter any kind of data object in the extension, split it up in the
`filter_parameters` (`_APPSIGNAL_FILTER_PARAMETERS`) and
`filter_session_data` (`_APPSIGNAL_FILTER_SESSION_DATA`) config options.

This will make it more predictable what keys are filtered out in a data
object.

Since the filtering is now done with a data object is given to the
`appsignal_set_span_sample_data` function, the
`appsignal_data_filtered_map_new` function implementation can be
removed.

This change requires an extension update for the revised configuration
behavior.

Part of https://github.com/appsignal/integration-guide/issues/31