### PR TITLE
Add send_environment_metadata config option

### DIFF
--- a/.changesets/add-send_environment_metadata-config-option.md
+++ b/.changesets/add-send_environment_metadata-config-option.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Add `send_environment_metadata` config option to configure the environment metadata collection. For more information, see our [environment metadata docs](https://docs.appsignal.com/application/environment-metadata.html).

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -26,6 +26,7 @@ defmodule Appsignal.Config do
       connection content-length path-info range request-method request-uri
       server-name server-port server-protocol
     ),
+    send_environment_metadata: true,
     send_params: true,
     skip_session_data: false,
     transaction_debug_mode: false
@@ -207,6 +208,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_PUSH_API_KEY" => :push_api_key,
     "APPSIGNAL_REQUEST_HEADERS" => :request_headers,
     "APPSIGNAL_RUNNING_IN_CONTAINER" => :running_in_container,
+    "APPSIGNAL_SEND_ENVIRONMENT_METADATA" => :send_environment_metadata,
     "APPSIGNAL_SEND_PARAMS" => :send_params,
     "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data,
     "APPSIGNAL_TRANSACTION_DEBUG_MODE" => :transaction_debug_mode,
@@ -225,7 +227,7 @@ defmodule Appsignal.Config do
     APPSIGNAL_ENABLE_ALLOCATION_TRACKING APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER
     APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA APPSIGNAL_TRANSACTION_DEBUG_MODE
     APPSIGNAL_FILES_WORLD_ACCESSIBLE APPSIGNAL_SEND_PARAMS APPSIGNAL_ENABLE_MINUTELY_PROBES
-    APPSIGNAL_ENABLE_STATSD
+    APPSIGNAL_ENABLE_STATSD APPSIGNAL_SEND_ENVIRONMENT_METADATA
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(
@@ -336,6 +338,12 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_LOG_FILE_PATH", to_string(log_file_path()))
     Nif.env_put("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")
+
+    Nif.env_put(
+      "_APPSIGNAL_SEND_ENVIRONMENT_METADATA",
+      to_string(config[:send_environment_metadata])
+    )
+
     Nif.env_put("_APPSIGNAL_RUNNING_IN_CONTAINER", to_string(config[:running_in_container]))
     Nif.env_put("_APPSIGNAL_TRANSACTION_DEBUG_MODE", to_string(config[:transaction_debug_mode]))
     Nif.env_put("_APPSIGNAL_WORKING_DIRECTORY_PATH", to_string(config[:working_directory_path]))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -368,6 +368,11 @@ defmodule Appsignal.ConfigTest do
                with_config(%{working_directory_path: "/tmp/appsignal"}, &init_config/0)
     end
 
+    test "send_environment_metadata" do
+      assert %{send_environment_metadata: false} =
+               with_config(%{send_environment_metadata: false}, &init_config/0)
+    end
+
     test "request_headers" do
       assert %{request_headers: ~w(accept accept-charset)} =
                with_config(%{request_headers: ~w(accept accept-charset)}, &init_config/0)
@@ -630,6 +635,13 @@ defmodule Appsignal.ConfigTest do
              ) == default_configuration() |> Map.put(:working_directory_path, "/tmp/appsignal")
     end
 
+    test "send_environment_metadata" do
+      assert with_env(
+               %{"APPSIGNAL_SEND_ENVIRONMENT_METADATA" => "false"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:send_environment_metadata, false)
+    end
+
     test "request_headers" do
       assert with_env(
                %{"APPSIGNAL_REQUEST_HEADERS" => "accept,accept-charset"},
@@ -885,6 +897,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_TRANSACTION_DEBUG_MODE") == 'true'
           assert Nif.env_get("_APPSIGNAL_FILTER_PARAMETERS") == 'password,confirm_password'
           assert Nif.env_get("_APPSIGNAL_FILTER_SESSION_DATA") == 'key1,key2'
+          assert Nif.env_get("_APPSIGNAL_SEND_ENVIRONMENT_METADATA") == 'true'
           assert Nif.env_get("_APP_REVISION") == '03bd9e'
         end
       )
@@ -983,6 +996,7 @@ defmodule Appsignal.ConfigTest do
         connection content-length path-info range request-method request-uri
         server-name server-port server-protocol
       ),
+      send_environment_metadata: true,
       send_params: true,
       skip_session_data: false,
       transaction_debug_mode: false


### PR DESCRIPTION
Allow users to enable/disable the environment metadata collection. This
is on by default.

This behavior is already implemented in the extension and agent. This
just makes it configurable for the user. No Elixir specific metadata
is currently collected.

Closes #728

For more information about this feature:
https://docs.appsignal.com/application/environment-metadata.html