### PR TITLE
Fix FunctionClauseError for Finch <0.12

### DIFF
--- a/.changesets/fix-functionclauseerror-for-old-finch-versions.md
+++ b/.changesets/fix-functionclauseerror-for-old-finch-versions.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix FunctionClauseError for old Finch versions. This change explicitly ignores events from old Finch versions, meaning only Finch versions 0.12 and above will be instrumented, but using Finch versions 0.11 and below won't cause an event handler crash.


### PR DESCRIPTION
Finch 0.11 and below report `telemetry` events with the same name as those by Finch 0.12 and above, but the events carry different meanings and the metadata map provided has a different structure.

Due to the different structure of the metadata map, our event handlers resulted in a `FunctionClauseError`, causing the handlers to detach.

This commit changes the event handlers so that events not matching the expected structure are silently ignored. This means that we do not break applications using Finch 0.11 and below, but those Finch versions remain unsupported by our Finch integration.

Fixes #797.