### PR TITLE
Don't set session when send_session_data is false

### DIFF
--- a/.changesets/don't-set-session-data-when-the-send_session_data-configuration-is-set-to-false.md
+++ b/.changesets/don't-set-session-data-when-the-send_session_data-configuration-is-set-to-false.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Don't set session data when the send_session_data configuration is set to false

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -198,7 +198,15 @@ defmodule Appsignal.Span do
     do_set_sample_data(span, "params", Appsignal.Utils.MapFilter.filter(value))
   end
 
+  defp set_sample_data(span, %{send_session_data: true}, "session_data", value) do
+    do_set_sample_data(span, "session-data", value)
+  end
+
   defp set_sample_data(span, _config, "params", _value) do
+    span
+  end
+
+  defp set_sample_data(span, _config, "session_data", _value) do
     span
   end
 

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -472,6 +472,50 @@ defmodule AppsignalSpanTest do
     end
   end
 
+  describe ".set_sample_data/3, if send_session_data is set to false" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      config = Application.get_env(:appsignal, :config)
+      Application.put_env(:appsignal, :config, %{config | send_session_data: false})
+
+      try do
+        Span.set_sample_data(span, "key", %{foo: "bar"})
+      after
+        Application.put_env(:appsignal, :config, config)
+      end
+
+      :ok
+    end
+
+    @tag :skip_env_test_no_nif
+    test "sets the sample data", %{span: span} do
+      assert %{"sample_data" => %{"key" => "{\"foo\":\"bar\"}"}} = Span.to_map(span)
+    end
+  end
+
+  describe ".set_sample_data/3, if send_session_data is set to false, when using 'session_data' as the key" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      config = Application.get_env(:appsignal, :config)
+      Application.put_env(:appsignal, :config, %{config | send_session_data: false})
+
+      try do
+        Span.set_sample_data(span, "session_data", %{foo: "bar"})
+      after
+        Application.put_env(:appsignal, :config, config)
+      end
+
+      :ok
+    end
+
+    @tag :skip_env_test_no_nif
+    test "does not set the sample data", %{span: span} do
+      assert Span.to_map(span)["sample_data"] == %{}
+    end
+  end
+
   describe ".set_sample_data/3, when passing a nil-span" do
     test "returns nil" do
       assert Span.set_sample_data(nil, "key", %{param: "value"}) == nil


### PR DESCRIPTION
Note: this is the same patch as 96c60363b06f64ed43b1f8a88484ecde45c1710a, but for session data.

Currently, the send_session_data configuration option is checked in [Appsignal.Plug.set_session_data/2-3](https://github.com/appsignal/appsignal-elixir-plug/blob/main/lib/appsignal_plug.ex#L168-L179).
    
Since sesion data is now also added from appsignal_phoenix, and because there's already a distinction between sample data and parameters in Appsignal.Span, Appsignal.Span.set_sample_data/3-4 now checks the send_session_data configuration if the passed key equals "sesion_data".
    
The implementation in appsignal_plug can be removed as soon as it depends on the upcoming version of this library.
