### PR TITLE
Add error_backend_enabled configuration option

### DIFF
--- a/.changesets/add-enable_error_backend-configuration-option.md
+++ b/.changesets/add-enable_error_backend-configuration-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add enable_error_backend configuration option

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -22,7 +22,10 @@ defmodule Appsignal do
 
     initialize()
 
-    Appsignal.Error.Backend.attach()
+    if Config.error_backend_enabled?() do
+      Appsignal.Error.Backend.attach()
+    end
+
     Appsignal.Ecto.attach()
     Appsignal.Finch.attach()
 

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -12,6 +12,7 @@ defmodule Appsignal.Config do
     enable_host_metrics: true,
     enable_minutely_probes: true,
     enable_statsd: false,
+    enable_error_backend: true,
     endpoint: "https://push.appsignal.com",
     env: :dev,
     files_world_accessible: true,
@@ -178,6 +179,13 @@ defmodule Appsignal.Config do
     end
   end
 
+  def error_backend_enabled? do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, value} -> !!value[:enable_error_backend]
+      _ -> true
+    end
+  end
+
   defp default_ca_file_path do
     Path.join(:code.priv_dir(:appsignal), "cacert.pem")
   end
@@ -222,6 +230,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_ENABLE_HOST_METRICS" => :enable_host_metrics,
     "APPSIGNAL_ENABLE_MINUTELY_PROBES" => :enable_minutely_probes,
     "APPSIGNAL_ENABLE_STATSD" => :enable_statsd,
+    "APPSIGNAL_ENABLE_ERROR_BACKEND" => :enable_error_backend,
     "APPSIGNAL_FILES_WORLD_ACCESSIBLE" => :files_world_accessible,
     "APPSIGNAL_FILTER_PARAMETERS" => :filter_parameters,
     "APPSIGNAL_FILTER_SESSION_DATA" => :filter_session_data,
@@ -261,7 +270,8 @@ defmodule Appsignal.Config do
     APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER
     APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SEND_SESSION_DATA APPSIGNAL_SKIP_SESSION_DATA
     APPSIGNAL_TRANSACTION_DEBUG_MODE APPSIGNAL_FILES_WORLD_ACCESSIBLE APPSIGNAL_SEND_PARAMS
-    APPSIGNAL_ENABLE_MINUTELY_PROBES APPSIGNAL_ENABLE_STATSD APPSIGNAL_SEND_ENVIRONMENT_METADATA
+    APPSIGNAL_ENABLE_MINUTELY_PROBES APPSIGNAL_ENABLE_STATSD APPSIGNAL_ENABLE_ERROR_BACKEND
+    APPSIGNAL_SEND_ENVIRONMENT_METADATA
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -14,8 +14,13 @@ defmodule Appsignal.Error.Backend do
 
   def attach do
     case Logger.add_backend(Appsignal.Error.Backend) do
-      {:error, error} -> Logger.warn("Appsignal.Error.Backend not attached to Logger: #{error}")
-      _ -> Appsignal.IntegrationLogger.debug("Appsignal.Error.Backend attached to Logger")
+      {:error, error} ->
+        Logger.warn("Appsignal.Error.Backend not attached to Logger: #{error}")
+        :error
+
+      _ ->
+        Appsignal.IntegrationLogger.debug("Appsignal.Error.Backend attached to Logger")
+        :ok
     end
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -282,6 +282,11 @@ defmodule Appsignal.ConfigTest do
       assert %{enable_statsd: true} = with_config(%{enable_statsd: true}, &init_config/0)
     end
 
+    test "enable_error_backend" do
+      assert %{enable_error_backend: false} =
+               with_config(%{enable_error_backend: false}, &init_config/0)
+    end
+
     test "endpoint" do
       assert %{endpoint: "https://push.staging.lol"} =
                with_config(%{endpoint: "https://push.staging.lol"}, &init_config/0)
@@ -542,6 +547,13 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_ENABLE_STATSD" => "true"},
                &init_config/0
              ) == default_configuration() |> Map.put(:enable_statsd, true)
+    end
+
+    test "enable_error_backend" do
+      assert with_env(
+               %{"APPSIGNAL_ENABLE_ERROR_BACKEND" => "false"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:enable_error_backend, false)
     end
 
     test "endpoint" do
@@ -1127,6 +1139,7 @@ defmodule Appsignal.ConfigTest do
       enable_host_metrics: true,
       enable_minutely_probes: true,
       enable_statsd: false,
+      enable_error_backend: true,
       endpoint: "https://push.appsignal.com",
       env: :dev,
       files_world_accessible: true,

--- a/test/appsignal/error/backend_test.exs
+++ b/test/appsignal/error/backend_test.exs
@@ -34,6 +34,7 @@ end
 defmodule Appsignal.Error.BackendTest do
   use ExUnit.Case
   alias Appsignal.{Error.Backend, Span, Test, Tracer}
+  import AppsignalTest.Utils
 
   setup do
     {:ok, _pid} = start_supervised(Test.Nif)
@@ -47,6 +48,13 @@ defmodule Appsignal.Error.BackendTest do
 
   test "is added as a Logger backend" do
     assert {:error, :already_present} = Logger.add_backend(Backend)
+  end
+
+  test "is not added as a Logger backend when disabled" do
+    Logger.remove_backend(Appsignal.Error.Backend)
+    with_config(%{enable_error_backend: false}, fn -> Appsignal.start([], []) end)
+
+    assert :ok = Appsignal.Error.Backend.attach()
   end
 
   describe "handle_event/3, when no span exists" do


### PR DESCRIPTION
In order to allow users to disable the error backend, which has now been replaced by our integrations, this patch adds a configuration option. By default, the backend is enabled, to not change the current functionality.

Users who get double or unneeded errors reported in the background namespace can disable the error backend. The error backend will be disabled by default in a future version before it's removed altogether in the next major release.

Part of https://github.com/appsignal/support/issues/222. 