### PR TITLE
Fix warning about an unused funtion in extension

### DIFF
--- a/.changesets/fix-compile-time-warning-about-unused-funtion-in-extension.md
+++ b/.changesets/fix-compile-time-warning-about-unused-funtion-in-extension.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix compile-time warning about an unused funtion in the extension. The `_set_span_attribute_sql_string` function wasn't hooked up, which didn't produce any issues since the SQL queries coming from Ecto don't need to be sanitized any further (sensitive data is already stripped out). This patch still runs them through AppSignal's SQL sanitizer to fix the warning and behave as promised, theoretically.

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -1373,7 +1373,7 @@ static ErlNifFunc nif_funcs[] =
     {"_set_span_attribute_int", 3, _set_span_attribute_int, 0},
     {"_set_span_attribute_bool", 3, _set_span_attribute_bool, 0},
     {"_set_span_attribute_double", 3, _set_span_attribute_double, 0},
-    {"_set_span_attribute_sql_string", 3, _set_span_attribute_string, 0},
+    {"_set_span_attribute_sql_string", 3, _set_span_attribute_sql_string, 0},
     {"_set_span_sample_data", 3, _set_span_sample_data, 0},
     {"_add_span_error", 4, _add_span_error, 0},
     {"_close_span", 1, _close_span, 0},


### PR DESCRIPTION
Hooks up _set_span_attribute_sql_string. Although Ecto and :telemetry report queries with the sensitive data stripped out, meaning AppSignal's SQL sanitizer doesn't have anything left to do, this patch properly hooks up _set_span_attribute_sql_string to call the function _with_ SQL sanitization.

This fixes a compile-time warning and makes the implementation of the Ecto integration behave as promised, theoretically.