### PR TITLE
Add Finch integration

### DIFF
--- a/.changesets/add-finch-integration.md
+++ b/.changesets/add-finch-integration.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add Finch integration

--- a/.changesets/add-finch-integration.md
+++ b/.changesets/add-finch-integration.md
@@ -3,4 +3,4 @@ bump: "minor"
 type: "add"
 ---
 
-Add Finch integration
+Add Finch integration. HTTP requests performed with Finch will show up as events in the sample view.

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -24,6 +24,7 @@ defmodule Appsignal do
 
     Appsignal.Error.Backend.attach()
     Appsignal.Ecto.attach()
+    Appsignal.Finch.attach()
 
     children = [
       {Appsignal.Tracer, []},

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -40,7 +40,7 @@ defmodule Appsignal.Finch do
 
   defp do_finch_request_start(nil, _name, _request), do: nil
 
-  defp do_finch_request_start(parent, name, request) do
+  defp do_finch_request_start(parent, _name, request) do
     uri = %URI{
       scheme: Atom.to_string(request.scheme),
       path: request.path,

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -42,13 +42,7 @@ defmodule Appsignal.Finch do
   defp do_finch_request_start(nil, _name, _request), do: nil
 
   defp do_finch_request_start(parent, _name, request) do
-    uri = %URI{
-      scheme: Atom.to_string(request.scheme),
-      path: request.path,
-      query: request.query,
-      host: request.host,
-      port: request.port
-    }
+    uri = %URI{scheme: Atom.to_string(request.scheme), host: request.host, port: request.port}
 
     "http_request"
     |> @tracer.create_span(parent)

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -3,7 +3,6 @@ defmodule Appsignal.Finch do
 
   @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
-  import Appsignal.Utils, only: [module_name: 1]
 
   @moduledoc false
 
@@ -52,7 +51,7 @@ defmodule Appsignal.Finch do
 
     "http_request"
     |> @tracer.create_span(parent)
-    |> @span.set_name("#{module_name(name)}: #{request.method} #{URI.to_string(uri)}")
+    |> @span.set_name("#{request.method} #{URI.to_string(uri)}")
     |> @span.set_attribute("appsignal:category", "request.finch")
   end
 

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -1,0 +1,62 @@
+defmodule Appsignal.Finch do
+  require Appsignal.Utils
+
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  import Appsignal.Utils, only: [module_name: 1]
+
+  @moduledoc false
+
+  require Logger
+
+  def attach do
+    handlers = %{
+      [:finch, :request, :start] => &__MODULE__.finch_request_start/4,
+      [:finch, :request, :stop] => &__MODULE__.finch_request_stop/4
+    }
+
+    for {event, fun} <- handlers do
+      case :telemetry.attach({__MODULE__, event}, event, fun, :ok) do
+        :ok ->
+          _ = Appsignal.Logger.debug("Appsignal.Finch attached to #{inspect(event)}")
+
+          :ok
+
+        {:error, _} = error ->
+          Logger.warn("Appsignal.Finch not attached to #{inspect(event)}: #{inspect(error)}")
+
+          error
+      end
+    end
+  end
+
+  def finch_request_start(
+        _event,
+        _measurements,
+        %{name: name, request: request},
+        _config
+      ) do
+    do_finch_request_start(@tracer.current_span(), name, request)
+  end
+
+  defp do_finch_request_start(nil, _name, _request), do: nil
+
+  defp do_finch_request_start(parent, name, request) do
+    uri = %URI{
+      scheme: Atom.to_string(request.scheme),
+      path: request.path,
+      query: request.query,
+      host: request.host,
+      port: request.port
+    }
+
+    "http_request"
+    |> @tracer.create_span(parent)
+    |> @span.set_name("#{module_name(name)}: #{request.method} #{URI.to_string(uri)}")
+    |> @span.set_attribute("appsignal:category", "request.finch")
+  end
+
+  def finch_request_stop(_event, _measurements, _metadata, _config) do
+    @tracer.close_span(@tracer.current_span())
+  end
+end

--- a/test/appsignal/finch_test.exs
+++ b/test/appsignal/finch_test.exs
@@ -73,7 +73,7 @@ defmodule Appsignal.FinchTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "FinchTest: GET https://example.com/"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "GET https://example.com/"}]} = Test.Span.get(:set_name)
     end
 
     test "sets the span's category" do

--- a/test/appsignal/finch_test.exs
+++ b/test/appsignal/finch_test.exs
@@ -1,0 +1,103 @@
+defmodule Appsignal.FinchTest do
+  use ExUnit.Case
+  alias Appsignal.{Span, Test}
+
+  test "attaches to Finch events automatically" do
+    assert attached?([:finch, :request, :start])
+    assert attached?([:finch, :request, :stop])
+  end
+
+  describe "finch_request_start/4, without a root span" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      :telemetry.execute(
+        [:finch, :request, :start],
+        %{},
+        %{
+          name: FinchTest,
+          request: %{
+            method: "GET",
+            scheme: :https,
+            path: "/",
+            query: "",
+            host: "example.com",
+            port: 443
+          }
+        }
+      )
+    end
+
+    test "does not create a span" do
+      assert Test.Tracer.get(:create_span) == :error
+    end
+  end
+
+  describe "finch_request_start/4, and finch_request_stop/4 with a root span" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      Appsignal.Tracer.create_span("http_request")
+
+      :telemetry.execute(
+        [:finch, :request, :start],
+        %{},
+        %{
+          name: FinchTest,
+          request: %{
+            method: "GET",
+            scheme: :https,
+            path: "/",
+            query: nil,
+            host: "example.com",
+            port: 443
+          }
+        }
+      )
+
+      :telemetry.execute(
+        [:finch, :request, :stop],
+        %{},
+        %{}
+      )
+    end
+
+    test "creates a span with a parent" do
+      assert {:ok, [{"http_request", %Span{}}]} = Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "FinchTest: GET https://example.com/"}]} = Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert attribute("appsignal:category", "request.finch")
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
+  defp attribute(asserted_key, asserted_data) do
+    {:ok, attributes} = Test.Span.get(:set_attribute)
+
+    Enum.any?(attributes, fn {%Span{}, key, data} ->
+      key == asserted_key and data == asserted_data
+    end)
+  end
+
+  defp attached?(event) do
+    event
+    |> :telemetry.list_handlers()
+    |> Enum.any?(fn %{id: id} ->
+      id == {Appsignal.Finch, event}
+    end)
+  end
+end

--- a/test/appsignal/finch_test.exs
+++ b/test/appsignal/finch_test.exs
@@ -23,7 +23,7 @@ defmodule Appsignal.FinchTest do
             method: "GET",
             scheme: :https,
             path: "/",
-            query: "",
+            query: "foo=bar",
             host: "example.com",
             port: 443
           }
@@ -54,7 +54,7 @@ defmodule Appsignal.FinchTest do
             method: "GET",
             scheme: :https,
             path: "/",
-            query: nil,
+            query: "foo=bar",
             host: "example.com",
             port: 443
           }
@@ -73,7 +73,7 @@ defmodule Appsignal.FinchTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "GET https://example.com/"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "GET https://example.com"}]} = Test.Span.get(:set_name)
     end
 
     test "sets the span's category" do


### PR DESCRIPTION
As requested [through support](https://github.com/appsignal/support/issues/216). This patch adds support for Finch, the HTTP client by listening for the `[:finch, :request, :start]` and `[:finch, :request, :stop]` messages sent through :telemetry.