### PR TITLE
Add send_session_data config option

### DIFF
--- a/.changesets/add-send_session_data-config-option.md
+++ b/.changesets/add-send_session_data-config-option.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add `send_session_data` option to configure if session data is automatically included in
+spans. By default this is turned on. It can be disabled by configuring
+`send_session_data` to `false`.

--- a/.changesets/deprecate-skip_session_data-config-option.md
+++ b/.changesets/deprecate-skip_session_data-config-option.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "deprecate"
+---
+
+Deprecate `skip_session_data` option in favor of the newly introduced `send_session_data` option.
+If it is configured, it will print a warning on AppSignal load, but will also retain its
+functionality until the config option is fully removed in the next major release.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -27,7 +27,6 @@ defmodule Appsignal.Config do
     ),
     send_environment_metadata: true,
     send_params: true,
-    skip_session_data: false,
     transaction_debug_mode: false
   }
 
@@ -57,6 +56,10 @@ defmodule Appsignal.Config do
       config
       |> merge_filter_parameters(Application.get_env(:phoenix, :filter_parameters, []))
 
+    config =
+      config
+      |> skip_session_data_backwards_compatibility(config[:skip_session_data])
+
     if !empty?(config[:working_dir_path]) do
       Logger.warn(fn ->
         "'working_dir_path' is deprecated, please use " <>
@@ -84,6 +87,41 @@ defmodule Appsignal.Config do
 
   defp merge_filter_parameters(map, _keys) do
     map
+  end
+
+  defp skip_session_data_backwards_compatibility(config, nil) do
+    if Map.has_key?(config, :send_session_data) do
+      Map.put(config, :skip_session_data, !config[:send_session_data])
+    else
+      config
+      |> Map.merge(%{send_session_data: true, skip_session_data: false})
+    end
+  end
+
+  defp skip_session_data_backwards_compatibility(config, skip_session_data) do
+    IO.warn(
+      "appsignal: Deprecation warning: The `skip_session_data` config option is " <>
+        "deprecated. Please use `send_session_data` instead."
+    )
+
+    if Map.has_key?(config, :send_session_data) do
+      config
+    else
+      update_system_sources(%{send_session_data: !skip_session_data})
+      Map.put(config, :send_session_data, !skip_session_data)
+    end
+  end
+
+  defp update_system_sources(map) do
+    sources = Application.get_env(:appsignal, :config_sources, %{})
+
+    system_sources =
+      sources[:system]
+      |> Map.merge(map)
+
+    new_sources = Map.put(sources, :system, system_sources)
+
+    Application.put_env(:appsignal, :config_sources, new_sources)
   end
 
   @doc """
@@ -210,6 +248,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_RUNNING_IN_CONTAINER" => :running_in_container,
     "APPSIGNAL_SEND_ENVIRONMENT_METADATA" => :send_environment_metadata,
     "APPSIGNAL_SEND_PARAMS" => :send_params,
+    "APPSIGNAL_SEND_SESSION_DATA" => :send_session_data,
     "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data,
     "APPSIGNAL_TRANSACTION_DEBUG_MODE" => :transaction_debug_mode,
     "APPSIGNAL_WORKING_DIRECTORY_PATH" => :working_directory_path,
@@ -226,9 +265,9 @@ defmodule Appsignal.Config do
   @bool_keys ~w(
     APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING
     APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER
-    APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SKIP_SESSION_DATA APPSIGNAL_TRANSACTION_DEBUG_MODE
-    APPSIGNAL_FILES_WORLD_ACCESSIBLE APPSIGNAL_SEND_PARAMS APPSIGNAL_ENABLE_MINUTELY_PROBES
-    APPSIGNAL_ENABLE_STATSD APPSIGNAL_SEND_ENVIRONMENT_METADATA
+    APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SEND_SESSION_DATA APPSIGNAL_SKIP_SESSION_DATA
+    APPSIGNAL_TRANSACTION_DEBUG_MODE APPSIGNAL_FILES_WORLD_ACCESSIBLE APPSIGNAL_SEND_PARAMS
+    APPSIGNAL_ENABLE_MINUTELY_PROBES APPSIGNAL_ENABLE_STATSD APPSIGNAL_SEND_ENVIRONMENT_METADATA
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(


### PR DESCRIPTION
This replaces the `skip_session_data` option that is now deprecated.

As discussed in https://github.com/appsignal/integration-guide/pull/114
the `skip_session_data` is inconsistently named compared to our other
options that do the same thing, but start with `send_`.

The behavior of `send_session_data` is also the exact opposite of
`skip_session_data`. It's on by default and if turned off it won't send
the session data.

Only when `send_session_data` is not set by the user, will
`skip_session_data` be listened to. If `send_session_data`'s value is
determined by the `skip_session_data_backwards_compatibility` method,
its value is set in the `system` source, because the system figured
out what value it needs to be set to. If the user has manually
configured it, it will not set it in the system source.

To keep appsignal-plug old versions compatibility, the
`skip_session_data` option is still set.

In the future, when the `skip_session_data` option is removed, the
`send_session_data` option should be added to the `@default_config`
attribute in the `Appsignal.Config` module and this behaviour should all
be removed.

Fixes: #743