### PR TITLE
Update default request_headers list

### DIFF
--- a/.changesets/remove-ruby-exclusive-headers-from-request_headers-defaults.md
+++ b/.changesets/remove-ruby-exclusive-headers-from-request_headers-defaults.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Remove Ruby exclusive headers from request_headers defaults.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -23,8 +23,7 @@ defmodule Appsignal.Config do
     log: "file",
     request_headers: ~w(
       accept accept-charset accept-encoding accept-language cache-control
-      connection content-length path-info range request-method request-uri
-      server-name server-port server-protocol
+      connection content-length range
     ),
     send_environment_metadata: true,
     send_params: true,

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -1006,8 +1006,7 @@ defmodule Appsignal.ConfigTest do
       log: "file",
       request_headers: ~w(
         accept accept-charset accept-encoding accept-language cache-control
-        connection content-length path-info range request-method request-uri
-        server-name server-port server-protocol
+        connection content-length range
       ),
       send_environment_metadata: true,
       send_params: true,


### PR DESCRIPTION
`request_headers` list had some elements inherited from the Ruby
integration that were exclusive to `Rack`. The list is now updated and
only includes headers that make sense.

Closes #725 