### PR TITLE
Fix OTP 20 tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -117,6 +117,10 @@ blocks:
             - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix compile
             - mix test --no-compile
+        - name: Elixir 1.9.4, OTP 20
+          commands:
+            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 . bin/setup
+            - mix test
       env_vars:
         - name: MIX_ENV
           value: test

--- a/mix.exs
+++ b/mix.exs
@@ -97,6 +97,7 @@ defmodule Appsignal.Mixfile do
 
   defp deps do
     system_version = System.version()
+    otp_version = System.otp_release()
 
     poison_version =
       case Version.compare(system_version, "1.6.0") do
@@ -108,6 +109,12 @@ defmodule Appsignal.Mixfile do
       case Version.compare(system_version, "1.5.0") do
         :lt -> "~> 1.2.3"
         _ -> "~> 1.2.3 or ~> 1.3"
+      end
+
+    telemetry_version =
+      case otp_version < "21" do
+        true -> "~> 0.4"
+        false -> "~> 0.4 or ~> 1.0"
       end
 
     mime_dependency =
@@ -127,7 +134,7 @@ defmodule Appsignal.Mixfile do
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},
       {:credo, "~> 1.5.6", only: [:test, :dev], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:telemetry, "~> 0.4 or ~> 1.0"}
+      {:telemetry, telemetry_version}
     ] ++ mime_dependency
   end
 end

--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -43,7 +43,11 @@ defmodule Appsignal.TransmitterTest do
 
       refute Keyword.has_key?(ssl_options, :verify_fun)
     else
-      assert ssl_options[:verify_fun] == (&:ssl_verify_hostname.verify_fun/3)
+      assert match?(
+               {fun, pid} when is_function(fun, 3) and is_pid(pid),
+               ssl_options[:verify_fun]
+             )
+
       refute Keyword.has_key?(ssl_options, :customize_hostname_check)
     end
   end


### PR DESCRIPTION
[skip changeset]

This PR must be rebased against `main` after #718 is merged.  The CI checks currently do not pass for the following reason:

- [ ] The integration does not pass the tests under OTP 20.

### Add OTP 20 checks for CI

This commit adds back CI checks for OTP 20 on Elixir 1.9.

### Install Telemetry 0.x version for OTP < 20

The integration compiles successfully when the Telemtry dependency version is set to `~> 0.4`, instead of to `~> 0.4 or ~> 1.0`.