### PR TITLE
Don't set params when send_params is false

### DIFF
--- a/.changesets/don't-set-parameters-when-the-send_params-configuration-is-set-to-false.md
+++ b/.changesets/don't-set-parameters-when-the-send_params-configuration-is-set-to-false.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Don't set parameters when the send_params configuration is set to false

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -190,11 +190,19 @@ defmodule Appsignal.Span do
       |> Appsignal.Span.set_sample_data("environment", %{"method" => "GET"})
 
   """
-  def set_sample_data(span, "params", value) do
+  def set_sample_data(span, key, value) do
+    set_sample_data(span, Application.get_env(:appsignal, :config), key, value)
+  end
+
+  defp set_sample_data(span, %{send_params: true}, "params", value) do
     do_set_sample_data(span, "params", Appsignal.Utils.MapFilter.filter(value))
   end
 
-  def set_sample_data(span, key, value) do
+  defp set_sample_data(span, _config, "params", _value) do
+    span
+  end
+
+  defp set_sample_data(span, _config, key, value) do
     do_set_sample_data(span, key, value)
   end
 

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -427,6 +427,48 @@ defmodule AppsignalSpanTest do
     end
   end
 
+  describe ".set_sample_data/3, if send_params is set to false" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      config = Application.get_env(:appsignal, :config)
+      Application.put_env(:appsignal, :config, %{config | send_params: false})
+
+      try do
+        Span.set_sample_data(span, "key", %{foo: "bar"})
+      after
+        Application.put_env(:appsignal, :config, config)
+      end
+
+      :ok
+    end
+
+    test "sets the sample data", %{span: span} do
+      assert %{"sample_data" => %{"key" => "{\"foo\":\"bar\"}"}} = Span.to_map(span)
+    end
+  end
+
+  describe ".set_sample_data/3, if send_params is set to false, when using 'params' as the key" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      config = Application.get_env(:appsignal, :config)
+      Application.put_env(:appsignal, :config, %{config | send_params: false})
+
+      try do
+        Span.set_sample_data(span, "params", %{foo: "bar"})
+      after
+        Application.put_env(:appsignal, :config, config)
+      end
+
+      :ok
+    end
+
+    test "does not set the sample data", %{span: span} do
+      assert Span.to_map(span)["sample_data"] == %{}
+    end
+  end
+
   describe ".set_sample_data/3, when passing a nil-span" do
     test "returns nil" do
       assert Span.set_sample_data(nil, "key", %{param: "value"}) == nil

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -415,11 +415,15 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      [return: Span.set_sample_data(span, "key", %{param: "value"})]
+      [return: Span.set_sample_data(span, "key", %{foo: "bar"})]
     end
 
     test "returns the span", %{span: span, return: return} do
       assert return == span
+    end
+
+    test "sets the sample data", %{span: span} do
+      assert %{"sample_data" => %{"key" => "{\"foo\":\"bar\"}"}} = Span.to_map(span)
     end
   end
 


### PR DESCRIPTION
Currently, the send_params configuration option is checked in [Appsignal.Plug.set_params/2-3](https://github.com/appsignal/appsignal-elixir-plug/blob/main/lib/appsignal_plug.ex#L168-L179).
    
Since parameters are now also added from appsignal_phoenix, and because there's already a distinction between sample data and parameters in Appsignal.Span, Appsignal.Span.set_sample_data/3-4 now checks the send_params configuration if the passed key equals "params".
    
The implementation in appsignal_plug can be removed as soon as it depends on the upcoming version of this library.
