### PR TITLE
Update make clean to also clean c_src directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,4 @@ all:
 
 clean:
 	@$(RM) -r "$(LIB_DIR)"/*appsignal* "$(LIB_DIR)"/*.report
+	@$(RM) -r c_src/libappsignal* c_src/appsignal-agent c_src/appsignal.*


### PR DESCRIPTION
The local install files are stored in `c_src/` directory. Running `make
clean` did not clean this and that is what I expect from the clean
command.

[skip changeset]