### PR TITLE
Use get_env with default config

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -386,7 +386,7 @@ defmodule Appsignal.Config do
   @log_filename "appsignal.log"
 
   def log_level do
-    config = Application.fetch_env!(:appsignal, :config)
+    config = Application.get_env(:appsignal, :config, @default_config)
 
     log_level(config)
   end


### PR DESCRIPTION
This may be the simple change needed to close https://github.com/appsignal/appsignal-elixir/issues/773.
A similar issue was fixed a while back with https://github.com/appsignal/appsignal-elixir/issues/643.

There are several other calls to `Application.fetch_env!` in this module that may also want to be changed. Unfortunately, I can't get the test suite to pass in my environment at the moment, and I'm not going to be able to take time right now to debug that.