### PR TITLE
Add Oban instrumentation

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -28,6 +28,7 @@ defmodule Appsignal do
 
     Appsignal.Ecto.attach()
     Appsignal.Finch.attach()
+    Appsignal.Oban.attach()
 
     children = [
       {Appsignal.Tracer, []},

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -43,7 +43,7 @@ defmodule Appsignal.Oban do
     span = @tracer.create_span("oban")
 
     span
-    |> @span.set_name(to_string(job.worker))
+    |> @span.set_name("#{to_string(job.worker)}#perform")
     |> @span.set_sample_data("params", job.args)
     |> @span.set_attribute("id", job.id)
     |> @span.set_attribute("queue", to_string(job.queue))

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -16,7 +16,7 @@ defmodule Appsignal.Oban do
       [:oban, :job, :exception] => &__MODULE__.oban_job_exception/4,
       [:oban, :engine, :insert_job, :start] => &__MODULE__.oban_insert_job_start/4,
       [:oban, :engine, :insert_job, :stop] => &__MODULE__.oban_insert_job_stop/4,
-      [:oban, :engine, :insert_job, :exception] => &__MODULE__.oban_insert_job_exception/4
+      [:oban, :engine, :insert_job, :exception] => &__MODULE__.oban_insert_job_stop/4
     }
 
     for {event, fun} <- handlers do
@@ -106,19 +106,7 @@ defmodule Appsignal.Oban do
     end
   end
 
-  def oban_insert_job_stop(_event, _measurements, metadata, _config) do
-    case metadata[:changeset] do
-      %{changes: %{worker: worker}} ->
-        @appsignal.increment_counter("oban_job_insert", 1, %{worker: to_string(worker)})
-
-      _ ->
-        nil
-    end
-
-    @tracer.close_span(@tracer.current_span())
-  end
-
-  def oban_insert_job_exception(_event, _measurements, _metadata, _config) do
+  def oban_insert_job_stop(_event, _measurements, _metadata, _config) do
     @tracer.close_span(@tracer.current_span())
   end
 

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -126,6 +126,7 @@ defmodule Appsignal.Oban do
   defp add_job_duration_value(job, duration, state) do
     tag_combinations = [
       %{worker: to_string(job.worker), state: to_string(state)},
+      %{worker: to_string(job.worker), hostname: Appsignal.Utils.Hostname.hostname()},
       %{worker: to_string(job.worker)}
     ]
 

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -55,8 +55,6 @@ defmodule Appsignal.Oban do
       @span.set_attribute(span, "job_tag_#{key}", value)
     end
 
-    increment_job_start_counter(job)
-
     add_job_queue_time_value(job)
   end
 
@@ -124,26 +122,16 @@ defmodule Appsignal.Oban do
     @tracer.close_span(@tracer.current_span())
   end
 
-  defp increment_job_start_counter(job) do
-    tag_combinations = [
-      %{worker: to_string(job.worker), queue: to_string(job.queue)},
-      %{worker: to_string(job.worker)},
-      %{queue: to_string(job.queue)}
-    ]
-
-    Enum.each(tag_combinations, fn tags ->
-      @appsignal.increment_counter("oban_job_start", 1, tags)
-    end)
-  end
-
   defp increment_job_stop_counter(job, state) do
     tag_combinations = [
+      %{worker: to_string(job.worker), queue: to_string(job.queue), state: to_string(state)},
       %{worker: to_string(job.worker), state: to_string(state)},
+      %{queue: to_string(job.queue), state: to_string(state)},
       %{state: to_string(state)}
     ]
 
     Enum.each(tag_combinations, fn tags ->
-      @appsignal.increment_counter("oban_job_stop", 1, tags)
+      @appsignal.increment_counter("oban_job_count", 1, tags)
     end)
   end
 

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -1,0 +1,170 @@
+defmodule Appsignal.Oban do
+  require Appsignal.Utils
+
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @appsignal Appsignal.Utils.compile_env(:appsignal, :appsignal, Appsignal)
+
+  @moduledoc false
+
+  require Logger
+
+  def attach do
+    handlers = %{
+      [:oban, :job, :start] => &__MODULE__.oban_job_start/4,
+      [:oban, :job, :stop] => &__MODULE__.oban_job_stop/4,
+      [:oban, :job, :exception] => &__MODULE__.oban_job_exception/4,
+      [:oban, :engine, :insert_job, :start] => &__MODULE__.oban_insert_job_start/4,
+      [:oban, :engine, :insert_job, :stop] => &__MODULE__.oban_insert_job_stop/4,
+      [:oban, :engine, :insert_job, :exception] => &__MODULE__.oban_insert_job_exception/4
+    }
+
+    for {event, fun} <- handlers do
+      case :telemetry.attach({__MODULE__, event}, event, fun, :ok) do
+        :ok ->
+          _ = Appsignal.IntegrationLogger.debug("Appsignal.Oban attached to #{inspect(event)}")
+
+          :ok
+
+        {:error, _} = error ->
+          Logger.warn("Appsignal.Oban not attached to #{inspect(event)}: #{inspect(error)}")
+
+          error
+      end
+    end
+  end
+
+  def oban_job_start(
+        _event,
+        _measurements,
+        %{job: job},
+        _config
+      ) do
+    span = @tracer.create_span("oban")
+
+    span
+    |> @span.set_name(to_string(job.worker))
+    |> @span.set_sample_data("params", job.args)
+    |> @span.set_attribute("id", job.id)
+    |> @span.set_attribute("queue", to_string(job.queue))
+    |> @span.set_attribute("attempt", job.attempt)
+    |> @span.set_attribute("priority", job.priority)
+    |> @span.set_attribute("appsignal:category", "job.oban")
+
+    for {key, value} <- job.tags do
+      @span.set_attribute(span, "job_tag_#{key}", value)
+    end
+
+    increment_job_start_counter(job)
+
+    add_job_queue_time_value(job)
+  end
+
+  def oban_job_stop(
+        _event,
+        %{duration: duration},
+        %{state: state, result: result, job: job},
+        _config
+      ) do
+    @tracer.current_span()
+    |> @span.set_attribute("state", to_string(state))
+    |> @span.set_attribute("result", inspect(result))
+    |> @tracer.close_span()
+
+    increment_job_stop_counter(job, state)
+
+    add_job_duration_value(job, duration, state)
+  end
+
+  def oban_job_exception(_event, %{duration: duration}, metadata, _config) do
+    span =
+      @tracer.current_span()
+      |> @span.set_attribute("state", to_string(metadata[:state]))
+      |> @span.set_attribute("worker", to_string(metadata[:job].worker))
+
+    if Map.has_key?(metadata, :kind) and Map.has_key?(metadata, :reason) and
+         Map.has_key?(metadata, :stacktrace) do
+      @span.add_error(span, metadata[:kind], metadata[:reason], metadata[:stacktrace])
+    end
+
+    @tracer.close_span(span)
+
+    increment_job_stop_counter(metadata[:job], metadata[:state])
+
+    add_job_duration_value(metadata[:job], duration, metadata[:state])
+  end
+
+  def oban_insert_job_start(_event, _measurements, metadata, _config) do
+    span = @tracer.create_span("oban", @tracer.current_span)
+
+    @span.set_attribute(span, "appsignal:category", "insert_job.oban")
+
+    changes = metadata[:changeset].changes
+
+    if changes[:worker] do
+      @span.set_name(span, "Insert job (#{changes[:worker]})")
+    else
+      @span.set_name(span, "Insert job")
+    end
+  end
+
+  def oban_insert_job_stop(_event, _measurements, metadata, _config) do
+    changes = metadata[:changeset].changes
+
+    if changes[:worker] do
+      @appsignal.increment_counter("oban_job_insert", 1, %{worker: changes[:worker]})
+    end
+
+    @tracer.close_span(@tracer.current_span())
+  end
+
+  def oban_insert_job_exception(_event, _measurements, _metadata, _config) do
+    @tracer.close_span(@tracer.current_span())
+  end
+
+  defp increment_job_start_counter(job) do
+    tag_combinations = [
+      %{worker: to_string(job.worker), queue: to_string(job.queue)},
+      %{worker: to_string(job.worker)},
+      %{queue: to_string(job.queue)}
+    ]
+
+    Enum.each(tag_combinations, fn tags ->
+      @appsignal.increment_counter("oban_job_start", 1, tags)
+    end)
+  end
+
+  defp increment_job_stop_counter(job, state) do
+    tag_combinations = [
+      %{worker: to_string(job.worker), state: to_string(state)},
+      %{state: to_string(state)}
+    ]
+
+    Enum.each(tag_combinations, fn tags ->
+      @appsignal.increment_counter("oban_job_stop", 1, tags)
+    end)
+  end
+
+  defp add_job_duration_value(job, duration, state) do
+    tag_combinations = [
+      %{worker: to_string(job.worker), state: to_string(state)},
+      %{worker: to_string(job.worker)}
+    ]
+
+    Enum.each(tag_combinations, fn tags ->
+      @appsignal.add_distribution_value(
+        "oban_job_duration",
+        System.convert_time_unit(duration, :native, :millisecond),
+        tags
+      )
+    end)
+  end
+
+  defp add_job_queue_time_value(job) do
+    delay = DateTime.diff(job.attempted_at, job.scheduled_at, :millisecond)
+
+    @appsignal.add_distribution_value("oban_job_queue_time", delay, %{
+      queue: to_string(job.queue)
+    })
+  end
+end

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -4,7 +4,6 @@ defmodule Appsignal.Probes.ErlangProbe do
   require Appsignal.Utils
 
   @appsignal Appsignal.Utils.compile_env(:appsignal, :appsignal, Appsignal)
-  @inet Appsignal.Utils.compile_env(:appsignal, :inet, :inet)
 
   def call(sample \\ nil) do
     next_sample = sample_schedulers()
@@ -120,18 +119,7 @@ defmodule Appsignal.Probes.ErlangProbe do
     @appsignal.set_gauge(
       name,
       value,
-      Map.merge(tags, %{hostname: hostname()})
+      Map.merge(tags, %{hostname: Appsignal.Utils.Hostname.hostname()})
     )
-  end
-
-  defp hostname do
-    case Application.fetch_env(:appsignal, :config) do
-      {:ok, %{hostname: hostname}} ->
-        hostname
-
-      _ ->
-        {:ok, hostname} = @inet.gethostname()
-        List.to_string(hostname)
-    end
   end
 end

--- a/lib/appsignal/utils/hostname.ex
+++ b/lib/appsignal/utils/hostname.ex
@@ -1,0 +1,18 @@
+defmodule Appsignal.Utils.Hostname do
+  @moduledoc false
+
+  require Appsignal.Utils
+
+  @inet Appsignal.Utils.compile_env(:appsignal, :inet, :inet)
+
+  def hostname do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, %{hostname: hostname}} ->
+        hostname
+
+      _ ->
+        {:ok, hostname} = @inet.gethostname()
+        List.to_string(hostname)
+    end
+  end
+end

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -237,37 +237,6 @@ defmodule Appsignal.ObanTest do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
     end
 
-    test "increments job insert counter" do
-      assert [
-               %{key: _, value: 1, tags: %{worker: "Test.Worker"}}
-             ] = FakeAppsignal.get_counters("oban_job_insert")
-    end
-
-    test "does not detach the handler" do
-      assert attached?([:oban, :engine, :insert_job, :stop])
-    end
-  end
-
-  describe "oban_insert_job_stop/4, without a changeset" do
-    setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
-      execute_insert_job(:start, %{})
-
-      execute_insert_job(:stop, %{})
-    end
-
-    test "closes a span" do
-      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
-    end
-
-    test "does not increment job insert counter" do
-      assert [] = FakeAppsignal.get_counters("oban_job_insert")
-    end
-
     test "does not detach the handler" do
       assert attached?([:oban, :engine, :insert_job, :stop])
     end

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -98,6 +98,11 @@ defmodule Appsignal.ObanTest do
     test "adds job duration distribution value" do
       assert [
                %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{
+                 key: _,
+                 value: 123,
+                 tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
+               },
                %{key: _, value: 123, tags: %{state: "success", worker: "Test.Worker"}}
              ] = FakeAppsignal.get_distribution_values("oban_job_duration")
     end
@@ -156,6 +161,11 @@ defmodule Appsignal.ObanTest do
     test "adds job duration distribution value" do
       assert [
                %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{
+                 key: _,
+                 value: 123,
+                 tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
+               },
                %{key: _, value: 123, tags: %{state: "success", worker: "Test.Worker"}}
              ] = FakeAppsignal.get_distribution_values("oban_job_duration")
     end

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -1,0 +1,381 @@
+defmodule Appsignal.ObanTest do
+  use ExUnit.Case
+  alias Appsignal.{FakeAppsignal, Span, Test}
+
+  test "attaches to Oban events automatically" do
+    assert attached?([:oban, :job, :start])
+    assert attached?([:oban, :job, :stop])
+    assert attached?([:oban, :job, :exception])
+    assert attached?([:oban, :engine, :insert_job, :start])
+    assert attached?([:oban, :engine, :insert_job, :stop])
+    assert attached?([:oban, :engine, :insert_job, :exception])
+  end
+
+  describe "oban_job_start/4" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+
+      execute_job_start()
+    end
+
+    test "creates a span" do
+      assert {:ok, [{"oban"}]} = Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "Test.Worker"}]} = Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert attribute?("appsignal:category", "job.oban")
+    end
+
+    test "sets job arguments as span params" do
+      assert {:ok, [{%Span{}, "params", %{foo: "bar"}}]} = Test.Span.get(:set_sample_data)
+    end
+
+    test "sets job attributes as span tags" do
+      assert attribute?("id", 123)
+      assert attribute?("queue", "default")
+      assert attribute?("attempt", 1)
+      assert attribute?("priority", 0)
+    end
+
+    test "sets job tags as span tags" do
+      assert attribute?("job_tag_foo", "bar")
+      assert attribute?("job_tag_baz", 123)
+    end
+
+    test "increments job start counter" do
+      assert [
+               %{key: _, value: 1, tags: %{queue: "default"}},
+               %{key: _, value: 1, tags: %{worker: "Test.Worker"}},
+               %{key: _, value: 1, tags: %{queue: "default", worker: "Test.Worker"}}
+             ] = FakeAppsignal.get_counters("oban_job_start")
+    end
+
+    test "adds job queue time distribution value" do
+      assert [
+               %{key: _, value: 3000, tags: %{queue: "default"}}
+             ] = FakeAppsignal.get_distribution_values("oban_job_queue_time")
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :job, :start])
+    end
+  end
+
+  describe "oban_job_stop/4" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+      execute_job_start()
+
+      execute_job_stop()
+    end
+
+    test "closes a span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+
+    test "sets the job state and result as span tags" do
+      assert attribute?("state", "success")
+      assert attribute?("result", ":ok")
+    end
+
+    test "increments job stop counter" do
+      assert [
+               %{key: _, value: 1, tags: %{state: "success"}},
+               %{key: _, value: 1, tags: %{state: "success", worker: "Test.Worker"}}
+             ] = FakeAppsignal.get_counters("oban_job_stop")
+    end
+
+    test "adds job duration distribution value" do
+      assert [
+               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{key: _, value: 123, tags: %{state: "success", worker: "Test.Worker"}}
+             ] = FakeAppsignal.get_distribution_values("oban_job_duration")
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :job, :stop])
+    end
+  end
+
+  describe "oban_job_exception/4" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+      execute_job_start()
+
+      execute_job_exception()
+    end
+
+    test "closes a span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+
+    test "sets the job state and worker as span tags" do
+      assert attribute?("state", "success")
+      assert attribute?("worker", "Test.Worker")
+    end
+
+    test "adds the error to the span" do
+      assert {:ok,
+              [
+                {
+                  %Span{},
+                  :error,
+                  %RuntimeError{message: "Exception!"},
+                  [{Appsignal.ObanTest, :execute_job_exception, _, _} | _]
+                }
+              ]} = Test.Span.get(:add_error)
+    end
+
+    test "increments job stop counter" do
+      assert [
+               %{key: _, value: 1, tags: %{state: "success"}},
+               %{key: _, value: 1, tags: %{state: "success", worker: "Test.Worker"}}
+             ] = FakeAppsignal.get_counters("oban_job_stop")
+    end
+
+    test "adds job duration distribution value" do
+      assert [
+               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{key: _, value: 123, tags: %{state: "success", worker: "Test.Worker"}}
+             ] = FakeAppsignal.get_distribution_values("oban_job_duration")
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :job, :exception])
+    end
+  end
+
+  describe "oban_insert_job_start/4" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+
+      execute_insert_job(:start)
+    end
+
+    test "creates a child span" do
+      assert {:ok, [{"oban", nil}]} = Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "Insert job (Test.Worker)"}]} = Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert attribute?("appsignal:category", "insert_job.oban")
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :engine, :insert_job, :start])
+    end
+  end
+
+  describe "oban_insert_job_start/4, without a changeset" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+
+      execute_insert_job(:start, %{})
+    end
+
+    test "creates a child span" do
+      assert {:ok, [{"oban", nil}]} = Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "Insert job"}]} = Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert attribute?("appsignal:category", "insert_job.oban")
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :engine, :insert_job, :start])
+    end
+  end
+
+  describe "oban_insert_job_stop/4" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+      execute_insert_job(:start)
+
+      execute_insert_job(:stop)
+    end
+
+    test "closes a span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+
+    test "increments job insert counter" do
+      assert [
+               %{key: _, value: 1, tags: %{worker: "Test.Worker"}}
+             ] = FakeAppsignal.get_counters("oban_job_insert")
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :engine, :insert_job, :stop])
+    end
+  end
+
+  describe "oban_insert_job_stop/4, without a changeset" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+      execute_insert_job(:start, %{})
+
+      execute_insert_job(:stop, %{})
+    end
+
+    test "closes a span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+
+    test "does not increment job insert counter" do
+      assert [] = FakeAppsignal.get_counters("oban_job_insert")
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :engine, :insert_job, :stop])
+    end
+  end
+
+  describe "oban_insert_job_exception/4" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+      execute_insert_job(:start)
+
+      execute_insert_job(:exception)
+    end
+
+    test "closes a span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :engine, :insert_job, :exception])
+    end
+  end
+
+  defp attribute?(asserted_key, asserted_data) do
+    {:ok, attributes} = Test.Span.get(:set_attribute)
+
+    Enum.any?(attributes, fn {%Span{}, key, data} ->
+      key == asserted_key and data == asserted_data
+    end)
+  end
+
+  defp attached?(event) do
+    event
+    |> :telemetry.list_handlers()
+    |> Enum.any?(fn %{id: id} ->
+      id == {Appsignal.Oban, event}
+    end)
+  end
+
+  defp execute_job_start do
+    :telemetry.execute(
+      [:oban, :job, :start],
+      %{},
+      %{
+        job: sample_job()
+      }
+    )
+  end
+
+  defp execute_insert_job(phase, changeset \\ sample_changeset()) do
+    :telemetry.execute(
+      [:oban, :engine, :insert_job, phase],
+      %{},
+      %{
+        changeset: changeset
+      }
+    )
+  end
+
+  defp execute_job_stop do
+    :telemetry.execute(
+      [:oban, :job, :stop],
+      %{duration: 123 * 1_000_000},
+      %{
+        job: sample_job(),
+        state: :success,
+        result: :ok
+      }
+    )
+  end
+
+  defp execute_job_exception do
+    try do
+      raise "Exception!"
+    catch
+      kind, reason ->
+        :telemetry.execute(
+          [:oban, :job, :exception],
+          %{duration: 123 * 1_000_000},
+          %{
+            job: sample_job(),
+            state: :success,
+            kind: kind,
+            reason: reason,
+            stacktrace: __STACKTRACE__
+          }
+        )
+    end
+  end
+
+  defp sample_job do
+    %{
+      worker: :"Test.Worker",
+      args: %{foo: "bar"},
+      id: 123,
+      queue: :default,
+      attempt: 1,
+      priority: 0,
+      tags: [foo: "bar", baz: 123],
+      scheduled_at: DateTime.from_unix!(1_234_000_000),
+      attempted_at: DateTime.from_unix!(1_234_000_003)
+    }
+  end
+
+  defp sample_changeset do
+    %{
+      changes: %{
+        worker: :"Test.Worker"
+      }
+    }
+  end
+end

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -27,7 +27,7 @@ defmodule Appsignal.ObanTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "Test.Worker"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "Test.Worker#perform"}]} = Test.Span.get(:set_name)
     end
 
     test "sets the span's category" do

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -50,14 +50,6 @@ defmodule Appsignal.ObanTest do
       assert attribute?("job_tag_baz", 123)
     end
 
-    test "increments job start counter" do
-      assert [
-               %{key: _, value: 1, tags: %{queue: "default"}},
-               %{key: _, value: 1, tags: %{worker: "Test.Worker"}},
-               %{key: _, value: 1, tags: %{queue: "default", worker: "Test.Worker"}}
-             ] = FakeAppsignal.get_counters("oban_job_start")
-    end
-
     test "adds job queue time distribution value" do
       assert [
                %{key: _, value: 3000, tags: %{queue: "default"}}
@@ -93,8 +85,14 @@ defmodule Appsignal.ObanTest do
     test "increments job stop counter" do
       assert [
                %{key: _, value: 1, tags: %{state: "success"}},
-               %{key: _, value: 1, tags: %{state: "success", worker: "Test.Worker"}}
-             ] = FakeAppsignal.get_counters("oban_job_stop")
+               %{key: _, value: 1, tags: %{state: "success", queue: "default"}},
+               %{key: _, value: 1, tags: %{state: "success", worker: "Test.Worker"}},
+               %{
+                 key: _,
+                 value: 1,
+                 tags: %{state: "success", worker: "Test.Worker", queue: "default"}
+               }
+             ] = FakeAppsignal.get_counters("oban_job_count")
     end
 
     test "adds job duration distribution value" do
@@ -145,8 +143,14 @@ defmodule Appsignal.ObanTest do
     test "increments job stop counter" do
       assert [
                %{key: _, value: 1, tags: %{state: "success"}},
-               %{key: _, value: 1, tags: %{state: "success", worker: "Test.Worker"}}
-             ] = FakeAppsignal.get_counters("oban_job_stop")
+               %{key: _, value: 1, tags: %{state: "success", queue: "default"}},
+               %{key: _, value: 1, tags: %{state: "success", worker: "Test.Worker"}},
+               %{
+                 key: _,
+                 value: 1,
+                 tags: %{state: "success", worker: "Test.Worker", queue: "default"}
+               }
+             ] = FakeAppsignal.get_counters("oban_job_count")
     end
 
     test "adds job duration distribution value" do

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -17,11 +17,9 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      fake_appsignal = start_supervised!(FakeAppsignal)
+      start_supervised!(FakeAppsignal)
 
       execute_job_start()
-
-      [fake_appsignal: fake_appsignal]
     end
 
     test "creates a span" do
@@ -42,24 +40,66 @@ defmodule Appsignal.ObanTest do
 
     test "sets job attributes as span tags" do
       assert attribute?("id", 123)
+      assert attribute?("worker", "Test.Worker")
       assert attribute?("queue", "default")
       assert attribute?("attempt", 1)
-      assert attribute?("priority", 0)
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:oban, :job, :start])
+    end
+  end
+
+  describe "oban_job_start/4, with a :tags metadata key (v2.1.0)" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+
+      execute_job_start(%{
+        tags: ["foo", "bar"]
+      })
     end
 
     test "sets job tags as span tags" do
-      assert attribute?("job_tag_foo", "bar")
-      assert attribute?("job_tag_baz", 123)
+      assert attribute?("job_tag_foo", true)
+      assert attribute?("job_tag_bar", true)
+    end
+  end
+
+  describe "oban_job_start/4, with a :job metadata key (v2.3.1)" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      execute_job_start(%{
+        job: sample_job()
+      })
+
+      [fake_appsignal: fake_appsignal]
+    end
+
+    test "sets job priority as a span tag" do
+      assert attribute?("priority", 0)
+    end
+
+    test "sets job meta as span tags" do
+      assert attribute?("job_meta_number", 123)
+      assert attribute?("job_meta_string", "foo")
+      assert attribute?("job_meta_atom", ":bar")
+      assert attribute?("job_meta_boolean", true)
+      assert !has_attribute?("job_meta_other")
     end
 
     test "adds job queue time distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
                %{key: _, value: 3000, tags: %{queue: "default"}}
              ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_queue_time")
-    end
-
-    test "does not detach the handler" do
-      assert attached?([:oban, :job, :start])
     end
   end
 
@@ -82,9 +122,8 @@ defmodule Appsignal.ObanTest do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
     end
 
-    test "sets the job state and result as span tags" do
+    test "sets the state attribute to success" do
       assert attribute?("state", "success")
-      assert attribute?("result", ":ok")
     end
 
     test "increments job stop counter", %{fake_appsignal: fake_appsignal} do
@@ -117,6 +156,73 @@ defmodule Appsignal.ObanTest do
     end
   end
 
+  describe "oban_job_stop/4, with a :state metadata key (v2.4.0)" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      execute_job_start()
+
+      execute_job_stop(%{
+        state: "snoozed"
+      })
+
+      [fake_appsignal: fake_appsignal]
+    end
+
+    test "sets the state attribute" do
+      assert attribute?("state", "snoozed")
+    end
+
+    test "increments job stop counter", %{fake_appsignal: fake_appsignal} do
+      assert [
+               %{key: _, value: 1, tags: %{state: "snoozed"}},
+               %{key: _, value: 1, tags: %{state: "snoozed", queue: "default"}},
+               %{key: _, value: 1, tags: %{state: "snoozed", worker: "Test.Worker"}},
+               %{
+                 key: _,
+                 value: 1,
+                 tags: %{state: "snoozed", worker: "Test.Worker", queue: "default"}
+               }
+             ] = FakeAppsignal.get_counters(fake_appsignal, "oban_job_count")
+    end
+
+    test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
+      assert [
+               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{
+                 key: _,
+                 value: 123,
+                 tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
+               },
+               %{key: _, value: 123, tags: %{state: "snoozed", worker: "Test.Worker"}}
+             ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
+    end
+  end
+
+  describe "oban_job_stop/4, with a :result metadata key (v2.5.0)" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      start_supervised!(FakeAppsignal)
+
+      execute_job_start()
+
+      execute_job_stop(%{
+        result: {:ok, 42}
+      })
+    end
+
+    test "sets the result attribute" do
+      assert attribute?("result", "{:ok, 42}")
+    end
+  end
+
   describe "oban_job_exception/4" do
     setup do
       start_supervised!(Test.Nif)
@@ -136,9 +242,8 @@ defmodule Appsignal.ObanTest do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
     end
 
-    test "sets the job state and worker as span tags" do
-      assert attribute?("state", "success")
-      assert attribute?("worker", "Test.Worker")
+    test "sets the state attribute to failure" do
+      assert attribute?("state", "failure")
     end
 
     test "adds the error to the span" do
@@ -155,13 +260,13 @@ defmodule Appsignal.ObanTest do
 
     test "increments job stop counter", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: _, value: 1, tags: %{state: "success"}},
-               %{key: _, value: 1, tags: %{state: "success", queue: "default"}},
-               %{key: _, value: 1, tags: %{state: "success", worker: "Test.Worker"}},
+               %{key: _, value: 1, tags: %{state: "failure"}},
+               %{key: _, value: 1, tags: %{state: "failure", queue: "default"}},
+               %{key: _, value: 1, tags: %{state: "failure", worker: "Test.Worker"}},
                %{
                  key: _,
                  value: 1,
-                 tags: %{state: "success", worker: "Test.Worker", queue: "default"}
+                 tags: %{state: "failure", worker: "Test.Worker", queue: "default"}
                }
              ] = FakeAppsignal.get_counters(fake_appsignal, "oban_job_count")
     end
@@ -174,12 +279,59 @@ defmodule Appsignal.ObanTest do
                  value: 123,
                  tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
                },
-               %{key: _, value: 123, tags: %{state: "success", worker: "Test.Worker"}}
+               %{key: _, value: 123, tags: %{state: "failure", worker: "Test.Worker"}}
              ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
 
     test "does not detach the handler" do
       assert attached?([:oban, :job, :exception])
+    end
+  end
+
+  describe "oban_job_exception/4, with a :state metadata key (v2.4.0)" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      execute_job_start()
+
+      execute_job_exception(%{
+        state: "discard"
+      })
+
+      [fake_appsignal: fake_appsignal]
+    end
+
+    test "sets the state attribute to the job's state" do
+      assert attribute?("state", "discard")
+    end
+
+    test "increments job stop counter", %{fake_appsignal: fake_appsignal} do
+      assert [
+               %{key: _, value: 1, tags: %{state: "discard"}},
+               %{key: _, value: 1, tags: %{state: "discard", queue: "default"}},
+               %{key: _, value: 1, tags: %{state: "discard", worker: "Test.Worker"}},
+               %{
+                 key: _,
+                 value: 1,
+                 tags: %{state: "discard", worker: "Test.Worker", queue: "default"}
+               }
+             ] = FakeAppsignal.get_counters(fake_appsignal, "oban_job_count")
+    end
+
+    test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
+      assert [
+               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{
+                 key: _,
+                 value: 123,
+                 tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
+               },
+               %{key: _, value: 123, tags: %{state: "discard", worker: "Test.Worker"}}
+             ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
   end
 
@@ -221,16 +373,8 @@ defmodule Appsignal.ObanTest do
       execute_insert_job(:start, %{})
     end
 
-    test "creates a child span" do
-      assert {:ok, [{"oban", nil}]} = Test.Tracer.get(:create_span)
-    end
-
-    test "sets the span's name" do
+    test "sets the span's name without the worker" do
       assert {:ok, [{%Span{}, "Insert job"}]} = Test.Span.get(:set_name)
-    end
-
-    test "sets the span's category" do
-      assert attribute?("appsignal:category", "insert_job.oban")
     end
 
     test "does not detach the handler" do
@@ -238,7 +382,7 @@ defmodule Appsignal.ObanTest do
     end
   end
 
-  describe "oban_insert_job_stop/4" do
+  describe "oban_insert_job_stop/4 and oban_insert_job_exception/4" do
     setup do
       start_supervised!(Test.Nif)
       start_supervised!(Test.Tracer)
@@ -249,24 +393,6 @@ defmodule Appsignal.ObanTest do
       execute_insert_job(:start)
 
       execute_insert_job(:stop)
-    end
-
-    test "closes a span" do
-      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
-    end
-
-    test "does not detach the handler" do
-      assert attached?([:oban, :engine, :insert_job, :stop])
-    end
-  end
-
-  describe "oban_insert_job_exception/4" do
-    setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
 
       execute_insert_job(:start)
 
@@ -274,10 +400,11 @@ defmodule Appsignal.ObanTest do
     end
 
     test "closes a span" do
-      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+      assert {:ok, [{%Span{}}, {%Span{}}]} = Test.Tracer.get(:close_span)
     end
 
     test "does not detach the handler" do
+      assert attached?([:oban, :engine, :insert_job, :stop])
       assert attached?([:oban, :engine, :insert_job, :exception])
     end
   end
@@ -290,6 +417,14 @@ defmodule Appsignal.ObanTest do
     end)
   end
 
+  defp has_attribute?(asserted_key) do
+    {:ok, attributes} = Test.Span.get(:set_attribute)
+
+    Enum.any?(attributes, fn {%Span{}, key, data} ->
+      key == asserted_key
+    end)
+  end
+
   defp attached?(event) do
     event
     |> :telemetry.list_handlers()
@@ -298,14 +433,40 @@ defmodule Appsignal.ObanTest do
     end)
   end
 
-  defp execute_job_start do
+  defp execute_job_start(additional_metadata \\ %{}) do
     :telemetry.execute(
       [:oban, :job, :start],
       %{},
-      %{
-        job: sample_job()
-      }
+      Map.merge(sample_metadata(), additional_metadata)
     )
+  end
+
+  defp execute_job_stop(additional_metadata \\ %{}) do
+    :telemetry.execute(
+      [:oban, :job, :stop],
+      %{duration: 123 * 1_000_000},
+      Map.merge(sample_metadata(), additional_metadata)
+    )
+  end
+
+  defp execute_job_exception(additional_metadata \\ %{}) do
+    try do
+      raise "Exception!"
+    catch
+      kind, reason ->
+        metadata =
+          Map.merge(sample_metadata(), %{
+            kind: kind,
+            error: reason,
+            stacktrace: __STACKTRACE__
+          })
+
+        :telemetry.execute(
+          [:oban, :job, :exception],
+          %{duration: 123 * 1_000_000},
+          Map.merge(metadata, additional_metadata)
+        )
+    end
   end
 
   defp execute_insert_job(phase, changeset \\ sample_changeset()) do
@@ -318,48 +479,28 @@ defmodule Appsignal.ObanTest do
     )
   end
 
-  defp execute_job_stop do
-    :telemetry.execute(
-      [:oban, :job, :stop],
-      %{duration: 123 * 1_000_000},
-      %{
-        job: sample_job(),
-        state: :success,
-        result: :ok
-      }
-    )
-  end
-
-  defp execute_job_exception do
-    try do
-      raise "Exception!"
-    catch
-      kind, reason ->
-        :telemetry.execute(
-          [:oban, :job, :exception],
-          %{duration: 123 * 1_000_000},
-          %{
-            job: sample_job(),
-            state: :success,
-            kind: kind,
-            reason: reason,
-            stacktrace: __STACKTRACE__
-          }
-        )
-    end
-  end
-
-  defp sample_job do
+  defp sample_metadata do
     %{
       worker: :"Test.Worker",
       args: %{foo: "bar"},
       id: 123,
       queue: :default,
-      attempt: 1,
+      attempt: 1
+    }
+  end
+
+  defp sample_job do
+    %{
       priority: 0,
-      tags: [foo: "bar", baz: 123],
       scheduled_at: DateTime.from_unix!(1_234_000_000),
-      attempted_at: DateTime.from_unix!(1_234_000_003)
+      attempted_at: DateTime.from_unix!(1_234_000_003),
+      meta: %{
+        number: 123,
+        string: "foo",
+        atom: :bar,
+        boolean: true,
+        other: [:ignore, :me]
+      }
     }
   end
 

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -17,9 +17,11 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
+      fake_appsignal = start_supervised!(FakeAppsignal)
 
       execute_job_start()
+
+      [fake_appsignal: fake_appsignal]
     end
 
     test "creates a span" do
@@ -50,10 +52,10 @@ defmodule Appsignal.ObanTest do
       assert attribute?("job_tag_baz", 123)
     end
 
-    test "adds job queue time distribution value" do
+    test "adds job queue time distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
                %{key: _, value: 3000, tags: %{queue: "default"}}
-             ] = FakeAppsignal.get_distribution_values("oban_job_queue_time")
+             ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_queue_time")
     end
 
     test "does not detach the handler" do
@@ -67,10 +69,13 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
       execute_job_start()
 
       execute_job_stop()
+
+      [fake_appsignal: fake_appsignal]
     end
 
     test "closes a span" do
@@ -82,7 +87,7 @@ defmodule Appsignal.ObanTest do
       assert attribute?("result", ":ok")
     end
 
-    test "increments job stop counter" do
+    test "increments job stop counter", %{fake_appsignal: fake_appsignal} do
       assert [
                %{key: _, value: 1, tags: %{state: "success"}},
                %{key: _, value: 1, tags: %{state: "success", queue: "default"}},
@@ -92,10 +97,10 @@ defmodule Appsignal.ObanTest do
                  value: 1,
                  tags: %{state: "success", worker: "Test.Worker", queue: "default"}
                }
-             ] = FakeAppsignal.get_counters("oban_job_count")
+             ] = FakeAppsignal.get_counters(fake_appsignal, "oban_job_count")
     end
 
-    test "adds job duration distribution value" do
+    test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
                %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
                %{
@@ -104,7 +109,7 @@ defmodule Appsignal.ObanTest do
                  tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
                },
                %{key: _, value: 123, tags: %{state: "success", worker: "Test.Worker"}}
-             ] = FakeAppsignal.get_distribution_values("oban_job_duration")
+             ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
 
     test "does not detach the handler" do
@@ -118,10 +123,13 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
       execute_job_start()
 
       execute_job_exception()
+
+      [fake_appsignal: fake_appsignal]
     end
 
     test "closes a span" do
@@ -145,7 +153,7 @@ defmodule Appsignal.ObanTest do
               ]} = Test.Span.get(:add_error)
     end
 
-    test "increments job stop counter" do
+    test "increments job stop counter", %{fake_appsignal: fake_appsignal} do
       assert [
                %{key: _, value: 1, tags: %{state: "success"}},
                %{key: _, value: 1, tags: %{state: "success", queue: "default"}},
@@ -155,10 +163,10 @@ defmodule Appsignal.ObanTest do
                  value: 1,
                  tags: %{state: "success", worker: "Test.Worker", queue: "default"}
                }
-             ] = FakeAppsignal.get_counters("oban_job_count")
+             ] = FakeAppsignal.get_counters(fake_appsignal, "oban_job_count")
     end
 
-    test "adds job duration distribution value" do
+    test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
                %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
                %{
@@ -167,7 +175,7 @@ defmodule Appsignal.ObanTest do
                  tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
                },
                %{key: _, value: 123, tags: %{state: "success", worker: "Test.Worker"}}
-             ] = FakeAppsignal.get_distribution_values("oban_job_duration")
+             ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
 
     test "does not detach the handler" do
@@ -181,7 +189,6 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
 
       execute_insert_job(:start)
     end
@@ -238,6 +245,7 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
       start_supervised!(FakeAppsignal)
+
       execute_insert_job(:start)
 
       execute_insert_job(:stop)
@@ -259,6 +267,7 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
       start_supervised!(FakeAppsignal)
+
       execute_insert_job(:start)
 
       execute_insert_job(:exception)

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -8,7 +8,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
     # from this test
     Appsignal.Probes.unregister(:erlang)
 
-    [fake_appsignal: start_supervised!(FakeAppsignal)]
+    start_supervised!(FakeAppsignal)
+    :ok
   end
 
   describe "when invoked by the scheduler" do
@@ -20,16 +21,16 @@ defmodule Appsignal.Probes.ErlangProbeTest do
       end)
     end
 
-    test "gathers any metrics", %{fake_appsignal: fake_appsignal} do
+    test "gathers any metrics" do
       until(fn ->
-        metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
+        metrics = FakeAppsignal.get_gauges("erlang_io")
         refute Enum.empty?(metrics)
       end)
     end
 
-    test "gathers metrics using previous sample", %{fake_appsignal: fake_appsignal} do
+    test "gathers metrics using previous sample" do
       until(fn ->
-        metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
+        metrics = FakeAppsignal.get_gauges("erlang_scheduler_utilization")
         refute Enum.empty?(metrics)
       end)
     end
@@ -40,8 +41,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
       [sample: ErlangProbe.call()]
     end
 
-    test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
+    test "gathers IO metrics" do
+      metrics = FakeAppsignal.get_gauges("erlang_io")
 
       assert Enum.any?(
                metrics,
@@ -68,8 +69,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers scheduler metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_schedulers")
+    test "gathers scheduler metrics" do
+      metrics = FakeAppsignal.get_gauges("erlang_schedulers")
 
       assert Enum.any?(
                metrics,
@@ -96,8 +97,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers process metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_processes")
+    test "gathers process metrics" do
+      metrics = FakeAppsignal.get_gauges("erlang_processes")
 
       assert Enum.any?(
                metrics,
@@ -124,8 +125,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers memory metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_memory")
+    test "gathers memory metrics" do
+      metrics = FakeAppsignal.get_gauges("erlang_memory")
 
       assert Enum.any?(
                metrics,
@@ -236,8 +237,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers atom metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_atoms")
+    test "gathers atom metrics" do
+      metrics = FakeAppsignal.get_gauges("erlang_atoms")
 
       assert Enum.any?(
                metrics,
@@ -264,8 +265,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers run queue lengths", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "total_run_queue_lengths")
+    test "gathers run queue lengths" do
+      metrics = FakeAppsignal.get_gauges("total_run_queue_lengths")
 
       assert Enum.any?(
                metrics,
@@ -304,21 +305,16 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "does not gather scheduler utilization metrics on the first run", %{
-      fake_appsignal: fake_appsignal
-    } do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
+    test "does not gather scheduler utilization metrics on the first run" do
+      metrics = FakeAppsignal.get_gauges("erlang_scheduler_utilization")
 
       assert Enum.empty?(metrics)
     end
 
-    test "gathers scheduler utilization metrics on subsequent runs", %{
-      fake_appsignal: fake_appsignal,
-      sample: sample
-    } do
+    test "gathers scheduler utilization metrics on subsequent runs", %{sample: sample} do
       ErlangProbe.call(sample)
 
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
+      metrics = FakeAppsignal.get_gauges("erlang_scheduler_utilization")
 
       scheduler_ids = Enum.to_list(1..:erlang.system_info(:schedulers))
 
@@ -344,11 +340,11 @@ defmodule Appsignal.Probes.ErlangProbeTest do
   end
 
   describe "call/0, with a configured hostname" do
-    test "adds the configured hostname as a tag", %{fake_appsignal: fake_appsignal} do
+    test "adds the configured hostname as a tag" do
       with_config(%{hostname: "Alices-MBP.example.com"}, &ErlangProbe.call/0)
 
       assert [%{tags: %{hostname: "Alices-MBP.example.com"}} | _] =
-               FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
+               FakeAppsignal.get_gauges("erlang_io")
     end
   end
 end

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -8,8 +8,7 @@ defmodule Appsignal.Probes.ErlangProbeTest do
     # from this test
     Appsignal.Probes.unregister(:erlang)
 
-    start_supervised!(FakeAppsignal)
-    :ok
+    [fake_appsignal: start_supervised!(FakeAppsignal)]
   end
 
   describe "when invoked by the scheduler" do
@@ -21,16 +20,16 @@ defmodule Appsignal.Probes.ErlangProbeTest do
       end)
     end
 
-    test "gathers any metrics" do
+    test "gathers any metrics", %{fake_appsignal: fake_appsignal} do
       until(fn ->
-        metrics = FakeAppsignal.get_gauges("erlang_io")
+        metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
         refute Enum.empty?(metrics)
       end)
     end
 
-    test "gathers metrics using previous sample" do
+    test "gathers metrics using previous sample", %{fake_appsignal: fake_appsignal} do
       until(fn ->
-        metrics = FakeAppsignal.get_gauges("erlang_scheduler_utilization")
+        metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
         refute Enum.empty?(metrics)
       end)
     end
@@ -41,8 +40,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
       [sample: ErlangProbe.call()]
     end
 
-    test "gathers IO metrics" do
-      metrics = FakeAppsignal.get_gauges("erlang_io")
+    test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
 
       assert Enum.any?(
                metrics,
@@ -69,8 +68,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers scheduler metrics" do
-      metrics = FakeAppsignal.get_gauges("erlang_schedulers")
+    test "gathers scheduler metrics", %{fake_appsignal: fake_appsignal} do
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_schedulers")
 
       assert Enum.any?(
                metrics,
@@ -97,8 +96,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers process metrics" do
-      metrics = FakeAppsignal.get_gauges("erlang_processes")
+    test "gathers process metrics", %{fake_appsignal: fake_appsignal} do
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_processes")
 
       assert Enum.any?(
                metrics,
@@ -125,8 +124,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers memory metrics" do
-      metrics = FakeAppsignal.get_gauges("erlang_memory")
+    test "gathers memory metrics", %{fake_appsignal: fake_appsignal} do
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_memory")
 
       assert Enum.any?(
                metrics,
@@ -237,8 +236,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers atom metrics" do
-      metrics = FakeAppsignal.get_gauges("erlang_atoms")
+    test "gathers atom metrics", %{fake_appsignal: fake_appsignal} do
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_atoms")
 
       assert Enum.any?(
                metrics,
@@ -265,8 +264,8 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "gathers run queue lengths" do
-      metrics = FakeAppsignal.get_gauges("total_run_queue_lengths")
+    test "gathers run queue lengths", %{fake_appsignal: fake_appsignal} do
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "total_run_queue_lengths")
 
       assert Enum.any?(
                metrics,
@@ -305,16 +304,21 @@ defmodule Appsignal.Probes.ErlangProbeTest do
              )
     end
 
-    test "does not gather scheduler utilization metrics on the first run" do
-      metrics = FakeAppsignal.get_gauges("erlang_scheduler_utilization")
+    test "does not gather scheduler utilization metrics on the first run", %{
+      fake_appsignal: fake_appsignal
+    } do
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
 
       assert Enum.empty?(metrics)
     end
 
-    test "gathers scheduler utilization metrics on subsequent runs", %{sample: sample} do
+    test "gathers scheduler utilization metrics on subsequent runs", %{
+      fake_appsignal: fake_appsignal,
+      sample: sample
+    } do
       ErlangProbe.call(sample)
 
-      metrics = FakeAppsignal.get_gauges("erlang_scheduler_utilization")
+      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
 
       scheduler_ids = Enum.to_list(1..:erlang.system_info(:schedulers))
 
@@ -340,11 +344,11 @@ defmodule Appsignal.Probes.ErlangProbeTest do
   end
 
   describe "call/0, with a configured hostname" do
-    test "adds the configured hostname as a tag" do
+    test "adds the configured hostname as a tag", %{fake_appsignal: fake_appsignal} do
       with_config(%{hostname: "Alices-MBP.example.com"}, &ErlangProbe.call/0)
 
       assert [%{tags: %{hostname: "Alices-MBP.example.com"}} | _] =
-               FakeAppsignal.get_gauges("erlang_io")
+               FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
     end
   end
 end

--- a/test/support/appsignal/fake_appsignal.ex
+++ b/test/support/appsignal/fake_appsignal.ex
@@ -1,29 +1,45 @@
 defmodule Appsignal.FakeAppsignal do
   use TestAgent, %{
-    gauges: []
+    gauges: [],
+    counters: [],
+    distribution_values: []
   }
 
+  def add_distribution_value(key, value, tags \\ %{}) do
+    add(:distribution_values, %{key: key, value: value, tags: tags})
+  end
+
+  def increment_counter(key, value \\ 1, tags \\ %{}) do
+    add(:counters, %{key: key, value: value, tags: tags})
+  end
+
   def set_gauge(key, value, tags \\ %{}) do
-    if alive?() do
-      Agent.update(__MODULE__, fn state ->
-        {_, new_state} =
-          Map.get_and_update(state, :gauges, fn current ->
-            gauge = %{key: key, value: value, tags: tags}
+    add(:gauges, %{key: key, value: value, tags: tags})
+  end
 
-            case current do
-              nil -> {nil, [gauge]}
-              _ -> {current, [gauge | current]}
-            end
-          end)
+  def get_distribution_values(key) do
+    Enum.filter(get(__MODULE__, :distribution_values), fn element ->
+      match?(%{key: ^key, tags: _, value: _}, element)
+    end)
+  end
 
-        new_state
-      end)
-    end
+  def get_counters(key) do
+    Enum.filter(get(__MODULE__, :counters), fn element ->
+      match?(%{key: ^key, tags: _, value: _}, element)
+    end)
   end
 
   def get_gauges(key) do
     Enum.filter(get(__MODULE__, :gauges), fn element ->
       match?(%{key: ^key, tags: _, value: _}, element)
     end)
+  end
+
+  defp add(key, event) do
+    if alive?() do
+      Agent.update(__MODULE__, fn state ->
+        Map.update!(state, key, fn current -> [event | current] end)
+      end)
+    end
   end
 end

--- a/test/support/appsignal/fake_appsignal.ex
+++ b/test/support/appsignal/fake_appsignal.ex
@@ -21,8 +21,8 @@ defmodule Appsignal.FakeAppsignal do
     end
   end
 
-  def get_gauges(pid_or_module, key) do
-    Enum.filter(get(pid_or_module, :gauges), fn element ->
+  def get_gauges(key) do
+    Enum.filter(get(__MODULE__, :gauges), fn element ->
       match?(%{key: ^key, tags: _, value: _}, element)
     end)
   end

--- a/test/support/appsignal/fake_appsignal.ex
+++ b/test/support/appsignal/fake_appsignal.ex
@@ -17,20 +17,20 @@ defmodule Appsignal.FakeAppsignal do
     add(:gauges, %{key: key, value: value, tags: tags})
   end
 
-  def get_distribution_values(key) do
-    Enum.filter(get(__MODULE__, :distribution_values), fn element ->
+  def get_distribution_values(pid_or_module, key) do
+    Enum.filter(get(pid_or_module, :distribution_values), fn element ->
       match?(%{key: ^key, tags: _, value: _}, element)
     end)
   end
 
-  def get_counters(key) do
-    Enum.filter(get(__MODULE__, :counters), fn element ->
+  def get_counters(pid_or_module, key) do
+    Enum.filter(get(pid_or_module, :counters), fn element ->
       match?(%{key: ^key, tags: _, value: _}, element)
     end)
   end
 
-  def get_gauges(key) do
-    Enum.filter(get(__MODULE__, :gauges), fn element ->
+  def get_gauges(pid_or_module, key) do
+    Enum.filter(get(pid_or_module, :gauges), fn element ->
       match?(%{key: ^key, tags: _, value: _}, element)
     end)
   end


### PR DESCRIPTION
Part of #805. See appsignal/test-setups#78 for a test setup. [skip blogpost]

---

Instrument the `[:oban, :engine, :insert_job, ...]` telemetry span events and create an AppSignal child span with data about the job inserted. Use the worker name as the span name, if available.

Instrument the `[:oban, :job, ...]` telemetry span-like events and create an AppSignal root span with data about the job being processed. Use the arguments given to the job as params, and set useful attributes of the job, such as its ID, the queue, the attempt number, its priority and the execution result, as tags. Use the job worker as the name of the root span.

Set an error for the `[:oban, :job, :exception]` event.

Track a distribution gauge for the job duration, by worker, and for each worker by state.

Track a distribution gauge for the job queue time, measured as the time between scheduling the job and attempting it for currently starting jobs, by queue.

Track a counter for when a job is inserted, by worker.

Track a counter for when a job is started, by worker and by queue.

Track a counter for when a job is stopped, by worker, and for each worker by state. Exceptions are tracked as stops with a failure state.

### Discuss?

- The "queue delay" is a bit of a hack, in that it doesn't tell you how many messages are left in the queue (we could make a minutely probe for that, but it sounds like a lot of effort, and the Oban people already sell Oban Pro for that) but instead it tells you, for the messages that are currently being processed, how long they've had to wait before starting. It's a better measure of how it affects users, but a worse measure to raise an alarm on.
- Currently, both the insertion child span and the execution root span show the arguments passed to the job (as body on the first one, as params on the second one) -- there's a good chance of PII in those, we might want to remove them or somehow sanitise them. The params could be safe, as the user could configure how to sanitise them.
- For counters and distribution values, I tried to provide only the tag combinations that I thought could be useful. Let me know if you think any tag combinations are missing, or there are any who aren't useful.