### PR TITLE
Unset the default log_level in the integration

### DIFF
--- a/.changesets/fix-debug-and-transaction_debug_mode-log-options.md
+++ b/.changesets/fix-debug-and-transaction_debug_mode-log-options.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix debug and transaction_debug_mode log options. If set, previously the log_level would remain "info", since version 2.2.8.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -21,7 +21,6 @@ defmodule Appsignal.Config do
     ignore_errors: [],
     ignore_namespaces: [],
     log: "file",
-    log_level: "info",
     request_headers: ~w(
       accept accept-charset accept-encoding accept-language cache-control
       connection content-length path-info range request-method request-uri
@@ -338,7 +337,7 @@ defmodule Appsignal.Config do
     )
 
     Nif.env_put("_APPSIGNAL_LOG", config[:log])
-    Nif.env_put("_APPSIGNAL_LOG_LEVEL", config[:log_level])
+    Nif.env_put("_APPSIGNAL_LOG_LEVEL", config[:log_level] || "")
     Nif.env_put("_APPSIGNAL_LOG_FILE_PATH", to_string(log_file_path()))
     Nif.env_put("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -863,7 +863,7 @@ defmodule Appsignal.ConfigTest do
           ignore_errors: ~w(VerySpecificError AnotherError),
           ignore_namespaces: ~w(admin private_namespace),
           log: "stdout",
-          log_level: "info",
+          log_level: "warn",
           log_path: "/tmp",
           name: "AppSignal test suite app",
           running_in_container: false,
@@ -899,7 +899,7 @@ defmodule Appsignal.ConfigTest do
                    'elixir-' ++ String.to_charlist(Mix.Project.config()[:version])
 
           assert Nif.env_get("_APPSIGNAL_LOG") == 'stdout'
-          assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == 'info'
+          assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == 'warn'
           assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == '/tmp/appsignal.log'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_ENDPOINT") == 'https://push.staging.lol'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_KEY") == '00000000-0000-0000-0000-000000000000'
@@ -1004,7 +1004,6 @@ defmodule Appsignal.ConfigTest do
       ignore_errors: [],
       ignore_namespaces: [],
       log: "file",
-      log_level: "info",
       request_headers: ~w(
         accept accept-charset accept-encoding accept-language cache-control
         connection content-length path-info range request-method request-uri


### PR DESCRIPTION
If the log_level was set by default by the Elixir integration it would
always use that level, even if `debug` or `transaction_debug_mode` were
set. These options are deprecated, but if set, and `log_level` is not
configured by the app, we should listen to these options.

I've removed the default log_level from the integration, but it will be
set by the extension and agent's log_level behavior. Since there's no
centralized logger in the Elixir integration yet, we do not need
to update any configuration for the integration's logger.