### PR TITLE
Bump agent to v-d573c9b

### DIFF
--- a/.changesets/bump-agent-to-v-d573c9b.md
+++ b/.changesets/bump-agent-to-v-d573c9b.md
@@ -1,0 +1,9 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to v-d573c9b
+
+- Clean up payload storage before sending. Should fix issues with locally queued payloads blocking data from being sent.
+- Add OpenTelemetry support for the Span API. Not currently implemented in this package's extension.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "be3107a"
+  def version, do: "d573c9b"
 
   def mirrors do
     [
@@ -16,51 +16,51 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "31b13af931f26832eb9b5f3283a0dcfc83e327a31570aef47704589de5bd54cc",
+        checksum: "a9a86594e50f22e7f7fd93a050e334048248a6dc971015e66c26150c4a689345",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "31b13af931f26832eb9b5f3283a0dcfc83e327a31570aef47704589de5bd54cc",
+        checksum: "a9a86594e50f22e7f7fd93a050e334048248a6dc971015e66c26150c4a689345",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
+        checksum: "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
+        checksum: "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
+        checksum: "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "37819d1df9b516d39a3aaf54bcc434f7d77e0067d75a86fff8c89be24cf16c28",
+        checksum: "79f1e7f9c34ab36c06d5c3d676173ee7c1219af2f51dc77865897598dc01349a",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "c372daebb69e9795c8dcd60f48cad2af66628e1e3c8211f00526bdc8c880fc97",
+        checksum: "835c6f823a2c6e9f8fa12704bf0953e3610dc9836355b57d2d6981e6ae412fb4",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "c372daebb69e9795c8dcd60f48cad2af66628e1e3c8211f00526bdc8c880fc97",
+        checksum: "835c6f823a2c6e9f8fa12704bf0953e3610dc9836355b57d2d6981e6ae412fb4",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "972a8b02061d747fbe35f3dd8d3d5b7c34bf7a6a38d0526d0ff55b9e70b67f13",
+        checksum: "6eb6f0df2f8c62a29769bf7f21cefaec92a24ee0ab363acc5bd4f9c2d1241c53",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "4821b9d4e9b4501a5002f731b633a64b3991272fb0e6e57a61ce1e2a0b33bcad",
+        checksum: "b16d46074527da5700e10e5a8b176aeb46b7bbb19431653029eda04437bef918",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "2b8ff925dd40daab892cf66ad3fefb72559cab57433907d8f70ae41722716832",
+        checksum: "e7bfc1dc355ce1237aaee6fdf967c78ecca533db41b09c2b10716e7f8593dbe0",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "2b8ff925dd40daab892cf66ad3fefb72559cab57433907d8f70ae41722716832",
+        checksum: "e7bfc1dc355ce1237aaee6fdf967c78ecca533db41b09c2b10716e7f8593dbe0",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }


### PR DESCRIPTION
- Clean up payload storage before sending. Should fix issues with
  locally queued payloads blocking data from being sent.
- Add OpenTelemetry support for the Span API. Not currently implemented
  in this package's extension.

[skip review]