### PR TITLE
Add metadata functions for Plug/Phoenix libraries

### DIFF
--- a/.changesets/add-metadata-functions-for-plug-phoenix-apps.md
+++ b/.changesets/add-metadata-functions-for-plug-phoenix-apps.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add metadata functions for Plug/Phoenix apps

--- a/lib/appsignal/metadata.ex
+++ b/lib/appsignal/metadata.ex
@@ -1,4 +1,43 @@
 defprotocol Appsignal.Metadata do
+  @fallback_to_any true
   @spec metadata(t) :: map()
   def metadata(value)
+
+  @fallback_to_any true
+  @spec name(t) :: nil | binary()
+  def name(value)
+
+  @fallback_to_any true
+  @spec category(t) :: nil | binary()
+  def category(value)
+
+  @fallback_to_any true
+  @spec params(t) :: map()
+  def params(value)
+
+  @fallback_to_any true
+  @spec session(t) :: map()
+  def session(value)
+end
+
+defimpl Appsignal.Metadata, for: Any do
+  def metadata(_) do
+    %{}
+  end
+
+  def name(_) do
+    nil
+  end
+
+  def category(_) do
+    nil
+  end
+
+  def params(_) do
+    %{}
+  end
+
+  def session(_) do
+    %{}
+  end
 end


### PR DESCRIPTION
The metadata function in the Plug integration now includes a name, category, params and session data. This patch is part of the work needed for https://github.com/appsignal/appsignal-elixir-phoenix/issues/57.