### PR TITLE
Unset Hackney metrics config during install

### DIFF
--- a/.changesets/fix-hackney-issue-with-metrics-configuration-during-install.md
+++ b/.changesets/fix-hackney-issue-with-metrics-configuration-during-install.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix an issue where user configuration enabling metrics for Hackney would cause the AppSignal Agent installation to fail.

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -165,6 +165,7 @@ defmodule Mix.Appsignal.Helper do
 
       false ->
         Mix.shell().info("Downloading agent release")
+        :application.unset_env(:hackney, :mod_metrics)
         :application.ensure_all_started(:hackney)
 
         case do_download_file!(filename, local_filename, Appsignal.Agent.mirrors()) do


### PR DESCRIPTION
Users may configure Hackney to report metrics to a separate module. However, that module will not be loaded during the installation Mix task, causing Hackney to error. This change unsets the configuration key that defines the module to report metrics to.

Fixes #802.

---

Thanks for the fix suggestion @arjan!