### PR TITLE
Avoid Lintje failure when force-pushing

### DIFF
--- a/script/lint_git
+++ b/script/lint_git
@@ -19,4 +19,13 @@ else
   cache store $cache_key $HOME/bin/lintje
 fi
 
-$HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
+# When force-pushing, the commit range may begin at a commit that does not
+# exist. When this happens, check only the commit at the head of the range.
+base_commit="$(echo "$SEMAPHORE_GIT_COMMIT_RANGE" | cut -d '.' -f 1)"
+
+if git cat-file -e "$base_commit"; then
+  $HOME/bin/lintje "$SEMAPHORE_GIT_COMMIT_RANGE"
+else
+  head_commit="$(echo "$SEMAPHORE_GIT_COMMIT_RANGE" | cut -d '.' -f 4)"
+  $HOME/bin/lintje "$head_commit"
+fi


### PR DESCRIPTION
[skip changeset]

When force-pushing a branch such that commits are dropped from the head of its history -- that is, if the branch goes from a history of the form `A -> B` to `A -> C`, where `A`, `B` and `C` are non-overlapping chains of commits -- then Github will report a force-push "from `B[0]` to `C[-1]`", where `B[0]` is the first commit of `B` and `C[-1]` is the last commit of `C`. And, in turn, the $SEMAPHORE_GIT_COMMIT_RANGE environment variable will contain the commit range `B[0]...C[-1]` -- which is a problem, because `B[0]` no longer exists. When this commit range is passed to Lintje, it will, quite reasonably, fail to analyze a commit range whose base is a non-existing commit.

This commit changes the `script/lint_git` script that invokes Lintje, so that it first checks that the base of the commit range is a commit that exists. If it isn't, then it will only check the head commit of the commit range -- which isn't _great_, but it's better than failing the build.