### PR TITLE
Update Git linter (Lintje) to 0.6.1

### DIFF
--- a/script/lint_git
+++ b/script/lint_git
@@ -2,7 +2,7 @@
 
 set -eu
 
-LINTJE_VERSION="0.5.0"
+LINTJE_VERSION="0.6.1"
 
 mkdir -p $HOME/bin
 cache_key=v1-lintje-$LINTJE_VERSION


### PR DESCRIPTION
Includes the latest rule updates and has a more human friendly output.

[skip changeset]
[skip review]