### PR TITLE
Change how the agent version is retrieved for diagnose

### DIFF
--- a/.changesets/diagnose-report-now-gets-the-agent-version-from-the-agent-file.md
+++ b/.changesets/diagnose-report-now-gets-the-agent-version-from-the-agent-file.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "change"
+---
+
+The diagnose library report now reports the agent version from the committed agent file,
+rather than the downloaded version, which is reported in the installation report.

--- a/lib/appsignal/diagnose/library.ex
+++ b/lib/appsignal/diagnose/library.ex
@@ -4,7 +4,7 @@ defmodule Appsignal.Diagnose.Library do
   require Appsignal.Utils
 
   @appsignal_version Mix.Project.config()[:version]
-  @agent_version Appsignal.Nif.agent_version()
+  @agent_version Appsignal.Agent.version()
   @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   def info do

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -28,16 +28,6 @@ defmodule Appsignal.Nif do
     end
   end
 
-  def agent_version do
-    case :appsignal
-         |> :code.priv_dir()
-         |> Path.join("appsignal.version")
-         |> File.read() do
-      {:ok, contents} -> String.trim(contents)
-      _ -> nil
-    end
-  end
-
   def env_put(key, value) do
     _env_put(key, value)
   end

--- a/test/appsignal/nif_test.exs
+++ b/test/appsignal/nif_test.exs
@@ -95,16 +95,4 @@ defmodule Appsignal.NifTest do
       assert Nif.close_span(ref) == :ok
     end
   end
-
-  describe "agent_version" do
-    @tag :skip_env_test_no_nif
-    test "returns the installed agent version" do
-      assert Nif.agent_version() == Appsignal.Agent.version()
-    end
-
-    @tag :skip_env_test
-    test "does not return the agent version if the agent is not installed" do
-      assert Nif.agent_version() == nil
-    end
-  end
 end

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
   alias Appsignal.{Diagnose.FakeReport, FakeNif, FakeSystem}
 
   @appsignal_version Mix.Project.config()[:version]
-  @agent_version Appsignal.Nif.agent_version()
+  @agent_version Appsignal.Agent.version()
 
   defp run, do: capture_io("Y", &run_fn/0)
   defp run(args) when is_list(args), do: capture_io(fn -> run_fn(args) end)


### PR DESCRIPTION
In the diagnose report, the agent version was obtained from the version
file that is generated after the agent installation is done.

To comply with the other integrations and to know which agent version is
being installed in the diagnose if something goes wrong, the version is
now obtained from `agent.exs` in the diagnose report.