### PR TITLE
Improve error reporting on extension load failure

### DIFF
--- a/.changesets/improve-error-message-on-extension-load-failure.md
+++ b/.changesets/improve-error-message-on-extension-load-failure.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Improve the error message on extension load failure. The error message will now print more details about the installed and expected architecture when they mismatch. This is most common on apps mounted on a container after first being installed on the host with a different architecture than the container.

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,6 +8,7 @@ if Mix.env() in [:bench, :test, :test_no_nif] do
   config :appsignal, inet: FakeInet
   config :appsignal, io: FakeIO
   config :appsignal, file: FakeFile
+  config :appsignal, os_internal: FakeOS
 
   config :appsignal, appsignal_tracer_nif: Appsignal.Test.Nif
   config :appsignal, appsignal_tracer: Appsignal.Test.Tracer

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -2,4 +2,4 @@ lib/appsignal/json.ex:31: Unknown function 'Elixir.Jason':encode/1
 lib/appsignal/json.ex:32: Unknown function 'Elixir.Jason':'encode!'/1
 lib/appsignal/json.ex:33: Unknown function 'Elixir.Jason':decode/1
 lib/appsignal/json.ex:34: Unknown function 'Elixir.Jason':'decode!'/1
-lib/appsignal.ex:46: The inferred return type of config_change/3 (pid()) has nothing in common with 'ok', which is the expected return type for the callback of the 'Elixir.Application' behaviour
+lib/appsignal.ex:50: The inferred return type of config_change/3 (pid()) has nothing in common with 'ok', which is the expected return type for the callback of the 'Elixir.Application' behaviour

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -391,7 +391,7 @@ defmodule Mix.Appsignal.Helper do
     defp map_arch('arm-' ++ _, platform), do: build_for("aarch64", platform)
   end
 
-  defp map_arch(arch, platform), do: {:error, {:unknown, {arch, platform}}}
+  defp map_arch(arch, platform), do: {:error, {:unknown, {to_string(arch), platform}}}
 
   defp build_for(bit, platform) do
     arch = {bit, platform}

--- a/test/appsignal/appsignal_test.exs
+++ b/test/appsignal/appsignal_test.exs
@@ -7,8 +7,78 @@ defmodule AppsignalTest do
     {:ok, _} = start_supervised(Appsignal.Test.Nif)
     {:ok, _} = start_supervised(Appsignal.Test.Span)
     {:ok, _} = start_supervised(Appsignal.Test.Monitor)
+    {:ok, _} = start_supervised(FakeIO)
 
-    :ok
+    [fake_os: start_supervised!(FakeOS)]
+  end
+
+  describe "initialize" do
+    @tag :skip_env_test
+    test "prints warning about extension not being loaded" do
+      Appsignal.initialize()
+      [{:stderr, device_output}] = FakeIO.all()
+      output = String.trim(device_output)
+
+      assert output =
+               "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/elixir/command-line/diagnose.html"
+    end
+
+    @tag :skip_env_test
+    test "prints warning about mismatch extension architecture", %{
+      fake_os: fake_os
+    } do
+      # Make current OS "unknown" value so it will always fail
+      FakeOS.update(fake_os, :type, {:unknown, :unknown})
+      Appsignal.initialize()
+      [{:stderr, device_output}] = FakeIO.all()
+      output = String.trim(device_output)
+
+      assert output =~
+               ~r{AppSignal NIF was installed for architecture '\w+-\w+', but the current architecture is '\w+-unknown'}
+    end
+  end
+
+  describe "initialize when the JSON file not valid" do
+    setup do
+      install_report = Path.join([:code.priv_dir(:appsignal), "install.report"])
+      install_contents = File.read!(install_report)
+      File.write(install_report, "invalid install report JSON")
+
+      on_exit(:reset, fn ->
+        File.write!(install_report, install_contents)
+      end)
+    end
+
+    @tag :skip_env_test
+    test "logs an error that the report file is invalid" do
+      Appsignal.initialize()
+
+      [{:stderr, _architecture_mismatch_error}, {:stderr, report_error}] = FakeIO.all()
+
+      assert report_error =~
+               ~r{Failed to parse the AppSignal 'install.report' file:}
+    end
+  end
+
+  describe "initialize when the report file is not readable" do
+    setup do
+      install_report = Path.join([:code.priv_dir(:appsignal), "install.report"])
+      File.chmod(install_report, 0o000)
+
+      on_exit(:reset, fn ->
+        File.chmod(install_report, 0o644)
+      end)
+    end
+
+    @tag :skip_env_test
+    test "logs an error when the report file is not found" do
+      Appsignal.initialize()
+
+      [{:stderr, _architecture_mismatch_error}, {:stderr, report_error}] = FakeIO.all()
+
+      assert report_error =~
+               ~r{Failed to read the AppSignal 'install.report' file:}
+    end
   end
 
   test "set gauge" do

--- a/test/support/fake_os.ex
+++ b/test/support/fake_os.ex
@@ -1,5 +1,12 @@
 defmodule FakeOS do
   use TestAgent, %{type: {:unix, :linux}}
 
-  def type, do: get(__MODULE__, :type)
+  def type do
+    if alive?() do
+      get(__MODULE__, :type)
+    else
+      # Fall back on original implementation if the fake process is not alive
+      :os.type()
+    end
+  end
 end


### PR DESCRIPTION
## Improve error reporting on extension load failure 

It's a common problem for apps first installed on the host system
(macOS) and then mounted with the `deps` and `_build` directory in a
Docker container that's running another Operating System like Ubuntu to
not start the extension. This is because the extension is not installed
for the container's architecture.

If the target and architecture mismatch, print the installed and current
target and architecture so users can spot the difference between them.
This will hopefully make the error more clear: the user needs to
reinstall the extension for their host's architecture.

Closes #254

### Message printed on start

This error message will be printed on the start of the AppSignal
application and not on compilation. On compilation it will still print
the generic message:

> Error loading NIF (Is your operating system (#{arch}) supported?

I initially tried to add the message here, but parsing the JSON
`install.report` file caused errors with the `Appsignal.JSON` module
being undefined.

```
13:35:51.744 [error] Process #PID<0.1551.0> raised an exception
** (UndefinedFunctionError) function Appsignal.Json.decode/1 is undefined (module Appsignal.Json is not available)
    Appsignal.Json.decode("Contents of install.report file")
    lib/appsignal/nif.ex:42: Appsignal.Nif.fetch_installed_architecture_target/0
    lib/appsignal/nif.ex:23: Appsignal.Nif.init/0
    (kernel 8.2) code_server.erl:1317: anonymous fn/1 in :code_server.handle_on_load/5
```

I considered writing the architecture and target to a file named
`priv/architecture_target` as plain text and reading that there instead.
In the end I decided to move this check to the AppSignal initialization
whenever AppSignal is started. This is usually when people would care
for this message, so it's not logged in environments where AppSignal is
not active.

### Using the AppSignal logger

I changed the call from `Logger.error` to `Appsignal.logger.error` so
it's logged to both the log file and printed to STDERR with the agreed
upon format.

### Testing changes

To make FakeOS work, I had to configure it in `config/config.exs`,
otherwise it would be loaded too late and not apply to the `Appsignal`
module. I used the key `os_internal`, otherwise it would conflict with
the `mix_helpers.exs`'s `os` key for the OS and break the entire
installation in the test env.

I also had to add a fallback to the original `:os` module, because the
Appsignal application is also started when the test process starts,
causing it to break on start of `mix test`.

## Store unsupported arch as string in install report

Otherwise it's stored as a list of integers representing the String
which makes it more difficult to inspect when looking at just the file.

The value shown in the diagnose report and sent to the server do appear
to be correct without this change already.