### PR TITLE
Don't mock all of :erlang.system_info/1 in tests

### DIFF
--- a/test/support/fake_erlang.ex
+++ b/test/support/fake_erlang.ex
@@ -1,5 +1,6 @@
 defmodule FakeErlang do
-  use TestAgent, %{system_info: 'x86_64-apple-darwin20.2.0'}
+  use TestAgent, %{system_architecture: 'x86_64-apple-darwin20.2.0'}
 
-  def system_info(_), do: get(__MODULE__, :system_info)
+  def system_info(:system_architecture), do: get(__MODULE__, :system_architecture)
+  def system_info(key), do: :erlang.system_info(key)
 end


### PR DESCRIPTION
Only mock the key we need to mock. This way any other values we ask from
`:erlang.system_info/1` isn't always the same host triple.

When something other than `:system_architecture` is asked, return the
real value.

[skip changeset]