### PR TITLE
Bump agent to v-be3107a

### DIFF
--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "f57e6cb"
+  def version, do: "be3107a"
 
   def mirrors do
     [
@@ -16,51 +16,51 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "dd1ae8d7897edf3112741381226e3622e91553dede6eeae48ca07aae84ac050d",
+        checksum: "31b13af931f26832eb9b5f3283a0dcfc83e327a31570aef47704589de5bd54cc",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "dd1ae8d7897edf3112741381226e3622e91553dede6eeae48ca07aae84ac050d",
+        checksum: "31b13af931f26832eb9b5f3283a0dcfc83e327a31570aef47704589de5bd54cc",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "cd5175979ec293d0471c71de1fdd00817bea75f800603a1b87931b19471495f3",
+        checksum: "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "cd5175979ec293d0471c71de1fdd00817bea75f800603a1b87931b19471495f3",
+        checksum: "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "cd5175979ec293d0471c71de1fdd00817bea75f800603a1b87931b19471495f3",
+        checksum: "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "ae899aba4fa260c1aa1d21cc8f2bf379a2b52596ef2979e9b9b70f0cd54872d4",
+        checksum: "37819d1df9b516d39a3aaf54bcc434f7d77e0067d75a86fff8c89be24cf16c28",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "3934810379bade5096a5f055450ddd38f60c1bb2fbc05bebcea92f8f7250a81e",
+        checksum: "c372daebb69e9795c8dcd60f48cad2af66628e1e3c8211f00526bdc8c880fc97",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "3934810379bade5096a5f055450ddd38f60c1bb2fbc05bebcea92f8f7250a81e",
+        checksum: "c372daebb69e9795c8dcd60f48cad2af66628e1e3c8211f00526bdc8c880fc97",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "956288a49717ea61ec303ef4ab52e7bfafea6e575a8bb9839df24b947d22d988",
+        checksum: "972a8b02061d747fbe35f3dd8d3d5b7c34bf7a6a38d0526d0ff55b9e70b67f13",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "5f96744692b6b079bd2b97ac6d8d5900123f108a27237664c88a49782b7ba433",
+        checksum: "4821b9d4e9b4501a5002f731b633a64b3991272fb0e6e57a61ce1e2a0b33bcad",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "23ea3fdcc5ae7dfdc85214c872ef928ed702c029b05c059db614583f689b9304",
+        checksum: "2b8ff925dd40daab892cf66ad3fefb72559cab57433907d8f70ae41722716832",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "23ea3fdcc5ae7dfdc85214c872ef928ed702c029b05c059db614583f689b9304",
+        checksum: "2b8ff925dd40daab892cf66ad3fefb72559cab57433907d8f70ae41722716832",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }


### PR DESCRIPTION
- Add `importOpenTelemetrySpan` extension function.
- Fix `determine_running_in_container` function for Heroku.
- Return seconds and nanoseconds from `span_to_json` function.

[skip changeset]
[skip review]