### PR TITLE
Support arm64 host for tests

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -23,6 +23,7 @@ defmodule Mix.Appsignal.Helper do
 
   require Mix.Appsignal.Utils
 
+  @erlang Mix.Appsignal.Utils.compile_env(:appsignal, :erlang, :erlang)
   @os Mix.Appsignal.Utils.compile_env(:appsignal, :os, :os)
   @system Mix.Appsignal.Utils.compile_env(:appsignal, :mix_system, System)
 
@@ -320,7 +321,7 @@ defmodule Mix.Appsignal.Helper do
       if force_linux_arm_build?() do
         'aarch64-linux'
       else
-        :erlang.system_info(:system_architecture)
+        @erlang.system_info(:system_architecture)
       end
 
     case map_arch(input_arch, agent_platform()) do

--- a/test/mix/helpers_test.exs
+++ b/test/mix/helpers_test.exs
@@ -1,4 +1,5 @@
 :code.delete(Mix.Appsignal.Helper)
+Application.put_env(:appsignal, :erlang, FakeErlang)
 Application.put_env(:appsignal, :os, FakeOS)
 Application.put_env(:appsignal, :mix_system, FakeSystem)
 {_, _} = Code.eval_file("mix_helpers.exs")
@@ -12,8 +13,12 @@ defmodule Mix.Appsignal.HelperTest do
   end
 
   describe ".verify_system_architecture" do
+    setup do
+      [fake_erlang: start_supervised!(FakeErlang)]
+    end
+
     @tag :skip_env_test_no_nif
-    test "returns 64-bit Linux build" do
+    test "returns 64-bit Linux build", %{fake_erlang: fake_erlang} do
       report = %{build: %{}}
 
       assert Mix.Appsignal.Helper.verify_system_architecture(report) == {

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert is_map(host_report["dependencies"])
 
     # Incomplete list for common test values
-    valid_architectures = ["x86", "x86_64"]
+    valid_architectures = ["x86", "x86_64", "aarch64"]
     valid_targets = ["darwin", "linux", "linux-gnu"]
     valid_sources = ["remote", "cached_in_priv_dir", "cached_in_tmp_dir"]
 
@@ -1133,7 +1133,7 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     assert String.contains?(output, "Download details")
     assert String.contains?(output, "  Download time: \"20")
     assert String.contains?(output, "  Download URL: \"https://")
-    assert output =~ ~r{Architecture: "x86(_64)?"}
+    assert output =~ ~r{Architecture: "(x86(_64)?|aarch64)"}
     assert output =~ ~r{Target: "[\w-]+"}
     assert String.contains?(output, "  Musl override: false")
     assert String.contains?(output, "  Linux ARM override: false")

--- a/test/support/fake_erlang.ex
+++ b/test/support/fake_erlang.ex
@@ -1,0 +1,5 @@
+defmodule FakeErlang do
+  use TestAgent, %{system_info: 'x86_64-apple-darwin20.2.0'}
+
+  def system_info(_), do: get(__MODULE__, :system_info)
+end


### PR DESCRIPTION
When I run the test suite on an arm64 host, support that architecture as
well in the test suite. I had to update on test that always assumed an
x86_64 architecture for the test suite.

I added a FakeErlang module to always return the x86_64 architecture.
It's only used in one test and seemed like the way to do it, otherwise
I'd have to construct the correct system architecture string again.

[skip changeset]