### PR TITLE
Fix Telemetry local function warning

### DIFF
--- a/.changesets/fix-telemetry-local-function-warning.md
+++ b/.changesets/fix-telemetry-local-function-warning.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Suppress a warning emitted by Telemetry 1.0.0, regarding the performance penalty of using local functions as event handlers, by specifying the module of the captured function.

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -29,7 +29,7 @@ defmodule Appsignal.Ecto do
   def attach(otp_app, repo) do
     event = telemetry_prefix(otp_app, repo) ++ [:query]
 
-    case :telemetry.attach({__MODULE__, event}, event, &handle_event/4, :ok) do
+    case :telemetry.attach({__MODULE__, event}, event, &__MODULE__.handle_event/4, :ok) do
       :ok ->
         Appsignal.Logger.debug("Appsignal.Ecto attached to #{inspect(event)}")
 


### PR DESCRIPTION
When a local function (meaning, either an anonymous function, or a capture of a function without the module being specified) is passed as an event handler to `:telemetry.attach/4` on Telemetry version 1.0.0, it produces a warning about the performance penalty of doing so, due to how these functions are handled by the Erlang VM.

This commit changes the event handler function passed to `:telemetry.attach/4` so that the module is specified in the function capture.