### PR TITLE
Handle empty configurations for all config options

### DIFF
--- a/.changesets/don-t-crash-at-compile-time-when-appsignal-is-not-configured.md
+++ b/.changesets/don-t-crash-at-compile-time-when-appsignal-is-not-configured.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Don't crash at compile time when AppSignal is not configured

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -162,7 +162,7 @@ defmodule Appsignal.Config do
   end
 
   def request_headers do
-    Application.get_env(:appsignal, :config, %{request_headers: []})[:request_headers] || []
+    Application.get_env(:appsignal, :config, @default_config)[:request_headers] || []
   end
 
   def ca_file_path do

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -416,7 +416,7 @@ defmodule Appsignal.Config do
         value
 
       :error ->
-        config = Application.fetch_env!(:appsignal, :config)
+        config = Application.get_env(:appsignal, :config, %{})
         value = do_log_file_path(config[:log_path])
         Application.put_env(:appsignal, :"$log_file_path", value)
 

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -162,7 +162,7 @@ defmodule Appsignal.Config do
   end
 
   def request_headers do
-    Application.fetch_env!(:appsignal, :config)[:request_headers] || []
+    Application.get_env(:appsignal, :config, %{request_headers: []})[:request_headers] || []
   end
 
   def ca_file_path do

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -119,7 +119,7 @@ defmodule Appsignal.Config do
   """
   @spec configured_as_active?() :: boolean
   def configured_as_active? do
-    Application.fetch_env!(:appsignal, :config).active
+    Application.get_env(:appsignal, :config, @default_config).active
   end
 
   @doc """

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -144,7 +144,7 @@ defmodule Appsignal.Config do
   @spec active?() :: boolean
   def active? do
     :appsignal
-    |> Application.fetch_env!(:config)
+    |> Application.get_env(:config, @default_config)
     |> do_active?
   end
 

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -166,7 +166,8 @@ defmodule Appsignal.Config do
   end
 
   def ca_file_path do
-    Application.fetch_env!(:appsignal, :config)[:ca_file_path]
+    config = Application.get_env(:appsignal, :config, %{ca_file_path: default_ca_file_path()})
+    config[:ca_file_path]
   end
 
   def minutely_probes_enabled? do

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -119,7 +119,7 @@ defmodule Appsignal.Config do
   """
   @spec configured_as_active?() :: boolean
   def configured_as_active? do
-    Application.get_env(:appsignal, :config, @default_config).active
+    Application.get_env(:appsignal, :config, @default_config)[:active] || false
   end
 
   @doc """

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -221,6 +221,11 @@ defmodule Appsignal.ConfigTest do
                Path.join(:code.priv_dir(:appsignal), "cacert.pem")
     end
 
+    test "uses the priv path when no config is set" do
+      assert without_config(&Config.ca_file_path/0) ==
+               Path.join(:code.priv_dir(:appsignal), "cacert.pem")
+    end
+
     test "returns user override when set" do
       assert with_config(%{ca_file_path: "/foo/bar/bat.ca"}, &Config.ca_file_path/0) ==
                "/foo/bar/bat.ca"

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -213,7 +213,8 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "without an appsignal config" do
-      assert without_config(&Config.request_headers/0) == []
+      assert without_config(&Config.request_headers/0) ==
+               default_configuration()[:request_headers]
     end
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -117,6 +117,13 @@ defmodule Appsignal.ConfigTest do
              )
     end
 
+    test "with an empty config" do
+      refute with_config(
+               %{},
+               &Config.configured_as_active?/0
+             )
+    end
+
     test "without an appsignal config" do
       refute without_config(&Config.configured_as_active?/0)
     end

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -150,6 +150,10 @@ defmodule Appsignal.ConfigTest do
                Config.active?()
              end)
     end
+
+    test "without an appsignal config" do
+      refute without_config(&Config.active?/0)
+    end
   end
 
   describe "log_level" do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -116,6 +116,10 @@ defmodule Appsignal.ConfigTest do
                &Config.configured_as_active?/0
              )
     end
+
+    test "without an appsignal config" do
+      refute without_config(&Config.configured_as_active?/0)
+    end
   end
 
   describe "active?" do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -853,6 +853,14 @@ defmodule Appsignal.ConfigTest do
       end)
     end
 
+    test "defaults to /tmp/appsignal.log without a config" do
+      system_tmp_dir = Appsignal.Utils.FileSystem.system_tmp_dir()
+
+      without_config(fn ->
+        assert Config.log_file_path() == Path.join(system_tmp_dir, "appsignal.log")
+      end)
+    end
+
     test "overrides user specified filename when set" do
       output =
         capture_io(:stderr, fn ->

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -204,6 +204,10 @@ defmodule Appsignal.ConfigTest do
     test "returns the request_headers config" do
       assert with_config(%{request_headers: []}, &Config.request_headers/0) == []
     end
+
+    test "without an appsignal config" do
+      assert without_config(&Config.request_headers/0) == []
+    end
   end
 
   describe "ca_file_path" do


### PR DESCRIPTION
After the `without_config/0` option was added in #775, I went over the configuration options that use `Application.fetch_env!/2`, added tests to make sure they function without any configuration loaded, and switched them over to `Application.get_env/3`. 