### PR TITLE
Elixir ci 1.13.2

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -57,6 +57,21 @@ blocks:
             - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
             - mix compile
             - mix test --no-compile
+        - name: Elixir 1.13.2, OTP 24
+          commands:
+            - ERLANG_VERSION=24.2 ELIXIR_VERSION=1.13.2 . bin/setup
+            - mix compile
+            - mix test --no-compile
+        - name: Elixir 1.13.2, OTP 23
+          commands:
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.13.2 . bin/setup
+            - mix compile
+            - mix test --no-compile
+        - name: Elixir 1.13.2, OTP 22
+          commands:
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.13.2 . bin/setup
+            - mix compile
+            - mix test --no-compile
         - name: Elixir 1.12.2, OTP 24
           commands:
             - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup

--- a/test/appsignal/error_test.exs
+++ b/test/appsignal/error_test.exs
@@ -65,7 +65,9 @@ defmodule Appsignal.ErrorTest do
     end
 
     test "extracts the error's message", %{metadata: metadata} do
-      assert {_name, "** (ArgumentError) argument error", _stack} = metadata
+      {_name, error_message, _stack} = metadata
+
+      assert String.match?(error_message, ~r/(ArgumentError)/)
     end
 
     test "format's the error's stack trace", %{metadata: metadata} do

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -270,8 +270,7 @@ defmodule AppsignalSpanTest do
     end
 
     test "sets the error through the Nif", %{span: %Span{reference: reference}} do
-      assert [{^reference, "ArgumentError", "** (ArgumentError) argument error", _}] =
-               Test.Nif.get!(:add_span_error)
+      assert [{^reference, "ArgumentError", _message, _}] = Test.Nif.get!(:add_span_error)
     end
   end
 
@@ -362,8 +361,7 @@ defmodule AppsignalSpanTest do
     end
 
     test "sets the error through the Nif", %{span: %Span{reference: reference}} do
-      assert [{^reference, "ArgumentError", "** (ArgumentError) argument error", _}] =
-               Test.Nif.get!(:add_span_error)
+      assert [{^reference, "ArgumentError", _message, _}] = Test.Nif.get!(:add_span_error)
     end
   end
 


### PR DESCRIPTION
## Add Elixir 1.13.2 to CI

Add the latest Elixir version along with OTP 24.2

## Update ArgumentError matchers for OTP 24.2

OTP 24.2 adds additional info to `ArgumentError` messages. This commit modifies the tests, so they pass no matter the OTP version.

---

I decided to ignore the message in the span tests as it is not so relevant for those two examples. If you think it's important enough to assert it, tell me, and I'll update it to check each value from the tuple that `Test.Nif.get!(:add_span_error)` returns.

Fixes: #757

[skip changeset]