### PR TITLE
Stack trace argument types

### DIFF
--- a/.changesets/replace-arguments-in-stack-traces-with-sanitized-versions-instead-of-stripping-them-out-completely.md
+++ b/.changesets/replace-arguments-in-stack-traces-with-sanitized-versions-instead-of-stripping-them-out-completely.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Replace arguments in stack traces with sanitized versions instead of stripping them out completely

--- a/lib/appsignal/stacktrace.ex
+++ b/lib/appsignal/stacktrace.ex
@@ -33,6 +33,6 @@ defmodule Appsignal.Stacktrace do
   end
 
   defp to_types(arguments) do
-    Enum.map(arguments, &Appsignal.Utils.Type.from/1)
+    Enum.map(arguments, &Appsignal.Utils.ArgumentCleaner.clean/1)
   end
 end

--- a/lib/appsignal/stacktrace.ex
+++ b/lib/appsignal/stacktrace.ex
@@ -1,22 +1,3 @@
-defmodule ArgumentType do
-  defstruct [:value, :type]
-
-  def from_term(term) do
-    %ArgumentType{value: term, type: typeof(term)}
-  end
-
-  for type <-
-        ~w[boolean binary bitstring float function integer list map nil pid port reference tuple atom] do
-    defp typeof(x) when unquote(:"is_#{type}")(x), do: unquote(type)
-  end
-
-  defp typeof(_), do: "unknown"
-end
-
-defimpl Inspect, for: ArgumentType do
-  def inspect(%ArgumentType{type: type}, _opts), do: type
-end
-
 defmodule Appsignal.Stacktrace do
   @moduledoc false
 
@@ -52,6 +33,6 @@ defmodule Appsignal.Stacktrace do
   end
 
   defp to_types(arguments) do
-    Enum.map(arguments, &ArgumentType.from_term/1)
+    Enum.map(arguments, &Appsignal.Utils.Type.from/1)
   end
 end

--- a/lib/appsignal/stacktrace.ex
+++ b/lib/appsignal/stacktrace.ex
@@ -1,3 +1,22 @@
+defmodule ArgumentType do
+  defstruct [:value, :type]
+
+  def from_term(term) do
+    %ArgumentType{value: term, type: typeof(term)}
+  end
+
+  for type <-
+        ~w[boolean binary bitstring float function integer list map nil pid port reference tuple atom] do
+    defp typeof(x) when unquote(:"is_#{type}")(x), do: unquote(type)
+  end
+
+  defp typeof(_), do: "unknown"
+end
+
+defimpl Inspect, for: ArgumentType do
+  def inspect(%ArgumentType{type: type}, _opts), do: type
+end
+
 defmodule Appsignal.Stacktrace do
   @moduledoc false
 
@@ -24,11 +43,15 @@ defmodule Appsignal.Stacktrace do
 
   defp format_stacktrace_entry(entry) when is_binary(entry), do: entry
 
-  defp format_stacktrace_entry({module, function, arity, location}) when is_list(arity) do
-    format_stacktrace_entry({module, function, length(arity), location})
+  defp format_stacktrace_entry({module, function, arguments, location}) when is_list(arguments) do
+    Exception.format_stacktrace_entry({module, function, to_types(arguments), location})
   end
 
   defp format_stacktrace_entry(entry) do
     Exception.format_stacktrace_entry(entry)
+  end
+
+  defp to_types(arguments) do
+    Enum.map(arguments, &ArgumentType.from_term/1)
   end
 end

--- a/lib/appsignal/utils/argument_cleaner.ex
+++ b/lib/appsignal/utils/argument_cleaner.ex
@@ -1,0 +1,17 @@
+defmodule Appsignal.Utils.ArgumentCleaner do
+  alias Appsignal.Utils.Type
+
+  def clean(argument)
+      when is_boolean(argument) or is_integer(argument) or is_float(argument) or is_pid(argument) or
+             is_port(argument) or is_reference(argument) do
+    argument
+  end
+
+  def clean(argument) when is_map(argument) do
+    {struct, map} = Map.pop(argument, :__struct__)
+
+    "%#{Appsignal.Utils.module_name(struct)}{#{Enum.map_join(map, ", ", fn {key, value} -> "#{inspect(key)} => #{clean(value)}" end)}}"
+  end
+
+  def clean(argument), do: Type.from(argument)
+end

--- a/lib/appsignal/utils/type.ex
+++ b/lib/appsignal/utils/type.ex
@@ -1,0 +1,43 @@
+defmodule Appsignal.Utils.Type do
+  def of(term) when is_boolean(term), do: "boolean"
+
+  def of(nil), do: "nil"
+
+  def of(term) when is_integer(term), do: "integer"
+
+  def of(term) when is_float(term), do: "float"
+
+  def of(term) when is_pid(term), do: "pid"
+
+  def of(term) when is_atom(term), do: "atom"
+
+  def of(term) when is_bitstring(term) and not is_binary(term), do: "bitstring"
+
+  def of(term) when is_binary(term), do: "binary"
+
+  def of(term) when is_function(term), do: "function"
+
+  def of(term) when is_binary(term), do: "binary"
+
+  def of(term) when is_function(term), do: "function"
+
+  def of(term) when is_port(term), do: "port"
+
+  def of(term) when is_reference(term), do: "reference"
+
+  def of(term) when is_tuple(term) do
+    "{#{Enum.map_join(Tuple.to_list(term), ", ", &of/1)}}"
+  end
+
+  def of(term) when is_list(term) do
+    "[#{Enum.map_join(term, ", ", &of/1)}]"
+  end
+
+  def of(term) when is_map(term) do
+    {struct, map} = Map.pop(term, :__struct__)
+
+    "%#{Appsignal.Utils.module_name(struct)}{#{Enum.map_join(map, ", ", fn {key, value} -> "#{of(key)} => #{of(value)}" end)}}"
+  end
+
+  def of(_term), do: "unknown"
+end

--- a/lib/appsignal/utils/type.ex
+++ b/lib/appsignal/utils/type.ex
@@ -1,4 +1,10 @@
 defmodule Appsignal.Utils.Type do
+  defstruct [:type]
+
+  def from(term) do
+    %__MODULE__{type: of(term)}
+  end
+
   def of(term) when is_boolean(term), do: "boolean"
 
   def of(nil), do: "nil"
@@ -40,4 +46,8 @@ defmodule Appsignal.Utils.Type do
   end
 
   def of(_term), do: "unknown"
+end
+
+defimpl Inspect, for: Appsignal.Utils.Type do
+  def inspect(%Appsignal.Utils.Type{type: type}, _opts), do: type
 end

--- a/lib/appsignal/utils/type.ex
+++ b/lib/appsignal/utils/type.ex
@@ -5,47 +5,43 @@ defmodule Appsignal.Utils.Type do
     %__MODULE__{type: of(term)}
   end
 
-  def of(term) when is_boolean(term), do: "boolean"
+  defp of(term) when is_boolean(term), do: "boolean"
 
-  def of(nil), do: "nil"
+  defp of(nil), do: "nil"
 
-  def of(term) when is_integer(term), do: "integer"
+  defp of(term) when is_integer(term), do: "integer"
 
-  def of(term) when is_float(term), do: "float"
+  defp of(term) when is_float(term), do: "float"
 
-  def of(term) when is_pid(term), do: "pid"
+  defp of(term) when is_pid(term), do: "pid"
 
-  def of(term) when is_atom(term), do: "atom"
+  defp of(term) when is_atom(term), do: "atom"
 
-  def of(term) when is_bitstring(term) and not is_binary(term), do: "bitstring"
+  defp of(term) when is_bitstring(term) and not is_binary(term), do: "bitstring"
 
-  def of(term) when is_binary(term), do: "binary"
+  defp of(term) when is_binary(term), do: "binary"
 
-  def of(term) when is_function(term), do: "function"
+  defp of(term) when is_function(term), do: "function"
 
-  def of(term) when is_binary(term), do: "binary"
+  defp of(term) when is_port(term), do: "port"
 
-  def of(term) when is_function(term), do: "function"
+  defp of(term) when is_reference(term), do: "reference"
 
-  def of(term) when is_port(term), do: "port"
-
-  def of(term) when is_reference(term), do: "reference"
-
-  def of(term) when is_tuple(term) do
+  defp of(term) when is_tuple(term) do
     "{#{Enum.map_join(Tuple.to_list(term), ", ", &of/1)}}"
   end
 
-  def of(term) when is_list(term) do
+  defp of(term) when is_list(term) do
     "[#{Enum.map_join(term, ", ", &of/1)}]"
   end
 
-  def of(term) when is_map(term) do
+  defp of(term) when is_map(term) do
     {struct, map} = Map.pop(term, :__struct__)
 
     "%#{Appsignal.Utils.module_name(struct)}{#{Enum.map_join(map, ", ", fn {key, value} -> "#{of(key)} => #{of(value)}" end)}}"
   end
 
-  def of(_term), do: "unknown"
+  defp of(_term), do: "unknown"
 end
 
 defimpl Inspect, for: Appsignal.Utils.Type do

--- a/lib/appsignal/utils/type.ex
+++ b/lib/appsignal/utils/type.ex
@@ -47,3 +47,7 @@ end
 defimpl Inspect, for: Appsignal.Utils.Type do
   def inspect(%Appsignal.Utils.Type{type: type}, _opts), do: type
 end
+
+defimpl String.Chars, for: Appsignal.Utils.Type do
+  def to_string(%Appsignal.Utils.Type{type: type}), do: type
+end

--- a/test/appsignal/stacktrace_test.exs
+++ b/test/appsignal/stacktrace_test.exs
@@ -47,7 +47,7 @@ defmodule Appsignal.StacktraceTest do
       :error, _ -> %{stack: Stacktrace.get()}
     end
 
-    test "replaces arguments with arities", %{stack: stack} do
+    test "replaces arguments with types", %{stack: stack} do
       [line | _] = Stacktrace.format(stack)
       assert line =~ ~r{\(elixir( [\w.-]+)?\) String.to_atom\(binary, atom\)}
     end

--- a/test/appsignal/stacktrace_test.exs
+++ b/test/appsignal/stacktrace_test.exs
@@ -49,7 +49,7 @@ defmodule Appsignal.StacktraceTest do
 
     test "replaces arguments with arities", %{stack: stack} do
       [line | _] = Stacktrace.format(stack)
-      assert line =~ ~r{\(elixir( [\w.-]+)?\) String.to_atom/2}
+      assert line =~ ~r{\(elixir( [\w.-]+)?\) String.to_atom\(binary, atom\)}
     end
   end
 

--- a/test/appsignal/utils/argument_cleaner_test.exs
+++ b/test/appsignal/utils/argument_cleaner_test.exs
@@ -1,0 +1,34 @@
+defmodule NonEmptyStruct do
+  defstruct [:foo]
+end
+
+defmodule Appsignal.Utils.ArgumentCleanerTest do
+  alias Appsignal.Utils.{ArgumentCleaner, Type}
+  use ExUnit.Case
+
+  test "cleaned types" do
+    assert ArgumentCleaner.clean(:foo) == %Type{type: "atom"}
+    assert ArgumentCleaner.clean("bar") == %Type{type: "binary"}
+    assert ArgumentCleaner.clean(<<1::1>>) == %Type{type: "bitstring"}
+    assert ArgumentCleaner.clean(fn -> nil end) == %Type{type: "function"}
+  end
+
+  test "untouched types" do
+    assert ArgumentCleaner.clean(true) == true
+    assert ArgumentCleaner.clean(false) == false
+    assert ArgumentCleaner.clean(1) == 1
+    assert ArgumentCleaner.clean(1.2) == 1.2
+    pid = :erlang.list_to_pid('<0.0.0>')
+    assert ArgumentCleaner.clean(pid) == pid
+    port = Port.open({:spawn, "echo foo"}, [])
+    assert ArgumentCleaner.clean(port) == port
+    reference = make_ref()
+    assert ArgumentCleaner.clean(reference) == reference
+  end
+
+  test "map" do
+    assert ArgumentCleaner.clean(%{foo: 1}) == "%{:foo => 1}"
+    assert ArgumentCleaner.clean(%{foo: "bar"}) == "%{:foo => binary}"
+    assert ArgumentCleaner.clean(%NonEmptyStruct{foo: "bar"}) == "%NonEmptyStruct{:foo => binary}"
+  end
+end

--- a/test/appsignal/utils/type_test.exs
+++ b/test/appsignal/utils/type_test.exs
@@ -92,4 +92,8 @@ defmodule Appsignal.Utils.TypeTest do
   test "non-empty struct" do
     assert Type.of(%NonEmptyStruct{foo: 1}) == "%NonEmptyStruct{atom => integer}"
   end
+
+  test "inspect" do
+    assert inspect(Type.from("string")) == "binary"
+  end
 end

--- a/test/appsignal/utils/type_test.exs
+++ b/test/appsignal/utils/type_test.exs
@@ -1,0 +1,95 @@
+defmodule EmptyStruct do
+  defstruct []
+end
+
+defmodule NonEmptyStruct do
+  defstruct [:foo]
+end
+
+defmodule Appsignal.Utils.TypeTest do
+  use ExUnit.Case
+  alias Appsignal.Utils.Type
+
+  test "atom" do
+    assert Type.of(:foo) == "atom"
+  end
+
+  test "booleans" do
+    assert Type.of(true) == "boolean"
+    assert Type.of(false) == "boolean"
+  end
+
+  test "nils" do
+    assert Type.of(nil) == "nil"
+  end
+
+  test "binary" do
+    assert Type.of("bar") == "binary"
+  end
+
+  test "bitstring" do
+    assert Type.of(<<1::1>>) == "bitstring"
+  end
+
+  test "function" do
+    assert Type.from(fn -> nil end).type == "function"
+  end
+
+  test "float" do
+    assert Type.of(1.2) == "float"
+  end
+
+  test "integer" do
+    assert Type.of(1) == "integer"
+  end
+
+  test "pid" do
+    assert '<0.0.0>'
+           |> :erlang.list_to_pid()
+           |> Type.of() == "pid"
+  end
+
+  test "port" do
+    assert Type.of(Port.open({:spawn, "echo foo"}, [])) == "port"
+  end
+
+  test "reference" do
+    assert Type.of(make_ref()) == "reference"
+  end
+
+  test "empty tuple" do
+    assert Type.of({}) == "{}"
+  end
+
+  test "non-empty tuple" do
+    assert Type.of({:foo, "bar"}) == "{atom, binary}"
+  end
+
+  test "empty list" do
+    assert Type.of([]) == "[]"
+  end
+
+  test "non-empty list" do
+    assert Type.of([:foo]) == "[atom]"
+  end
+
+  test "keyword list" do
+    assert Type.from(foo: "bar").type == "[{atom, binary}]"
+  end
+
+  test "empty map" do
+    assert Type.of(%{}) == "%{}"
+  end
+
+  test "non-empty map" do
+    assert Type.of(%{foo: "bar"}) == "%{atom => binary}"
+  end
+
+  test "empty struct" do
+    assert Type.of(%EmptyStruct{}) == "%EmptyStruct{}"
+  end
+
+  test "non-empty struct" do
+    assert Type.of(%NonEmptyStruct{foo: 1}) == "%NonEmptyStruct{atom => integer}"
+  end
+end

--- a/test/appsignal/utils/type_test.exs
+++ b/test/appsignal/utils/type_test.exs
@@ -11,24 +11,24 @@ defmodule Appsignal.Utils.TypeTest do
   alias Appsignal.Utils.Type
 
   test "atom" do
-    assert Type.of(:foo) == "atom"
+    assert Type.from(:foo).type == "atom"
   end
 
   test "booleans" do
-    assert Type.of(true) == "boolean"
-    assert Type.of(false) == "boolean"
+    assert Type.from(true).type == "boolean"
+    assert Type.from(false).type == "boolean"
   end
 
   test "nils" do
-    assert Type.of(nil) == "nil"
+    assert Type.from(nil).type == "nil"
   end
 
   test "binary" do
-    assert Type.of("bar") == "binary"
+    assert Type.from("bar").type == "binary"
   end
 
   test "bitstring" do
-    assert Type.of(<<1::1>>) == "bitstring"
+    assert Type.from(<<1::1>>).type == "bitstring"
   end
 
   test "function" do
@@ -36,41 +36,39 @@ defmodule Appsignal.Utils.TypeTest do
   end
 
   test "float" do
-    assert Type.of(1.2) == "float"
+    assert Type.from(1.2).type == "float"
   end
 
   test "integer" do
-    assert Type.of(1) == "integer"
+    assert Type.from(1).type == "integer"
   end
 
   test "pid" do
-    assert '<0.0.0>'
-           |> :erlang.list_to_pid()
-           |> Type.of() == "pid"
+    assert Type.from(:erlang.list_to_pid('<0.0.0>')).type == "pid"
   end
 
   test "port" do
-    assert Type.of(Port.open({:spawn, "echo foo"}, [])) == "port"
+    assert Type.from(Port.open({:spawn, "echo foo"}, [])).type == "port"
   end
 
   test "reference" do
-    assert Type.of(make_ref()) == "reference"
+    assert Type.from(make_ref()).type == "reference"
   end
 
   test "empty tuple" do
-    assert Type.of({}) == "{}"
+    assert Type.from({}).type == "{}"
   end
 
   test "non-empty tuple" do
-    assert Type.of({:foo, "bar"}) == "{atom, binary}"
+    assert Type.from({:foo, "bar"}).type == "{atom, binary}"
   end
 
   test "empty list" do
-    assert Type.of([]) == "[]"
+    assert Type.from([]).type == "[]"
   end
 
   test "non-empty list" do
-    assert Type.of([:foo]) == "[atom]"
+    assert Type.from([:foo]).type == "[atom]"
   end
 
   test "keyword list" do
@@ -78,19 +76,19 @@ defmodule Appsignal.Utils.TypeTest do
   end
 
   test "empty map" do
-    assert Type.of(%{}) == "%{}"
+    assert Type.from(%{}).type == "%{}"
   end
 
   test "non-empty map" do
-    assert Type.of(%{foo: "bar"}) == "%{atom => binary}"
+    assert Type.from(%{foo: "bar"}).type == "%{atom => binary}"
   end
 
   test "empty struct" do
-    assert Type.of(%EmptyStruct{}) == "%EmptyStruct{}"
+    assert Type.from(%EmptyStruct{}).type == "%EmptyStruct{}"
   end
 
   test "non-empty struct" do
-    assert Type.of(%NonEmptyStruct{foo: 1}) == "%NonEmptyStruct{atom => integer}"
+    assert Type.from(%NonEmptyStruct{foo: 1}).type == "%NonEmptyStruct{atom => integer}"
   end
 
   test "inspect" do


### PR DESCRIPTION
Instead of stripping out arguments from exceptions like `UndefinedFunctionError`s, this patch replaces the arguments with their types where required.

For example, a string (like `”foo”`) is replaced with `binary`. Types like integers aren’t replaced, as they don’t pose a threat to expose sensitive data. For maps and structs, the values are stripped out, but their keys aren’t.

Closes https://github.com/appsignal/support/issues/221.

[skip blogpost]
