### PR TITLE
Add compilation step to CI tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,59 +47,76 @@ blocks:
         - name: Elixir main, OTP 24
           commands:
             - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir main, OTP 24, without the NIF loaded
+          env_vars:
+            - name: MIX_ENV
+              value: test_no_nif
           commands:
             - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
-            - MIX_ENV=test_no_nif mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.12.2, OTP 24
           commands:
             - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.12.2, OTP 23
           commands:
             - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.12.2, OTP 22
           commands:
             - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.11.4, OTP 24
           commands:
             - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.11.4, OTP 23
           commands:
             - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.11.4, OTP 22
           commands:
             - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.11.4, OTP 21
           commands:
             - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.10.4, OTP 23
           commands:
             - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.10.4, OTP 22
           commands:
             - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.10.4, OTP 21
           commands:
             - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.9.4, OTP 22
           commands:
             - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.9.4, OTP 21
           commands:
             - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
-            - mix test
+            - mix compile
+            - mix test --no-compile
       env_vars:
         - name: MIX_ENV
           value: test

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -1,4 +1,6 @@
-{_, _} = Code.eval_file("agent.exs")
+unless Code.ensure_loaded?(Appsignal.Agent) do
+  {_, _} = Code.eval_file("agent.exs")
+end
 
 defmodule Mix.Appsignal.Utils do
   defmacro compile_env(app, key, default \\ nil) do

--- a/test/appsignal/nif_test.exs
+++ b/test/appsignal/nif_test.exs
@@ -1,3 +1,7 @@
+unless Code.ensure_loaded?(Appsignal.Agent) do
+  {_, _} = Code.eval_file("agent.exs")
+end
+
 defmodule Appsignal.NifTest do
   alias Appsignal.Nif
   use ExUnit.Case, async: true


### PR DESCRIPTION
To highlight any problems of modules that could be loaded in memory. We
call `mix compile` before running the test suite. There's a need to call
`mix test` with the `--no-compile` flag otherwise it will still have the
modules from the extension installation in memory.

[skip changeset]