### PR TITLE
Add log_level config option

### DIFF
--- a/.changesets/add-log_level-config-option.md
+++ b/.changesets/add-log_level-config-option.md
@@ -1,0 +1,14 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add "log_level" config option. This new option allows you to select the type of messages
+AppSignal's logger will log and up. The "debug" option will log all "debug", "info", "warning"
+and "error" log messages. The default value is: "info"
+
+The allowed values are:
+- error
+- warning
+- info
+- debug

--- a/.changesets/bump-agent-to-v-0db01c2.md
+++ b/.changesets/bump-agent-to-v-0db01c2.md
@@ -1,0 +1,9 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to v-0db01c2
+
+- Add `log_level` config option in extension.
+- Deprecate `debug` and `transaction_debug_mode` option in extension.

--- a/.changesets/deprecate-debug-and-transaction_debug_mode-config-options.md
+++ b/.changesets/deprecate-debug-and-transaction_debug_mode-config-options.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "deprecate"
+---
+
+Deprecate "debug" and "transaction_debug_mode" config options in favor of the new "log_level"
+config option.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "5b63505"
+  def version, do: "0db01c2"
 
   def mirrors do
     [
@@ -16,51 +16,51 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "122bbf4a5931f850644853a80b3fc929db93e18d32c2c75d487f5dc6a17358f7",
+        checksum: "8a7cf35f8c9aa98e7778b720f33b38bfbdedcdedb0047035259ab187517be971",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "122bbf4a5931f850644853a80b3fc929db93e18d32c2c75d487f5dc6a17358f7",
+        checksum: "8a7cf35f8c9aa98e7778b720f33b38bfbdedcdedb0047035259ab187517be971",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c",
+        checksum: "a22cd07e656f194dd1921983be6507816b60c79bc0c4623d2cac5c88fda9d407",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c",
+        checksum: "a22cd07e656f194dd1921983be6507816b60c79bc0c4623d2cac5c88fda9d407",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c",
+        checksum: "a22cd07e656f194dd1921983be6507816b60c79bc0c4623d2cac5c88fda9d407",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "d2eeac3b67e6629b43965f5056131b79dc9dd5ac3767951c79c9e2d8f7aca8c3",
+        checksum: "edf43f1a6b340c0afa07c7b71963def9bb68bd8d62d17cb64a7f7a36f84a4517",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "5a292e5a14e737a0a3756573b264ab749f211ff370717b80f9812e837e09392d",
+        checksum: "4179334f88dc32e00ce62aa196b3e47b4258b12ec48dd3cf722d4f6eeb4dc2c0",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "5a292e5a14e737a0a3756573b264ab749f211ff370717b80f9812e837e09392d",
+        checksum: "4179334f88dc32e00ce62aa196b3e47b4258b12ec48dd3cf722d4f6eeb4dc2c0",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "3a2688cf0e645d1d881f535ffbcf9602f626d7cc426591c605d89eeabd66d5f7",
+        checksum: "d602823277cac752bdea742d928112cef457bc61ee05b960b316fc052f0cc714",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "0cab0c9dadd9a9d48df0e35a8e8e1896edad1678d04bb7b5742d571c5fbff4f9",
+        checksum: "dfbdff116339b99613fff6ed4092b772e58f0d3e667b7de347b4215fb7ea9d62",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "3f470aaeb68fca7a7e2a7d36f557f23c72056807efc429f2ceef8922e73e8ca2",
+        checksum: "e31a7d89798193857247bd3590a554782fcff64b65d3da86d9c451d3147e961a",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "3f470aaeb68fca7a7e2a7d36f557f23c72056807efc429f2ceef8922e73e8ca2",
+        checksum: "e31a7d89798193857247bd3590a554782fcff64b65d3da86d9c451d3147e961a",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -21,6 +21,7 @@ defmodule Appsignal.Config do
     ignore_errors: [],
     ignore_namespaces: [],
     log: "file",
+    log_level: "info",
     request_headers: ~w(
       accept accept-charset accept-encoding accept-language cache-control
       connection content-length path-info range request-method request-uri
@@ -202,6 +203,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
     "APPSIGNAL_IGNORE_NAMESPACES" => :ignore_namespaces,
     "APPSIGNAL_LOG" => :log,
+    "APPSIGNAL_LOG_LEVEL" => :log_level,
     "APPSIGNAL_LOG_PATH" => :log_path,
     "APPSIGNAL_OTP_APP" => :otp_app,
     "APPSIGNAL_PUSH_API_ENDPOINT" => :endpoint,
@@ -219,8 +221,9 @@ defmodule Appsignal.Config do
 
   @string_keys ~w(
     APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH
-    APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH
-    APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION
+    APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_LEVEL APPSIGNAL_LOG_PATH
+    APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH
+    APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION
   )
   @bool_keys ~w(
     APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING
@@ -335,6 +338,7 @@ defmodule Appsignal.Config do
     )
 
     Nif.env_put("_APPSIGNAL_LOG", config[:log])
+    Nif.env_put("_APPSIGNAL_LOG_LEVEL", config[:log_level])
     Nif.env_put("_APPSIGNAL_LOG_FILE_PATH", to_string(log_file_path()))
     Nif.env_put("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -314,6 +314,10 @@ defmodule Appsignal.ConfigTest do
       assert %{log: "stdout"} = with_config(%{log: "stdout"}, &init_config/0)
     end
 
+    test "log_level" do
+      assert %{log_level: "warning"} = with_config(%{log_level: "warning"}, &init_config/0)
+    end
+
     test "log_path" do
       log_path = File.cwd!()
 
@@ -552,6 +556,13 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_LOG" => "stdout"},
                &init_config/0
              ) == default_configuration() |> Map.put(:log, "stdout")
+    end
+
+    test "log_level" do
+      assert with_env(
+               %{"APPSIGNAL_LOG_LEVEL" => "debug"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:log_level, "debug")
     end
 
     test "log_path" do
@@ -852,6 +863,7 @@ defmodule Appsignal.ConfigTest do
           ignore_errors: ~w(VerySpecificError AnotherError),
           ignore_namespaces: ~w(admin private_namespace),
           log: "stdout",
+          log_level: "info",
           log_path: "/tmp",
           name: "AppSignal test suite app",
           running_in_container: false,
@@ -887,6 +899,7 @@ defmodule Appsignal.ConfigTest do
                    'elixir-' ++ String.to_charlist(Mix.Project.config()[:version])
 
           assert Nif.env_get("_APPSIGNAL_LOG") == 'stdout'
+          assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == 'info'
           assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == '/tmp/appsignal.log'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_ENDPOINT") == 'https://push.staging.lol'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_KEY") == '00000000-0000-0000-0000-000000000000'
@@ -991,6 +1004,7 @@ defmodule Appsignal.ConfigTest do
       ignore_errors: [],
       ignore_namespaces: [],
       log: "file",
+      log_level: "info",
       request_headers: ~w(
         accept accept-charset accept-encoding accept-language cache-control
         connection content-length path-info range request-method request-uri


### PR DESCRIPTION
This new option allows users to set up the level of severity AppSignal
logs.

PR implementing the usage of this option: appsignal/appsignal-agent#730

**WARNING**: Do not publish this change until an agent release has been done with the changes from the linked PR