### PR TITLE
Track OS distro in diagnose report

### DIFF
--- a/.changesets/track-the-operating-system-release-distro-in-the-diagnose-report.md
+++ b/.changesets/track-the-operating-system-release-distro-in-the-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Track the Operating System release/distro in the diagnose report. This helps us with debugging what exact version of Linux an app is running on, for example.

--- a/lib/appsignal/diagnose/host.ex
+++ b/lib/appsignal/diagnose/host.ex
@@ -14,9 +14,26 @@ defmodule Appsignal.Diagnose.Host do
       language_version: System.version(),
       otp_version: System.otp_release(),
       os: os,
+      os_distribution: os_distribution(),
       heroku: @system.heroku?(),
       root: @system.root?(),
       running_in_container: @nif.running_in_container?()
     }
+  end
+
+  defp os_distribution do
+    file_path = "/etc/os-release"
+
+    if File.exists?(file_path) do
+      case File.read(file_path) do
+        {:ok, contents} ->
+          contents
+
+        {:error, reason} ->
+          "Error reading #{file_path}: #{reason}"
+      end
+    else
+      ""
+    end
   end
 end

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -401,12 +401,21 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
       |> Map.drop([:root, :running_in_container])
 
     {_, os} = :os.type()
+    file_path = "/etc/os-release"
+
+    os_distribution =
+      if File.exists?(file_path) do
+        File.read!(file_path)
+      else
+        ""
+      end
 
     assert report == %{
              architecture: to_string(:erlang.system_info(:system_architecture)),
              language_version: System.version(),
              otp_version: System.otp_release(),
              os: os,
+             os_distribution: os_distribution,
              heroku: false
            }
   end


### PR DESCRIPTION
This helps us with debugging what exact version of Linux an app is running on, for example.

Part of https://github.com/appsignal/support/issues/206

Test failures are unrelated.