### PR TITLE
Tracer can ignore a specific process

### DIFF
--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -184,13 +184,11 @@ defmodule Appsignal.Tracer do
   def close_span(nil, _options), do: nil
 
   @doc """
-  Ignores the current process.
+  Ignores the given process.
   """
-  @spec ignore() :: :ok | nil
-  def ignore do
+  @spec ignore(pid()) :: :ok
+  def ignore(pid) do
     if running?() do
-      pid = self()
-
       delete(pid)
       :ets.insert(@table, {pid, :ignore})
       @monitor.add()
@@ -200,15 +198,11 @@ defmodule Appsignal.Tracer do
   end
 
   @doc """
-  Ignores the given process.
+  Ignores the current process.
   """
-  @spec ignore(pid()) :: :ok | nil
-  def ignore(pid) do
-    :ets.delete(@table, pid)
-    :ets.insert(@table, {pid, :ignore})
-    @monitor.add()
-
-    :ok
+  @spec ignore() :: :ok | nil
+  def ignore do
+    self() |> ignore()
   end
 
   @doc """

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -244,8 +244,4 @@ defmodule Appsignal.Tracer do
   defp running? do
     is_pid(Process.whereis(__MODULE__))
   end
-
-  defp running?(pid) do
-    is_pid(pid)
-  end
 end

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -204,11 +204,9 @@ defmodule Appsignal.Tracer do
   """
   @spec ignore(pid()) :: :ok | nil
   def ignore(pid) do
-    if running?(pid) do
-      delete(pid)
-      :ets.insert(@table, {pid, :ignore})
-      @monitor.add()
-    end
+    :ets.delete(@table, pid)
+    :ets.insert(@table, {pid, :ignore})
+    @monitor.add()
 
     :ok
   end

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -200,6 +200,20 @@ defmodule Appsignal.Tracer do
   end
 
   @doc """
+  Ignores the given process.
+  """
+  @spec ignore(pid()) :: :ok | nil
+  def ignore(pid) do
+    if running?(pid) do
+      delete(pid)
+      :ets.insert(@table, {pid, :ignore})
+      @monitor.add()
+    end
+
+    :ok
+  end
+
+  @doc """
   Removes the process' spans from the registry.
   """
   @spec delete(pid()) :: :ok
@@ -231,5 +245,9 @@ defmodule Appsignal.Tracer do
 
   defp running? do
     is_pid(Process.whereis(__MODULE__))
+  end
+
+  defp running?(pid) do
+    is_pid(pid)
   end
 end


### PR DESCRIPTION
`Tracer.ignore_process/0` can only ignore current pid.
I want to make Tracer also ignore another pid (see: https://github.com/appsignal/appsignal-elixir/pull/549)