### PR TITLE
Check CAcert file exists when installing extension

### DIFF
--- a/.changesets/prevent-extension-installation-failure-when-cacert-is-not-accessible.md
+++ b/.changesets/prevent-extension-installation-failure-when-cacert-is-not-accessible.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+The extension installation will no longer fail when the CA certificate file is not accessible.

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -252,11 +252,28 @@ defmodule Mix.Appsignal.Helper do
   end
 
   defp download_options do
+    default_cacert_file_path = priv_path("cacert.pem")
+
+    cacert_file =
+      case check_cacert_access(default_cacert_file_path) do
+        :ok ->
+          default_cacert_file_path
+
+        {:error, message} ->
+          Logger.warn(
+            "The cacert file path: #{default_cacert_file_path} is not accessible. " <>
+              "Reason: #{inspect(message)}. " <>
+              "Using system defaults instead."
+          )
+
+          :certifi.cacertfile()
+      end
+
     options = [
       ssl_options:
         [
           verify: :verify_peer,
-          cacertfile: priv_path("cacert.pem")
+          cacertfile: cacert_file
         ] ++ tls_options() ++ customize_hostname_check_or_verify_fun()
     ]
 
@@ -267,6 +284,19 @@ defmodule Mix.Appsignal.Helper do
       {var, url} ->
         Mix.shell().info("- using proxy from #{var} (#{url})")
         options ++ [proxy: url]
+    end
+  end
+
+  defp check_cacert_access(cacert_path) do
+    case File.stat(cacert_path) do
+      {:ok, %{access: access}} when access in [:read, :read_write] ->
+        :ok
+
+      {:ok, %{access: access}} ->
+        {:error, "File access is #{inspect(access)}"}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 


### PR DESCRIPTION
The extension installation will no longer fail if the CA cert file is
not accessible. It'll print a warning and use the library defaults.

Fixes: #756 