### PR TITLE
Always return :ok from Appsignal.config_change/3

### DIFF
--- a/.changesets/always-return--ok-from-appsignal-config_change-3.md
+++ b/.changesets/always-return--ok-from-appsignal-config_change-3.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Always return :ok from Appsignal.config_change/3

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -2,4 +2,3 @@ lib/appsignal/json.ex:31: Unknown function 'Elixir.Jason':encode/1
 lib/appsignal/json.ex:32: Unknown function 'Elixir.Jason':'encode!'/1
 lib/appsignal/json.ex:33: Unknown function 'Elixir.Jason':decode/1
 lib/appsignal/json.ex:34: Unknown function 'Elixir.Jason':'decode!'/1
-lib/appsignal.ex:50: The inferred return type of config_change/3 (pid()) has nothing in common with 'ok', which is the expected return type for the callback of the 'Elixir.Application' behaviour

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -56,6 +56,8 @@ defmodule Appsignal do
       :ok = Appsignal.Nif.stop()
       :ok = initialize()
     end)
+
+    :ok
   end
 
   @doc false

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -53,14 +53,15 @@ defmodule Appsignal do
     # calling itself once it reached `Application.put_env` in
     # `Appsignal.Config`.
     spawn(fn ->
-      :ok = Appsignal.Nif.stop()
-      :ok = initialize()
+      Appsignal.Nif.stop()
+      initialize()
     end)
 
     :ok
   end
 
   @doc false
+  @spec initialize() :: :ok
   def initialize do
     case {Config.initialize(), Config.configured_as_active?()} do
       {_, false} ->

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -6,26 +6,35 @@ defmodule Appsignal.Logger do
 
   @log_levels [:trace, :debug, :info, :warn, :error]
 
+  @type log_level :: :trace | :debug | :info | :warn | :error
+  @type device :: :stdio | :stderr | :file
+
+  @spec trace(String.t()) :: :ok
   def trace(message) do
     log(:trace, message, [])
   end
 
+  @spec debug(String.t()) :: :ok
   def debug(message) do
     log(:debug, message, [])
   end
 
+  @spec info(String.t()) :: :ok
   def info(message) do
     log(:info, message, [])
   end
 
+  @spec warn(String.t()) :: :ok
   def warn(message, options \\ []) do
     log(:warn, message, options)
   end
 
+  @spec error(String.t()) :: :ok
   def error(message, options \\ []) do
     log(:error, message, options)
   end
 
+  @spec log(log_level(), String.t(), keyword()) :: :ok
   defp log(level, message, options) do
     threshold = Appsignal.Config.log_level()
 
@@ -44,6 +53,7 @@ defmodule Appsignal.Logger do
     end
   end
 
+  @spec device() :: device()
   defp device do
     case Application.fetch_env!(:appsignal, :config)[:log] do
       "stdout" -> :stdio
@@ -51,11 +61,13 @@ defmodule Appsignal.Logger do
     end
   end
 
+  @spec log_level?(log_level(), log_level()) :: bool()
   defp log_level?(level, threshold) do
     Enum.find_index(@log_levels, &(&1 == level)) >=
       Enum.find_index(@log_levels, &(&1 == threshold))
   end
 
+  @spec do_log(device(), log_level(), String.t()) :: :ok
   defp do_log(device, level, message) do
     time = NaiveDateTime.from_erl!(:calendar.local_time())
     pid = System.pid()
@@ -63,14 +75,20 @@ defmodule Appsignal.Logger do
     puts(device, format(device, time, pid, level, message))
   end
 
+  @spec puts(device(), String.t()) :: :ok
+  defp puts(device, content)
+
   defp puts(:file, content) do
     @file_module.write(Appsignal.Config.log_file_path(), content <> "\n", [:append, :utf8])
+    :ok
   end
 
   defp puts(device, content) do
     @io.puts(device, content)
+    :ok
   end
 
+  @spec format(device(), NaiveDateTime.t(), binary(), log_level(), String.t()) :: String.t()
   defp format(device, time, pid, level, message) do
     time = format_time(time)
     level = format_level(level)
@@ -82,6 +100,7 @@ defmodule Appsignal.Logger do
     end
   end
 
+  @spec format_level(log_level()) :: String.t()
   defp format_level(level) do
     case level do
       :trace -> "TRACE"
@@ -92,6 +111,7 @@ defmodule Appsignal.Logger do
     end
   end
 
+  @spec format_time(NaiveDateTime.t()) :: String.t()
   defp format_time(time) do
     time
     |> NaiveDateTime.truncate(:second)

--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -25,16 +25,12 @@ defmodule Appsignal.ReleaseUpgradeTest do
 
       with_config(new_config, fn ->
         # Hot reload / upgrade
-        config_reload_pid = Appsignal.config_change([], [], [])
-        # The config is reloaded in a separate process so we wait for it here
-        assert Process.alive?(config_reload_pid)
+        :ok = Appsignal.config_change([], [], [])
 
-        Process.monitor(config_reload_pid)
-
-        assert_receive({:DOWN, _, :process, ^config_reload_pid, _}, 5000)
-
-        assert config()[:name] == "AppSignal test suite app v2"
-        assert Nif.env_get("_APPSIGNAL_APP_NAME") == 'AppSignal test suite app v2'
+        until(fn ->
+          assert config()[:name] == "AppSignal test suite app v2"
+          assert Nif.env_get("_APPSIGNAL_APP_NAME") == 'AppSignal test suite app v2'
+        end)
       end)
     end)
   end


### PR DESCRIPTION
In some situations, Appsignal.config_change/3 didn’t produce the expected `:ok` response. This patch makes sure it always does. It also includes fixes and type specs for the Logger, which also didn’t always return the expected `:ok`

Closes #779.