### PR TITLE
Bump agent to d4b6997

### DIFF
--- a/.changesets/bump-agent-d4b6997.md
+++ b/.changesets/bump-agent-d4b6997.md
@@ -1,0 +1,9 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to d4b6997
+
+- Accept "warning" value for the `log_level` config option.
+- Add aarch64 Linux musl build.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "d573c9b"
+  def version, do: "d4b6997"
 
   def mirrors do
     [
@@ -16,51 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "a9a86594e50f22e7f7fd93a050e334048248a6dc971015e66c26150c4a689345",
+        checksum: "e1fb1b5bd3da20e6b11952d03ee7c65879d659cb74db98496cac2c2e6fd4fa74",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "a9a86594e50f22e7f7fd93a050e334048248a6dc971015e66c26150c4a689345",
+        checksum: "e1fb1b5bd3da20e6b11952d03ee7c65879d659cb74db98496cac2c2e6fd4fa74",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
+        checksum: "24c438670080fff110d21a6f08484c3cad1af51b9c408ca6fc57c1f2b324306a",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
+        checksum: "24c438670080fff110d21a6f08484c3cad1af51b9c408ca6fc57c1f2b324306a",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
+        checksum: "24c438670080fff110d21a6f08484c3cad1af51b9c408ca6fc57c1f2b324306a",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "79f1e7f9c34ab36c06d5c3d676173ee7c1219af2f51dc77865897598dc01349a",
+        checksum: "9bf7b130279a5f64eb1c81372f481cfc077bd27910c7e6444f11f2dbecdf4424",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "835c6f823a2c6e9f8fa12704bf0953e3610dc9836355b57d2d6981e6ae412fb4",
+        checksum: "87449265504cc75140d34db4c01fa8257552e0aaf765bf72a67599c3ca180885",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "835c6f823a2c6e9f8fa12704bf0953e3610dc9836355b57d2d6981e6ae412fb4",
+        checksum: "87449265504cc75140d34db4c01fa8257552e0aaf765bf72a67599c3ca180885",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "6eb6f0df2f8c62a29769bf7f21cefaec92a24ee0ab363acc5bd4f9c2d1241c53",
+        checksum: "e93a4cfaf05d99e9a3e52affb511b895729f8bee12f1f606f6db46ff1126f0d9",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "b16d46074527da5700e10e5a8b176aeb46b7bbb19431653029eda04437bef918",
+        checksum: "5ffb26996dd2979828ed52b0ddd3caa81ff2c86228431f415c37de72ad07ed58",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
+      "aarch64-linux-musl" => %{
+        checksum: "fc1edeccdbb115c6bf596a7f3bd58b67099ad7bb155c0c901b7a15f2dc012419",
+        filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
+      },
       "x86_64-freebsd" => %{
-        checksum: "e7bfc1dc355ce1237aaee6fdf967c78ecca533db41b09c2b10716e7f8593dbe0",
+        checksum: "5bf7a44675b14ada1b8c88471e694ceef32bcbb72bc83b33c4f3c7ee1c29e7cf",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "e7bfc1dc355ce1237aaee6fdf967c78ecca533db41b09c2b10716e7f8593dbe0",
+        checksum: "5bf7a44675b14ada1b8c88471e694ceef32bcbb72bc83b33c4f3c7ee1c29e7cf",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }


### PR DESCRIPTION
- Accept "warning" value for the `log_level` config option.
- Add aarch64 Linux musl build.

Part of https://github.com/appsignal/appsignal-nextjs-blog/pull/569

[skip review]