### PR TITLE
Add changeset types to existing changesets

### DIFF
--- a/.changesets/add-scheduler-utilization-to-minutely-probes.md
+++ b/.changesets/add-scheduler-utilization-to-minutely-probes.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "add"
 ---
 
 Add the Erlang scheduler utilization to the metrics reported by the minutely probes. The metric is reported as a percentage value with the name `erlang_scheduler_utilization`, with the tag `type` set to `"normal"` and the tag `id` set to the ID of the scheduler in the Erlang VM.

--- a/.changesets/add-send_environment_metadata-config-option.md
+++ b/.changesets/add-send_environment_metadata-config-option.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "add"
 ---
 
 Add `send_environment_metadata` config option to configure the environment metadata collection. For more information, see our [environment metadata docs](https://docs.appsignal.com/application/environment-metadata.html).

--- a/.changesets/bump-agent-to-v-5b63505.md
+++ b/.changesets/bump-agent-to-v-5b63505.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "change"
 ---
 
 Bump agent to v-5b63505

--- a/.changesets/fix-agent-download-openssl-below-111.md
+++ b/.changesets/fix-agent-download-openssl-below-111.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "fix"
 ---
 
 Fix the download of the agent during installation when Erlang is

--- a/.changesets/fix-diagnose-report-path-modes-format.md
+++ b/.changesets/fix-diagnose-report-path-modes-format.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "fix"
 ---
 
 Transmit the path file modes in the diagnose report as an octal number. Previously it send values like `33188` and now it transmits `100644`, which is a bit more human readable.

--- a/.changesets/fix-phoenix-filter-parameters.md
+++ b/.changesets/fix-phoenix-filter-parameters.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "fix"
 ---
 
 Fix a bug where setting the `:phoenix, :filter_parameters` configuration key to an allow-list of the form `{:keep, [keys]}` would apply this filtering to all sample data maps. The filtering is now only applied to the params sample data map.

--- a/.changesets/fix-push-api-key-validator-request-query-params-encoding.md
+++ b/.changesets/fix-push-api-key-validator-request-query-params-encoding.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "fix"
 ---
 
 Fix the Push API key validator request query params encoding.

--- a/.changesets/improve-parameter-and-session-data-filtering-options.md
+++ b/.changesets/improve-parameter-and-session-data-filtering-options.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "fix"
 ---
 
 Improve parameter and session data filtering options. Previously all filtering was done with one combined denylist of parameters and session data. Now `filter_parameters` only applies to parameters, and `filter_session_data` only applies to session data.

--- a/.changesets/print-dependencies-and-flags-for-install-in-diagnose-report.md
+++ b/.changesets/print-dependencies-and-flags-for-install-in-diagnose-report.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "change"
 ---
 
 Print the extension installation dependencies and flags in the diagnose report output.

--- a/.changesets/push-api-key-as-an-empty-string-is-not-considered-valid-anymore.md
+++ b/.changesets/push-api-key-as-an-empty-string-is-not-considered-valid-anymore.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "fix"
 ---
 
 When the Push API key config option value is an empty string,

--- a/.changesets/remove-valid-option-from-diagnose-output.md
+++ b/.changesets/remove-valid-option-from-diagnose-output.md
@@ -1,7 +1,7 @@
 ---
 bump: "patch"
+type: "change"
 ---
-
 
 Remove the `valid` key from the diagnose output. It's not a configuration option that
 can be configured, but an internal state check if the configuration was considered valid.

--- a/.changesets/standardize-diagnose-validation-error-message.md
+++ b/.changesets/standardize-diagnose-validation-error-message.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "change"
 ---
 
 Standardize diagnose validation failure message. Explain the diagnose request failed and why.


### PR DESCRIPTION
In the latest mono version support for changeset types were added. Newer
mono versions won't publish package changesets without types. Add these
types for existing changesets so they can be published with the latest
mono version.

[skip changeset]
[skip ci]