### PR TITLE
Explicitly define used NIF symbols

### DIFF
--- a/.changesets/fix-extension-link-new-xcode-tools.md
+++ b/.changesets/fix-extension-link-new-xcode-tools.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix compile-time error that broke linking on macOS 12.6, more specifically the latest Xcode at this time (version 14.0 14A309).

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,23 @@ ifneq ($(OS),Windows_NT)
 endif
 
 ifeq ($(shell uname),Darwin)
-	LDFLAGS += -dynamiclib -undefined dynamic_lookup
+	# Specify symbols used in the appsignal_extension.c file.
+	# The symbols are looked up at runtime, when the Elixir Nif library is loaded.
+	LDFLAGS += -dynamiclib -Wl,-fatal_warnings, \
+		-U,_enif_alloc_resource, \
+		-U,_enif_get_double, \
+		-U,_enif_get_int, \
+		-U,_enif_get_long, \
+		-U,_enif_get_resource, \
+		-U,_enif_inspect_iolist_as_binary, \
+		-U,_enif_make_atom, \
+		-U,_enif_make_badarg, \
+		-U,_enif_make_resource, \
+		-U,_enif_make_string, \
+		-U,_enif_make_string_len, \
+		-U,_enif_make_tuple, \
+		-U,_enif_open_resource_type, \
+		-U,_enif_release_resource
 endif
 
 all:


### PR DESCRIPTION
We ran into an issue with the new Xcode version 14 command line tools, version 2395.
The linker gave a warning about `dynamic_lookup` not working with chained fixups, a thing that is now enabled by default on the command line tools looks like.

```
ld: warning: -undefined dynamic_lookup may not work with chained fixups
```

It looks like we can't use `dynamic_lookup`. Instead define a list ourselves of all the symbols we use in the `c_src/appsignal_extension.c` file. That way we tell the linker to ignore the undefined symbols, and have them be looked up at runtime when the Elixir NIF library is loaded. Every time we call another NIF function defined in `erl_nif.h` we need to update this list.

## ld documentation changes between Xcode versions that broke

Xcode Version 13.4.1 (13F100), from macOS 12.5:

```
$ man ld

     -undefined treatment
             Specifies how undefined symbols are to be treated. Options
             are: error, warning, suppress, or dynamic_lookup.  The
             default is error.
```

New Xcode Version 14.0 (14A309), from macOS 12.6:

```
$ man ld

     -undefined treatment
             Specifies how undefined symbols are to be treated. Options
             are: error, warning, suppress, or dynamic_lookup.  The
             default is error. Note: dynamic_lookup that depends on lazy
             binding will not work with chained fixups.

     -U symbol_name
             Specified that it is ok for symbol_name to have no
             definition.  With -two_levelnamespace, the resulting symbol
             will be marked dynamic_lookup which means dyld will search
             all loaded images.
```

Closes #790

Co-authored-by: Jeff Kreeftmeijer <jeffkreeftmeijer@gmail.com>