### PR TITLE
Always return the span from Span setter functions

### DIFF
--- a/.changesets/always-return-the-span-from-span-setter-functions--to-allow-for-chaining-setter-calls-with-optional-values.md
+++ b/.changesets/always-return-the-span-from-span-setter-functions--to-allow-for-chaining-setter-calls-with-optional-values.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Always return the Span from span setter functions, to allow for chaining setter calls with optional values

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -104,7 +104,7 @@ defmodule Appsignal.Span do
     end
   end
 
-  def set_name(_span, _name), do: nil
+  def set_name(span, _name), do: span
 
   @spec set_namespace(t() | nil, String.t()) :: t() | nil
   @doc """
@@ -123,7 +123,7 @@ defmodule Appsignal.Span do
     span
   end
 
-  def set_namespace(_span, _name), do: nil
+  def set_namespace(span, _name), do: span
 
   @spec set_attribute(t() | nil, String.t(), String.t() | integer() | boolean() | float()) ::
           t() | nil
@@ -222,7 +222,7 @@ defmodule Appsignal.Span do
     span
   end
 
-  defp do_set_sample_data(_span, _key, _value), do: nil
+  defp do_set_sample_data(span, _key, _value), do: span
 
   @spec add_error(t() | nil, Exception.kind(), any(), Exception.stacktrace()) :: t() | nil
   @doc """


### PR DESCRIPTION
The set_name/2, set_namespace/2 and set_sample_data/3 functions all had
a rescue clause that returned a nil value, even if a span was passed to
them.

This caused issues with optional arguments, where a value that should be
a string was a nil. Instead of returning the span unchanged (which is
expected when chainging functions), these functions would then return a
nil, breaking the setters for the rest of the chain.

This patch makes sure the span is returned as passed, if it's a nil or a
proper span.