### PR TITLE
Don't consider config valid if API key is empty

### DIFF
--- a/.changesets/push-api-key-as-an-empty-string-is-not-considered-valid-anymore.md
+++ b/.changesets/push-api-key-as-an-empty-string-is-not-considered-valid-anymore.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+When the Push API key config option value is an empty string,
+or a string with only whitespace characters, it is not considered valid anymore.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -104,10 +104,14 @@ defmodule Appsignal.Config do
   """
   @spec valid?() :: boolean
   def valid? do
-    Application.get_env(:appsignal, :config)[:push_api_key]
-    |> empty?
-    |> Kernel.not()
+    do_valid?(Application.get_env(:appsignal, :config)[:push_api_key])
   end
+
+  defp do_valid?(push_api_key) when is_binary(push_api_key) do
+    !empty?(String.trim(push_api_key))
+  end
+
+  defp do_valid?(_push_api_key), do: false
 
   @doc """
   Returns true if the configuration is valid and the AppSignal agent is

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -81,6 +81,20 @@ defmodule Appsignal.ConfigTest do
                &Config.valid?/0
              )
     end
+
+    test "when the push api key is an empty string" do
+      refute with_config(
+               %{push_api_key: ""},
+               &Config.valid?/0
+             )
+    end
+
+    test "when the push api key is filled with whitespaces" do
+      refute with_config(
+               %{push_api_key: "    "},
+               &Config.valid?/0
+             )
+    end
   end
 
   describe "configured_as_active?" do


### PR DESCRIPTION
The configuration validation will not return true anymore if the passed
push API key is an empty string.