### PR TITLE
Logging feature

### DIFF
--- a/.changesets/logging-support.md
+++ b/.changesets/logging-support.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Support log collection from Elixir apps using the new AppSignal Logging feature. Learn more about [AppSignal's Logging on our docs](https://docs.appsignal.com/logging/platforms/integrations/nodejs.html).

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "06391fb"
+  def version, do: "9b62288"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "9bf41c183d94c80e980f57ea2e29d08bae97e8097b5284a2b91a5484bf866f8c",
+        checksum: "5ff2ec4f16f5089e15188670b2c43866c76ab5db2ac07d72878a9816e63171ca",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "9bf41c183d94c80e980f57ea2e29d08bae97e8097b5284a2b91a5484bf866f8c",
+        checksum: "5ff2ec4f16f5089e15188670b2c43866c76ab5db2ac07d72878a9816e63171ca",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
+        checksum: "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
+        checksum: "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
+        checksum: "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "0f2430e637eb77ce2093f021777087e87cb1e7be7c86a53771172696791c4879",
+        checksum: "0e5d89aeda1e883c912ff069bb76029a1e3cad69f493865d877ffaffa2b45142",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "449ba623aaa1853c2d211bf1e2d3a14e5ae09225a62457cbdbcc0983a5713a52",
+        checksum: "ff3cffb1204afd846ba0bb33c50b03f8ada8305527a5908ccfebed6fdcce0e61",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "449ba623aaa1853c2d211bf1e2d3a14e5ae09225a62457cbdbcc0983a5713a52",
+        checksum: "ff3cffb1204afd846ba0bb33c50b03f8ada8305527a5908ccfebed6fdcce0e61",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "394796c0ddeb4881c9f2e6ce82f840e66bcb69e027324f6c04f6671067445fbb",
+        checksum: "0b6fe4b343461a1a906fc73edb44bc5b12c75214d21fc81ed26d3eb88588003e",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "673271c8c5fd55053d8a719bcd307f787db4ca4633baf8cf961c442bf1805614",
+        checksum: "b3f52d7a7a1f4ae8095dd5b1207270dc1797766820d925aca0d09133983c9163",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "e90ca19bf61596be022ba04897e8902b3401add58f351a40a3d3a7af241d0bbb",
+        checksum: "d306c50cc9f1bc8ea3339b4185b2a60a1c27f17d9067a529b1889d74c6c0a8d6",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "cb45da91c51123859e5ef5cea850460c28d6e77dfa08b90375178d9017162ba8",
+        checksum: "135d2ff898f30b15721eca36569d1a0a5deaaee7b4787937d0888ed49f25019b",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "cb45da91c51123859e5ef5cea850460c28d6e77dfa08b90375178d9017162ba8",
+        checksum: "135d2ff898f30b15721eca36569d1a0a5deaaee7b4787937d0888ed49f25019b",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -44,7 +44,7 @@ defmodule Appsignal do
 
   @doc false
   def stop(_state) do
-    Appsignal.Logger.debug("AppSignal stopping.")
+    Appsignal.IntegrationLogger.debug("AppSignal stopping.")
   end
 
   @doc false
@@ -69,12 +69,12 @@ defmodule Appsignal do
         Logger.info("AppSignal disabled.")
 
       {:ok, true} ->
-        Appsignal.Logger.debug("AppSignal starting.")
+        Appsignal.IntegrationLogger.debug("AppSignal starting.")
         Config.write_to_environment()
         Appsignal.Nif.start()
 
         if Appsignal.Nif.loaded?() do
-          Appsignal.Logger.debug("AppSignal started.")
+          Appsignal.IntegrationLogger.debug("AppSignal started.")
         else
           log_nif_loading_error()
         end
@@ -154,12 +154,12 @@ defmodule Appsignal do
     {install_arch, install_target} = fetch_installed_architecture_target()
 
     if arch == install_arch && target == install_target do
-      Appsignal.Logger.error(
+      Appsignal.IntegrationLogger.error(
         "AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/elixir/command-line/diagnose.html\n",
         stderr: true
       )
     else
-      Appsignal.Logger.error(
+      Appsignal.IntegrationLogger.error(
         "The AppSignal NIF was installed for architecture '#{install_arch}-#{install_target}', but the current architecture is '#{arch}-#{target}'. Please reinstall the AppSignal package on the host the app is started: mix deps.compile appsignal --force",
         stderr: true
       )
@@ -176,7 +176,7 @@ defmodule Appsignal do
             {parse_architecture(arch), target}
 
           {:error, reason} ->
-            Appsignal.Logger.error(
+            Appsignal.IntegrationLogger.error(
               "Failed to parse the AppSignal 'install.report' file: #{inspect(reason)}",
               stderr: true
             )
@@ -185,7 +185,7 @@ defmodule Appsignal do
         end
 
       {:error, reason} ->
-        Appsignal.Logger.error(
+        Appsignal.IntegrationLogger.error(
           "Failed to read the AppSignal 'install.report' file: #{inspect(reason)}",
           stderr: true
         )

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -21,6 +21,7 @@ defmodule Appsignal.Config do
     ignore_errors: [],
     ignore_namespaces: [],
     log: "file",
+    logging_endpoint: "https://appsignal-endpoint.net",
     request_headers: ~w(
       accept accept-charset accept-encoding accept-language cache-control
       connection content-length range
@@ -233,6 +234,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_LOG" => :log,
     "APPSIGNAL_LOG_LEVEL" => :log_level,
     "APPSIGNAL_LOG_PATH" => :log_path,
+    "APPSIGNAL_LOGGING_ENDPOINT" => :logging_endpoint,
     "APPSIGNAL_OTP_APP" => :otp_app,
     "APPSIGNAL_PUSH_API_ENDPOINT" => :endpoint,
     "APPSIGNAL_PUSH_API_KEY" => :push_api_key,
@@ -251,7 +253,7 @@ defmodule Appsignal.Config do
   @string_keys ~w(
     APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH
     APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_LEVEL APPSIGNAL_LOG_PATH
-    APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH
+    APPSIGNAL_LOGGING_ENDPOINT APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH
     APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION
   )
   @bool_keys ~w(
@@ -369,6 +371,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_LOG", config[:log])
     Nif.env_put("_APPSIGNAL_LOG_LEVEL", config[:log_level] || "")
     Nif.env_put("_APPSIGNAL_LOG_FILE_PATH", to_string(log_file_path()))
+    Nif.env_put("_APPSIGNAL_LOGGING_ENDPOINT", config[:logging_endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_KEY", config[:push_api_key] || "")
 

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -31,7 +31,7 @@ defmodule Appsignal.Ecto do
 
     case :telemetry.attach({__MODULE__, event}, event, &__MODULE__.handle_event/4, :ok) do
       :ok ->
-        Appsignal.Logger.debug("Appsignal.Ecto attached to #{inspect(event)}")
+        Appsignal.IntegrationLogger.debug("Appsignal.Ecto attached to #{inspect(event)}")
 
       {:error, _} = error ->
         Logger.warn("Appsignal.Ecto not attached to #{inspect(event)}: #{inspect(error)}")

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -15,7 +15,7 @@ defmodule Appsignal.Error.Backend do
   def attach do
     case Logger.add_backend(Appsignal.Error.Backend) do
       {:error, error} -> Logger.warn("Appsignal.Error.Backend not attached to Logger: #{error}")
-      _ -> Appsignal.Logger.debug("Appsignal.Error.Backend attached to Logger")
+      _ -> Appsignal.IntegrationLogger.debug("Appsignal.Error.Backend attached to Logger")
     end
   end
 

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -18,7 +18,7 @@ defmodule Appsignal.Finch do
     for {event, fun} <- handlers do
       case :telemetry.attach({__MODULE__, event}, event, fun, :ok) do
         :ok ->
-          _ = Appsignal.Logger.debug("Appsignal.Finch attached to #{inspect(event)}")
+          _ = Appsignal.IntegrationLogger.debug("Appsignal.Finch attached to #{inspect(event)}")
 
           :ok
 

--- a/lib/appsignal/integration_logger.ex
+++ b/lib/appsignal/integration_logger.ex
@@ -1,4 +1,4 @@
-defmodule Appsignal.Logger do
+defmodule Appsignal.IntegrationLogger do
   require Appsignal.Utils
 
   @io Appsignal.Utils.compile_env(:appsignal, :io, IO)

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -1,0 +1,52 @@
+defmodule Appsignal.Logger do
+  require Appsignal.Utils
+
+  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
+  @severity %{
+    trace: 1,
+    debug: 2,
+    info: 3,
+    warn: 5,
+    error: 6
+  }
+
+  @type log_level :: :trace | :debug | :info | :warn | :error
+
+  @spec trace(String.t(), String.t(), %{}) :: :ok
+  def trace(group, message, metadata \\ %{}) do
+    log(:trace, group, message, metadata)
+  end
+
+  @spec debug(String.t(), String.t(), %{}) :: :ok
+  def debug(group, message, metadata \\ %{}) do
+    log(:debug, group, message, metadata)
+  end
+
+  @spec info(String.t(), String.t(), %{}) :: :ok
+  def info(group, message, metadata \\ %{}) do
+    log(:info, group, message, metadata)
+  end
+
+  @spec warn(String.t(), String.t(), %{}) :: :ok
+  def warn(group, message, metadata \\ %{}) do
+    log(:warn, group, message, metadata)
+  end
+
+  @spec error(String.t(), String.t(), %{}) :: :ok
+  def error(group, message, metadata \\ %{}) do
+    log(:error, group, message, metadata)
+  end
+
+  @spec log(log_level(), String.t(), String.t(), %{}) :: :ok
+  defp log(log_level, group, message, metadata) do
+    severity = @severity[log_level]
+    encoded_metadata = Appsignal.Utils.DataEncoder.encode(metadata)
+
+    @nif.log(
+      group,
+      severity,
+      message,
+      encoded_metadata
+    )
+  end
+end

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -3,19 +3,18 @@ defmodule Appsignal.Logger do
 
   @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
   @severity %{
-    trace: 1,
     debug: 2,
     info: 3,
-    warn: 5,
-    error: 6
+    notice: 4,
+    warning: 5,
+    error: 6,
+    critical: 7,
+    alert: 8,
+    emergency: 9
   }
 
-  @type log_level :: :trace | :debug | :info | :warn | :error
-
-  @spec trace(String.t(), String.t(), %{}) :: :ok
-  def trace(group, message, metadata \\ %{}) do
-    log(:trace, group, message, metadata)
-  end
+  @type log_level ::
+          :debug | :info | :notice | :warning | :error | :critical | :alert | :emergency
 
   @spec debug(String.t(), String.t(), %{}) :: :ok
   def debug(group, message, metadata \\ %{}) do
@@ -27,14 +26,34 @@ defmodule Appsignal.Logger do
     log(:info, group, message, metadata)
   end
 
-  @spec warn(String.t(), String.t(), %{}) :: :ok
-  def warn(group, message, metadata \\ %{}) do
-    log(:warn, group, message, metadata)
+  @spec notice(String.t(), String.t(), %{}) :: :ok
+  def notice(group, message, metadata \\ %{}) do
+    log(:notice, group, message, metadata)
+  end
+
+  @spec warning(String.t(), String.t(), %{}) :: :ok
+  def warning(group, message, metadata \\ %{}) do
+    log(:warning, group, message, metadata)
   end
 
   @spec error(String.t(), String.t(), %{}) :: :ok
   def error(group, message, metadata \\ %{}) do
     log(:error, group, message, metadata)
+  end
+
+  @spec critical(String.t(), String.t(), %{}) :: :ok
+  def critical(group, message, metadata \\ %{}) do
+    log(:critical, group, message, metadata)
+  end
+
+  @spec alert(String.t(), String.t(), %{}) :: :ok
+  def alert(group, message, metadata \\ %{}) do
+    log(:alert, group, message, metadata)
+  end
+
+  @spec emergency(String.t(), String.t(), %{}) :: :ok
+  def emergency(group, message, metadata \\ %{}) do
+    log(:emergency, group, message, metadata)
   end
 
   @spec log(log_level(), String.t(), String.t(), %{}) :: :ok

--- a/lib/appsignal/monitor.ex
+++ b/lib/appsignal/monitor.ex
@@ -47,7 +47,7 @@ defmodule Appsignal.Monitor do
 
     pids = MapSet.new(monitored_pids())
 
-    Appsignal.Logger.debug(
+    Appsignal.IntegrationLogger.debug(
       "Synchronizing monitored PIDs in Appsignal.Monitor (#{MapSet.size(pids)})"
     )
 

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -248,6 +248,10 @@ defmodule Appsignal.Nif do
     _span_to_json(resource)
   end
 
+  def log(group, severity, message, attributes) do
+    _log(group, severity, message, attributes)
+  end
+
   if Mix.env() == :test do
     def data_to_json(reference) do
       _data_to_json(reference)
@@ -482,6 +486,10 @@ defmodule Appsignal.Nif do
 
   def _span_to_json(_reference) do
     {:ok, "{}"}
+  end
+
+  def _log(_group, _severity, _message, _attributes) do
+    :ok
   end
 
   if Mix.env() in [:test, :test_no_nif] do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -380,6 +380,11 @@ defmodule Appsignal.ConfigTest do
       assert %{log_path: ^log_path} = with_config(%{log_path: log_path}, &init_config/0)
     end
 
+    test "logging_endpoint" do
+      assert %{logging_endpoint: "https://push.staging.lol"} =
+               with_config(%{logging_endpoint: "https://push.staging.lol"}, &init_config/0)
+    end
+
     test "name" do
       assert %{name: "AppSignal test suite app"} =
                with_config(%{name: "AppSignal test suite app"}, &init_config/0)
@@ -649,6 +654,14 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_LOG_PATH" => log_path},
                &init_config/0
              ) == default_configuration() |> Map.put(:log_path, log_path)
+    end
+
+    test "logging_endpoint" do
+      assert with_env(
+               %{"APPSIGNAL_LOGGING_ENDPOINT" => "https://push.staging.lol"},
+               &init_config/0
+             ) ==
+               default_configuration() |> Map.put(:logging_endpoint, "https://push.staging.lol")
     end
 
     test "otp_app" do
@@ -982,6 +995,7 @@ defmodule Appsignal.ConfigTest do
           log: "stdout",
           log_level: "warn",
           log_path: "/tmp",
+          logging_endpoint: "https://push.staging.lol",
           name: "AppSignal test suite app",
           running_in_container: false,
           working_dir_path: "/tmp/appsignal-deprecated",
@@ -1018,6 +1032,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_LOG") == 'stdout'
           assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == 'warn'
           assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == '/tmp/appsignal.log'
+          assert Nif.env_get("_APPSIGNAL_LOGGING_ENDPOINT") == 'https://push.staging.lol'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_ENDPOINT") == 'https://push.staging.lol'
           assert Nif.env_get("_APPSIGNAL_PUSH_API_KEY") == '00000000-0000-0000-0000-000000000000'
           assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == 'false'
@@ -1121,6 +1136,7 @@ defmodule Appsignal.ConfigTest do
       ignore_errors: [],
       ignore_namespaces: [],
       log: "file",
+      logging_endpoint: "https://appsignal-endpoint.net",
       request_headers: ~w(
         accept accept-charset accept-encoding accept-language cache-control
         connection content-length range

--- a/test/appsignal/integration_logger_test.exs
+++ b/test/appsignal/integration_logger_test.exs
@@ -1,4 +1,4 @@
-defmodule Appsignal.LoggerTest do
+defmodule Appsignal.IntegrationLoggerTest do
   import AppsignalTest.Utils
   use ExUnit.Case
 
@@ -11,11 +11,11 @@ defmodule Appsignal.LoggerTest do
 
   test "all methods log messages when config log level is trace" do
     with_config(%{log_level: "trace"}, fn ->
-      Appsignal.Logger.trace("trace!")
-      Appsignal.Logger.debug("debug!")
-      Appsignal.Logger.info("info!")
-      Appsignal.Logger.warn("warning!")
-      Appsignal.Logger.error("error!")
+      Appsignal.IntegrationLogger.trace("trace!")
+      Appsignal.IntegrationLogger.debug("debug!")
+      Appsignal.IntegrationLogger.info("info!")
+      Appsignal.IntegrationLogger.warn("warning!")
+      Appsignal.IntegrationLogger.error("error!")
     end)
 
     until(fn -> assert FakeFile.count() == 5 end)
@@ -39,11 +39,11 @@ defmodule Appsignal.LoggerTest do
 
   test "only error method logs messages when config log level is error" do
     with_config(%{log_level: "error"}, fn ->
-      Appsignal.Logger.trace("trace!")
-      Appsignal.Logger.debug("debug!")
-      Appsignal.Logger.info("info!")
-      Appsignal.Logger.warn("warning!")
-      Appsignal.Logger.error("error!")
+      Appsignal.IntegrationLogger.trace("trace!")
+      Appsignal.IntegrationLogger.debug("debug!")
+      Appsignal.IntegrationLogger.info("info!")
+      Appsignal.IntegrationLogger.warn("warning!")
+      Appsignal.IntegrationLogger.error("error!")
     end)
 
     until(fn -> assert FakeFile.count() == 1 end)
@@ -54,7 +54,7 @@ defmodule Appsignal.LoggerTest do
 
   test "logs info message when config log level is debug" do
     with_config(%{log_level: "debug"}, fn ->
-      Appsignal.Logger.info("info!")
+      Appsignal.IntegrationLogger.info("info!")
     end)
 
     until(fn -> assert FakeFile.count() == 1 end)
@@ -65,7 +65,7 @@ defmodule Appsignal.LoggerTest do
 
   test "logs debug message when config log level is debug" do
     with_config(%{log_level: "debug"}, fn ->
-      Appsignal.Logger.debug("debug!")
+      Appsignal.IntegrationLogger.debug("debug!")
     end)
 
     until(fn -> assert FakeFile.count() == 1 end)
@@ -76,7 +76,7 @@ defmodule Appsignal.LoggerTest do
 
   test "does not log trace message when config log level is debug" do
     with_config(%{log_level: "debug"}, fn ->
-      Appsignal.Logger.trace("trace!")
+      Appsignal.IntegrationLogger.trace("trace!")
     end)
 
     repeatedly(fn -> assert FakeFile.count() == 0 end)
@@ -84,7 +84,7 @@ defmodule Appsignal.LoggerTest do
 
   test "logs to file by default" do
     with_config(%{}, fn ->
-      Appsignal.Logger.info("info!")
+      Appsignal.IntegrationLogger.info("info!")
     end)
 
     until(fn ->
@@ -100,7 +100,7 @@ defmodule Appsignal.LoggerTest do
 
   test "logs to stdout when config log is stdout" do
     with_config(%{log: "stdout"}, fn ->
-      Appsignal.Logger.info("info!")
+      Appsignal.IntegrationLogger.info("info!")
     end)
 
     until(fn ->
@@ -115,7 +115,7 @@ defmodule Appsignal.LoggerTest do
 
   test "logs to stderr instead of stdout when stderr is set" do
     with_config(%{log: "stdout"}, fn ->
-      Appsignal.Logger.warn("warning!", stderr: true)
+      Appsignal.IntegrationLogger.warn("warning!", stderr: true)
     end)
 
     until(fn ->
@@ -130,7 +130,7 @@ defmodule Appsignal.LoggerTest do
 
   test "logs to stderr and to file when stderr is set" do
     with_config(%{}, fn ->
-      Appsignal.Logger.warn("warning!", stderr: true)
+      Appsignal.IntegrationLogger.warn("warning!", stderr: true)
     end)
 
     until(fn ->
@@ -154,7 +154,7 @@ defmodule Appsignal.LoggerTest do
     on_exit(fn -> File.rm_rf("/tmp/foo") end)
 
     with_config(%{log_path: "/tmp/foo"}, fn ->
-      Appsignal.Logger.warn("warning!")
+      Appsignal.IntegrationLogger.warn("warning!")
     end)
 
     until(fn -> assert FakeFile.count() == 1 end)

--- a/test/appsignal/logger_test.exs
+++ b/test/appsignal/logger_test.exs
@@ -7,14 +7,6 @@ defmodule Appsignal.LoggerTest do
     :ok
   end
 
-  test "trace/3 sends the trace log call through the extension" do
-    metadata = %{some: "metadata"}
-
-    Logger.trace("app", "This is a trace", metadata)
-
-    assert [{"app", 1, "This is a trace", _encoded_metadata}] = Test.Nif.get!(:log)
-  end
-
   test "debug/3 sends the debug log call through the extension" do
     metadata = %{some: "metadata"}
 
@@ -31,12 +23,20 @@ defmodule Appsignal.LoggerTest do
     assert [{"app", 3, "This is an info", _encoded_metadata}] = Test.Nif.get!(:log)
   end
 
-  test "warn/3 sends the warn log call through the extension" do
+  test "notice/3 sends the notice log call through the extension" do
     metadata = %{some: "metadata"}
 
-    Logger.warn("app", "This is a warn", metadata)
+    Logger.notice("app", "This is a notice", metadata)
 
-    assert [{"app", 5, "This is a warn", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [{"app", 4, "This is a notice", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+
+  test "warning/3 sends the warning log call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.warning("app", "This is a warning", metadata)
+
+    assert [{"app", 5, "This is a warning", _encoded_metadata}] = Test.Nif.get!(:log)
   end
 
   test "error/3 sends the error log call through the extension" do
@@ -45,5 +45,29 @@ defmodule Appsignal.LoggerTest do
     Logger.error("app", "This is an error", metadata)
 
     assert [{"app", 6, "This is an error", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+
+  test "critical/3 sends the critical log call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.critical("app", "This is a critical", metadata)
+
+    assert [{"app", 7, "This is a critical", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+
+  test "alert/3 sends the alert log call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.alert("app", "This is an alert", metadata)
+
+    assert [{"app", 8, "This is an alert", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+
+  test "emergency/3 sends the emergency log call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.emergency("app", "This is an emergency", metadata)
+
+    assert [{"app", 9, "This is an emergency", _encoded_metadata}] = Test.Nif.get!(:log)
   end
 end

--- a/test/appsignal/logger_test.exs
+++ b/test/appsignal/logger_test.exs
@@ -1,0 +1,49 @@
+defmodule Appsignal.LoggerTest do
+  use ExUnit.Case
+  alias Appsignal.{Logger, Test}
+
+  setup do
+    start_supervised(Test.Nif)
+    :ok
+  end
+
+  test "trace/3 sends the trace log call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.trace("app", "This is a trace", metadata)
+
+    assert [{"app", 1, "This is a trace", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+
+  test "debug/3 sends the debug log call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.debug("app", "This is a debug", metadata)
+
+    assert [{"app", 2, "This is a debug", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+
+  test "info/3 sends the info call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.info("app", "This is an info", metadata)
+
+    assert [{"app", 3, "This is an info", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+
+  test "warn/3 sends the warn log call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.warn("app", "This is a warn", metadata)
+
+    assert [{"app", 5, "This is a warn", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+
+  test "error/3 sends the error log call through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.error("app", "This is an error", metadata)
+
+    assert [{"app", 6, "This is an error", _encoded_metadata}] = Test.Nif.get!(:log)
+  end
+end

--- a/test/support/appsignal/test_nif.ex
+++ b/test/support/appsignal/test_nif.ex
@@ -46,4 +46,9 @@ defmodule Appsignal.Test.Nif do
     add(:close_span_with_timestamp, {reference, sec, nsec})
     Nif.close_span_with_timestamp(reference, sec, nsec)
   end
+
+  def log(group, severity, message, metadata) do
+    add(:log, {group, severity, message, metadata})
+    Nif.log(group, severity, message, metadata)
+  end
 end


### PR DESCRIPTION
## [Rename Logger to IntegrationLogger](https://github.com/appsignal/appsignal-elixir/commit/e1d72e52529608985fde2ed127b4406433263081)

In order to implement the Logger that comunicates with the Logging API
in the agent, the integration internal logger is renamed to Integration
Logger. This is based in the Ruby and Node.js implementation.

## [Implement Logger module](https://github.com/appsignal/appsignal-elixir/commit/cdf4f5b0da5650a952f0c335dbe8d9f92d04ed70)

This module exposes functions to log messages by severity through the
extension Logging API

## [Add logging endpoint config option](https://github.com/appsignal/appsignal-elixir/pull/801/commits/1815e7fc30aeb9b20296a92c901871b2f2fc4c73)

This option tells the agent where to send the logs made through its API.

## [Update diagnose tests](https://github.com/appsignal/appsignal-elixir/pull/801/commits/6a6a906740a0fd24688a2bcbef0b03e1d509d5ad)

Adds the diagnose tests updated submodule with support for the
`logging_endpoint` config option.

Closes #799 