### PR TITLE
Use default log level when AppSignal is not configured

### DIFF
--- a/.changesets/fix-compile-time-error-with-empty-configurations.md
+++ b/.changesets/fix-compile-time-error-with-empty-configurations.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix compile-time error with empty configurations

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -386,7 +386,7 @@ defmodule Appsignal.Config do
   @log_filename "appsignal.log"
 
   def log_level do
-    config = Application.fetch_env!(:appsignal, :config)
+    config = Application.get_env(:appsignal, :config, @default_config)
 
     log_level(config)
   end

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -149,6 +149,10 @@ defmodule Appsignal.ConfigTest do
   end
 
   describe "log_level" do
+    test "without an appsignal config" do
+      assert without_config(&Config.log_level/0) == :info
+    end
+
     test "when log level is set to a known log level" do
       assert with_config(%{log_level: "warn"}, &Config.log_level/0) == :warn
     end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -38,6 +38,13 @@ defmodule AppsignalTest.Utils do
     end)
   end
 
+  def without_config(function) do
+    with_frozen_environment(fn ->
+      Application.delete_env(:appsignal, :config)
+      function.()
+    end)
+  end
+
   defp put_merged_config_for(app, config) do
     config =
       app


### PR DESCRIPTION
This is based on https://github.com/appsignal/appsignal-elixir/pull/774, in which @tonyvanriet fixed a compile-time error when the `Appsignal.Config.log_level/0` function was called without a config present. This patch adds a regression test and a changeset.