### PR TITLE
Always return the span from set_attribute/3 and set_sql/3

### DIFF
--- a/.changesets/always-return-the-span-from-span-set_attribute-3.md
+++ b/.changesets/always-return-the-span-from-span-set_attribute-3.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "fix"
 ---
 
-Always return the Span from Span.set_attribute/3
+Always return the Span from Span.set_attribute/3, making it easier to chain this function call.

--- a/.changesets/always-return-the-span-from-span-set_attribute-3.md
+++ b/.changesets/always-return-the-span-from-span-set_attribute-3.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Always return the Span from Span.set_attribute/3

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -179,7 +179,7 @@ defmodule Appsignal.Span do
     span
   end
 
-  def set_sql(_span, _body), do: nil
+  def set_sql(span, _body), do: span
 
   @spec set_sample_data(t() | nil, String.t(), map()) :: t() | nil
   @doc """

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -163,7 +163,7 @@ defmodule Appsignal.Span do
     span
   end
 
-  def set_attribute(_span, _key, _value), do: nil
+  def set_attribute(span, _key, _value), do: span
 
   @spec set_sql(t() | nil, String.t()) :: t() | nil
   @doc """

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -563,6 +563,10 @@ defmodule AppsignalSpanTest do
       assert Span.set_attribute(span, "key", "value") == span
     end
 
+    test "returns span when sending nil values" do
+      assert Span.set_attribute(nil, "key", nil) == span
+    end
+
     test "returns nil when passing a nil-span" do
       assert Span.set_attribute(nil, "key", "value") == nil
     end

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -572,6 +572,22 @@ defmodule AppsignalSpanTest do
     end
   end
 
+  describe ".set_sql/2" do
+    setup :create_root_span
+
+    test "returns the span", %{span: span} do
+      assert Span.set_sql(span, "SELECT * FROM users") == span
+    end
+
+    test "returns span when sending nil values", %{span: span} do
+      assert Span.set_sql(span, nil) == span
+    end
+
+    test "returns nil when passing a nil-span" do
+      assert Span.set_sql(nil, "SELECT * FROM users") == nil
+    end
+  end
+
   describe ".close/1, when passing a nil" do
     test "returns nil" do
       assert Span.close(nil) == nil

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -563,8 +563,8 @@ defmodule AppsignalSpanTest do
       assert Span.set_attribute(span, "key", "value") == span
     end
 
-    test "returns span when sending nil values" do
-      assert Span.set_attribute(nil, "key", nil) == span
+    test "returns span when sending nil values", %{span: span} do
+      assert Span.set_attribute(span, "key", nil) == span
     end
 
     test "returns nil when passing a nil-span" do


### PR DESCRIPTION
Previously, the Span.set_attribute/3 function returned nil when
non accepted values (like nil) were passed in the rescue clause.
Instead, this patch makes sure to always return the span.