### PR TITLE
Fix meaningless scheduler utilization values

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -85,6 +85,9 @@ defmodule Appsignal do
 
   @doc false
   def add_default_probes do
+    # This is a workaround for https://github.com/erlang/otp/issues/5425.
+    _ = :scheduler.sample()
+
     Appsignal.Probes.register(:erlang, &Appsignal.Probes.ErlangProbe.call/1)
   end
 

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -86,7 +86,7 @@ defmodule Appsignal do
   @doc false
   def add_default_probes do
     # This is a workaround for https://github.com/erlang/otp/issues/5425.
-    _ = :scheduler.sample()
+    :erlang.system_flag(:scheduler_wall_time, true)
 
     Appsignal.Probes.register(:erlang, &Appsignal.Probes.ErlangProbe.call/1)
   end


### PR DESCRIPTION
[skip changeset]

### Sample schedulers when probe starts

The scheduler utilization sample was being obtained only after all the other metrics had been collected, and no second sample was being passed to `:scheduler.utilization`, meaning the elapsed time between samples was inconsistent. This commit modifies the Erlang probe so that the sample is collected when the probe starts, and so that the utilization is compared between the previous sample and the next.

### Fix meaningless utilization values

When `:scheduler.sample/0` is called from a process for the first time, _if and only if none of its parent processes have themselves called `:scheduler.sample/0`_, the values obtained from the call will refer to the time the child process has been alive. As such, calculating the scheduler utilization from two calls obtained from different child processes returns meaningless values. This has been [reported as a bug in the OTP repository][bug].

[bug]: https://github.com/erlang/otp/issues/5425

As a workaround, this commit calls `:scheduler.sample/0` from `Appsignal`, right before the Erlang probe is initialised, ensuring that the Task child processes receive coherent values.

### Implement scheduler utilization for OTP < 21

Using `:erlang.statistics(:scheduler_wall_time)`, we can implement the functionality provided by `:scheduler.sample/0` and `:scheduler.utilization/2` for versions of OTP which do not implement them. The calculation performed to obtain the utilization rate from a pair of samples is [described in the documentation for `:erlang.statistics(:scheduler_wall_time)`][docs].

[docs]: https://www.erlang.org/doc/man/erlang.html#statistics_scheduler_wall_time