### PR TITLE
Add NGINX metrics support

### DIFF
--- a/.changesets/add-nginx-metrics-support.md
+++ b/.changesets/add-nginx-metrics-support.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add NGINX metrics support. See [our documentation](https://docs.appsignal.com/metrics/nginx.html) for details.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "9b62288"
+  def version, do: "debb8cf"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "5ff2ec4f16f5089e15188670b2c43866c76ab5db2ac07d72878a9816e63171ca",
+        checksum: "7597130ddfeac866b4eea69348d446603b19b25c9ebd0714a3c39546d0cb6bc3",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "5ff2ec4f16f5089e15188670b2c43866c76ab5db2ac07d72878a9816e63171ca",
+        checksum: "7597130ddfeac866b4eea69348d446603b19b25c9ebd0714a3c39546d0cb6bc3",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
+        checksum: "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
+        checksum: "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
+        checksum: "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "0e5d89aeda1e883c912ff069bb76029a1e3cad69f493865d877ffaffa2b45142",
+        checksum: "1cfd0b66000d32e10529b61c78c2f96c217a0f1eb40ddb12869c36ba8595f94c",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "ff3cffb1204afd846ba0bb33c50b03f8ada8305527a5908ccfebed6fdcce0e61",
+        checksum: "4f90a840931a9c4d0bc0b90b5a20268a0f67e87b1d9cdc4f58f874e8077e96ab",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "ff3cffb1204afd846ba0bb33c50b03f8ada8305527a5908ccfebed6fdcce0e61",
+        checksum: "4f90a840931a9c4d0bc0b90b5a20268a0f67e87b1d9cdc4f58f874e8077e96ab",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "0b6fe4b343461a1a906fc73edb44bc5b12c75214d21fc81ed26d3eb88588003e",
+        checksum: "bbb7e29a20384ecc848291a2637ecb2653a0020a62606c19b631dbe8e04d6089",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "b3f52d7a7a1f4ae8095dd5b1207270dc1797766820d925aca0d09133983c9163",
+        checksum: "69b48e0bcacbc1f2bf642800a7d5be2cf5031f2fabe567c39ac0faaa0143d8fb",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "d306c50cc9f1bc8ea3339b4185b2a60a1c27f17d9067a529b1889d74c6c0a8d6",
+        checksum: "0db801296acce9ff11ca19a14c4a113d30e2f155fcc790af75b80a0013503484",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "135d2ff898f30b15721eca36569d1a0a5deaaee7b4787937d0888ed49f25019b",
+        checksum: "bba6e8f2d5492ef15a5623ee606c91d4db726f917bb2f7e86fe26afc880cafb3",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "135d2ff898f30b15721eca36569d1a0a5deaaee7b4787937d0888ed49f25019b",
+        checksum: "bba6e8f2d5492ef15a5623ee606c91d4db726f917bb2f7e86fe26afc880cafb3",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "debb8cf"
+  def version, do: "d704afb"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "7597130ddfeac866b4eea69348d446603b19b25c9ebd0714a3c39546d0cb6bc3",
+        checksum: "56c7cc0e7464f1d8777c0909bba6c4741855af73b8af3a98d494491479575324",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "7597130ddfeac866b4eea69348d446603b19b25c9ebd0714a3c39546d0cb6bc3",
+        checksum: "56c7cc0e7464f1d8777c0909bba6c4741855af73b8af3a98d494491479575324",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
+        checksum: "b9ece4e56246971015eb75ca41308325277c35c20173163bc2a6319147f3fcda",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
+        checksum: "b9ece4e56246971015eb75ca41308325277c35c20173163bc2a6319147f3fcda",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
+        checksum: "b9ece4e56246971015eb75ca41308325277c35c20173163bc2a6319147f3fcda",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "1cfd0b66000d32e10529b61c78c2f96c217a0f1eb40ddb12869c36ba8595f94c",
+        checksum: "abfbffbf285172d6b4677ac3cbaa94880dbaaee2be6d28326b67cd3c5cb9636e",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "4f90a840931a9c4d0bc0b90b5a20268a0f67e87b1d9cdc4f58f874e8077e96ab",
+        checksum: "78e0a51e8dc38aeb12791ce597a579aa1eba3060196569614309cc7597c62b03",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "4f90a840931a9c4d0bc0b90b5a20268a0f67e87b1d9cdc4f58f874e8077e96ab",
+        checksum: "78e0a51e8dc38aeb12791ce597a579aa1eba3060196569614309cc7597c62b03",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "bbb7e29a20384ecc848291a2637ecb2653a0020a62606c19b631dbe8e04d6089",
+        checksum: "579410e3e41f12dfe367ff6c5e64751ed9b53699ce934f5f02e26f2119e45ef4",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "69b48e0bcacbc1f2bf642800a7d5be2cf5031f2fabe567c39ac0faaa0143d8fb",
+        checksum: "d8994feae00a5b83736b98f96e4343aed6b5943b71da5d05a5a19edc24d8d485",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "0db801296acce9ff11ca19a14c4a113d30e2f155fcc790af75b80a0013503484",
+        checksum: "931ed7052cede5efe9cd0b4cbd4ce28ba29dc82dde8a37722d72af9a867037b7",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "bba6e8f2d5492ef15a5623ee606c91d4db726f917bb2f7e86fe26afc880cafb3",
+        checksum: "8b5aaddfa3e01bd0301d975a1f2ab5525c265267f96159b7fac32686d7d8ec2b",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "bba6e8f2d5492ef15a5623ee606c91d4db726f917bb2f7e86fe26afc880cafb3",
+        checksum: "8b5aaddfa3e01bd0301d975a1f2ab5525c265267f96159b7fac32686d7d8ec2b",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -12,6 +12,7 @@ defmodule Appsignal.Config do
     enable_host_metrics: true,
     enable_minutely_probes: true,
     enable_statsd: false,
+    enable_nginx_metrics: false,
     enable_error_backend: true,
     endpoint: "https://push.appsignal.com",
     env: :dev,
@@ -230,6 +231,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_ENABLE_HOST_METRICS" => :enable_host_metrics,
     "APPSIGNAL_ENABLE_MINUTELY_PROBES" => :enable_minutely_probes,
     "APPSIGNAL_ENABLE_STATSD" => :enable_statsd,
+    "APPSIGNAL_ENABLE_NGINX_METRICS" => :enable_nginx_metrics,
     "APPSIGNAL_ENABLE_ERROR_BACKEND" => :enable_error_backend,
     "APPSIGNAL_FILES_WORLD_ACCESSIBLE" => :files_world_accessible,
     "APPSIGNAL_FILTER_PARAMETERS" => :filter_parameters,
@@ -270,8 +272,8 @@ defmodule Appsignal.Config do
     APPSIGNAL_ENABLE_GC_INSTRUMENTATION APPSIGNAL_RUNNING_IN_CONTAINER
     APPSIGNAL_ENABLE_HOST_METRICS APPSIGNAL_SEND_SESSION_DATA APPSIGNAL_SKIP_SESSION_DATA
     APPSIGNAL_TRANSACTION_DEBUG_MODE APPSIGNAL_FILES_WORLD_ACCESSIBLE APPSIGNAL_SEND_PARAMS
-    APPSIGNAL_ENABLE_MINUTELY_PROBES APPSIGNAL_ENABLE_STATSD APPSIGNAL_ENABLE_ERROR_BACKEND
-    APPSIGNAL_SEND_ENVIRONMENT_METADATA
+    APPSIGNAL_ENABLE_MINUTELY_PROBES APPSIGNAL_ENABLE_STATSD APPSIGNAL_ENABLE_NGINX_METRICS
+    APPSIGNAL_ENABLE_ERROR_BACKEND APPSIGNAL_SEND_ENVIRONMENT_METADATA
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(
@@ -358,6 +360,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_DEBUG_LOGGING", to_string(config[:debug]))
     Nif.env_put("_APPSIGNAL_DNS_SERVERS", config[:dns_servers] |> Enum.join(","))
     Nif.env_put("_APPSIGNAL_ENABLE_HOST_METRICS", to_string(config[:enable_host_metrics]))
+    Nif.env_put("_APPSIGNAL_ENABLE_NGINX_METRICS", to_string(config[:enable_nginx_metrics]))
     Nif.env_put("_APPSIGNAL_ENVIRONMENT", to_string(config[:env]))
     Nif.env_put("_APPSIGNAL_HOSTNAME", to_string(config[:hostname]))
     Nif.env_put("_APPSIGNAL_HTTP_PROXY", to_string(config[:http_proxy]))

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -360,6 +360,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_DEBUG_LOGGING", to_string(config[:debug]))
     Nif.env_put("_APPSIGNAL_DNS_SERVERS", config[:dns_servers] |> Enum.join(","))
     Nif.env_put("_APPSIGNAL_ENABLE_HOST_METRICS", to_string(config[:enable_host_metrics]))
+    Nif.env_put("_APPSIGNAL_ENABLE_STATSD", to_string(config[:enable_statsd]))
     Nif.env_put("_APPSIGNAL_ENABLE_NGINX_METRICS", to_string(config[:enable_nginx_metrics]))
     Nif.env_put("_APPSIGNAL_ENVIRONMENT", to_string(config[:env]))
     Nif.env_put("_APPSIGNAL_HOSTNAME", to_string(config[:hostname]))
@@ -393,6 +394,8 @@ defmodule Appsignal.Config do
       to_string(config[:send_environment_metadata])
     )
 
+    Nif.env_put("_APPSIGNAL_SEND_PARAMS", to_string(config[:send_params]))
+    Nif.env_put("_APPSIGNAL_SEND_SESSION_DATA", to_string(config[:send_session_data]))
     Nif.env_put("_APPSIGNAL_RUNNING_IN_CONTAINER", to_string(config[:running_in_container]))
     Nif.env_put("_APPSIGNAL_TRANSACTION_DEBUG_MODE", to_string(config[:transaction_debug_mode]))
     Nif.env_put("_APPSIGNAL_WORKING_DIRECTORY_PATH", to_string(config[:working_directory_path]))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -282,6 +282,11 @@ defmodule Appsignal.ConfigTest do
       assert %{enable_statsd: true} = with_config(%{enable_statsd: true}, &init_config/0)
     end
 
+    test "enable_nginx_metrics" do
+      assert %{enable_nginx_metrics: true} =
+               with_config(%{enable_nginx_metrics: true}, &init_config/0)
+    end
+
     test "enable_error_backend" do
       assert %{enable_error_backend: false} =
                with_config(%{enable_error_backend: false}, &init_config/0)
@@ -547,6 +552,13 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_ENABLE_STATSD" => "true"},
                &init_config/0
              ) == default_configuration() |> Map.put(:enable_statsd, true)
+    end
+
+    test "enable_nginx_metrics" do
+      assert with_env(
+               %{"APPSIGNAL_ENABLE_NGINX_METRICS" => "true"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:enable_nginx_metrics, true)
     end
 
     test "enable_error_backend" do

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -1150,6 +1150,7 @@ defmodule Appsignal.ConfigTest do
       dns_servers: [],
       enable_host_metrics: true,
       enable_minutely_probes: true,
+      enable_nginx_metrics: false,
       enable_statsd: false,
       enable_error_backend: true,
       endpoint: "https://push.appsignal.com",


### PR DESCRIPTION
### [Add enable_nginx_metrics config option](https://github.com/appsignal/appsignal-elixir/commit/756144d8331df2b1a41de840d7fc974e99a7381c) 

Update the diagnose tests to expect the config option.

### [Add missing private environment variables](https://github.com/appsignal/appsignal-elixir/commit/31b7acde778a4aa23c02f46eb27655e002bea046)

These options should've been passed to the agent before, but weren't.

### [Bump agent version](https://github.com/appsignal/appsignal-elixir/commit/88cc3a2406f1c564fdc8c7f787886f270d29e1ec)

Update the agent to a version that supports NGINX metrics.