### PR TITLE
Add "override" config source

### DIFF
--- a/.changesets/add-config-override-source.md
+++ b/.changesets/add-config-override-source.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add the config "override" source to better communicate and help debug when certain config options are set. This is used by the diagnose report. The override source is used to set the new config option value when a config option has been renamed, like `send_session_data`.

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -303,7 +303,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   end
 
   defp sources_for_option(key, sources) do
-    [:default, :system, :file, :env]
+    [:default, :system, :file, :env, :override]
     |> Enum.map(fn source ->
       if Map.has_key?(sources[source], key) do
         source

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -31,7 +31,8 @@ defmodule Appsignal.ConfigTest do
                default: default,
                system: %{},
                file: %{},
-               env: %{}
+               env: %{},
+               override: %{send_session_data: true, skip_session_data: false}
              }
     end
 
@@ -417,7 +418,7 @@ defmodule Appsignal.ConfigTest do
                config,
                fn ->
                  init_config()
-                 Application.get_env(:appsignal, :config_sources)[:system]
+                 Application.get_env(:appsignal, :config_sources)[:override]
                end
              ) == %{send_session_data: false}
 
@@ -708,7 +709,7 @@ defmodule Appsignal.ConfigTest do
                    %{"APPSIGNAL_SKIP_SESSION_DATA" => "true"},
                    fn ->
                      init_config()
-                     Application.get_env(:appsignal, :config_sources)[:system]
+                     Application.get_env(:appsignal, :config_sources)[:override]
                    end
                  ) == %{send_session_data: false}
         end)

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -400,8 +400,6 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "send_session_data" do
-      config = %{send_session_data: false}
-
       assert %{send_session_data: false, skip_session_data: true} =
                with_config(%{send_session_data: false}, &init_config/0)
     end


### PR DESCRIPTION
## Remove unused variable from test

I saw a warning about an unused variable in the test so I removed it.

## Add "override" config source

When a config option is set by the integration based on other config
options, the new config option values are written to the "override"
source.

This may happen for renamed config options that set the new config
option when the deprecated config option is set, like the
`skip_session_data` and `send_session_data` config options this commit
updates to this new source.

This "override" config source is leading. It should not be confused with
"system" that determines _defaults_ for the config based on environment
details like host and system (not AppSignal environment variables).

I've changed the order how the config sources and options are loaded in
the code, sources are only written to the `Application` env at the very
end, but it shouldn't change the result. This just made it easier to
modify the sources during the process.

Closes https://github.com/appsignal/appsignal-elixir/issues/752
