### PR TITLE
Fix Phoenix parameter filtering

### DIFF
--- a/.changesets/fix-phoenix-filter-parameters.md
+++ b/.changesets/fix-phoenix-filter-parameters.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix a bug where setting the `:phoenix, :filter_parameters` configuration key to an allow-list of the form `{:keep, [keys]}` would apply this filtering to all sample data maps. The filtering is now only applied to the params sample data map.

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -190,18 +190,23 @@ defmodule Appsignal.Span do
       |> Appsignal.Span.set_sample_data("environment", %{"method" => "GET"})
 
   """
-  def set_sample_data(%Span{reference: reference} = span, key, value)
-      when is_binary(key) and is_map(value) do
-    data =
-      value
-      |> Appsignal.Utils.MapFilter.filter()
-      |> Appsignal.Utils.DataEncoder.encode()
+  def set_sample_data(span, "params", value) do
+    do_set_sample_data(span, "params", Appsignal.Utils.MapFilter.filter(value))
+  end
+
+  def set_sample_data(span, key, value) do
+    do_set_sample_data(span, key, value)
+  end
+
+  defp do_set_sample_data(%Span{reference: reference} = span, key, value)
+       when is_binary(key) and is_map(value) do
+    data = Appsignal.Utils.DataEncoder.encode(value)
 
     :ok = Nif.set_span_sample_data(reference, key, data)
     span
   end
 
-  def set_sample_data(_span, _key, _value), do: nil
+  defp do_set_sample_data(_span, _key, _value), do: nil
 
   @spec add_error(t() | nil, Exception.kind(), any(), Exception.stacktrace()) :: t() | nil
   @doc """


### PR DESCRIPTION
Before this change, all sample data was passed through the `Appsignal.Utils.MapFilter.filter/1` function, which filters the given map by the allowlist specified in the `:filter_parameters` Phoenix configuration key, when it exists and is an allowlist.

This commit changes the behaviour of the `set_sample_data/3` function so that it only filters the sample data when the given key is `"params"`. This fixes #649.