### PR TITLE
Fix Alpine Linux ARM64 extension linking

### DIFF
--- a/.changesets/fix-extension-linking-on-alpine-linux-arm64-systems.md
+++ b/.changesets/fix-extension-linking-on-alpine-linux-arm64-systems.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix extension linking on Alpine Linux ARM64 systems.

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ LIB_DIR ?= ./priv
 CFLAGS = -g -O3 -pedantic -Wall -Wextra -I"$(ERLANG_PATH)" -I"$(LIB_DIR)"
 ifeq ($(shell uname),Linux)
 	LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive -static-libgcc -Wl,-fatal_warnings
+	ifeq ($(shell arch),aarch64)
+		LDFLAGS += -Wl,--allow-multiple-definition
+	endif
 else
 	ifeq ($(shell uname),FreeBSD)
 		LDFLAGS = -Wl,--whole-archive "$(LIB_DIR)"/$(LIB_NAME) -Wl,--no-whole-archive -Wl,--fatal-warnings


### PR DESCRIPTION
The extension linking failed on symbols being defined multiple times. This is because the Rust compiler includes the `__fe_getround` `__fe_raise_inexact` [symbols for ARM64 targets][symbols].

I couldn't find a way to mark either symbol as "weak", so it would be overridden with the other "strong" symbol. I couldn't find a way to mark them as weak outside of their original definition.

Instead this change allows symbols to be defined multiple times. As per the GNU libc [documentation of this linker flag][ld man], it will only use the first defined symbol. (I link to the GNU linker docs, because I can't find the musl linker docs.)

> --allow-multiple-definition
> -z muldefs
>   Normally when a symbol is defined multiple times, the linker will
>   report a fatal error. These options allow multiple definitions and
>   the first definition will be used.

Since I don't have a reliable way to detect Alpine Linux/musl systems in the Makefile, this new flag applies to all ARM64 hosts. It won't negatively affect builds in which this is not a problem (no multiple definitions of a symbol).

Fixes #795

[symbols]: https://github.com/rust-lang/compiler-builtins/blob/83b2c07a6bfa394fa5979ca12b60536f402a792c/build.rs#L436-L437
[ld man]: https://www.man7.org/linux/man-pages/man1/ld.1.html
