### PR TITLE
Add `report_oban_errors` config option

### DIFF
--- a/.changesets/disable-instrumentations.md
+++ b/.changesets/disable-instrumentations.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add config options to disable automatic Ecto, Finch and Oban instrumentations.
+Set `instrument_ecto`, `instrument_finch` or `instrument_oban` to `true` in
+order to disable that instrumentation.

--- a/.changesets/fix-enable-error-backend.md
+++ b/.changesets/fix-enable-error-backend.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the default value of `enable_error_backend` so it defaults to `true` when
+the config option is not set.

--- a/.changesets/report-oban-errors.md
+++ b/.changesets/report-oban-errors.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add a `report_oban_errors` config option to decide when to report Oban errors. When set to `"all"`, all errors will be reported; when set to `"none"`, no errors will be reported. Set it to `"discard"` to only report errors when the job is discarded due to the error and won't be re-attempted.

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -26,9 +26,17 @@ defmodule Appsignal do
       Appsignal.Error.Backend.attach()
     end
 
-    Appsignal.Ecto.attach()
-    Appsignal.Finch.attach()
-    Appsignal.Oban.attach()
+    if Config.instrument_ecto?() do
+      Appsignal.Ecto.attach()
+    end
+
+    if Config.instrument_finch?() do
+      Appsignal.Finch.attach()
+    end
+
+    if Config.instrument_oban?() do
+      Appsignal.Oban.attach()
+    end
 
     children = [
       {Appsignal.Tracer, []},

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -215,10 +215,25 @@ defmodule Appsignal.Config do
   def report_oban_errors do
     case Application.fetch_env(:appsignal, :config) do
       {:ok, value} ->
-        case value[:report_oban_errors] do
-          "discard" -> "discard"
-          "none" -> "none"
-          _ -> "all"
+        case to_string(value[:report_oban_errors]) do
+          "discard" ->
+            "discard"
+
+          x when x in ["none", "false"] ->
+            "none"
+
+          # to_string(nil) == ""
+          x when x in ["all", "true", ""] ->
+            "all"
+
+          unknown ->
+            Logger.warn(
+              "Unknown value #{inspect(unknown)} for report_oban_errors config " <>
+                ~s(option. Valid values are "discard", "none", "all". ) <>
+                ~s(Defaulting to "all".)
+            )
+
+            "all"
         end
 
       _ ->

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -31,6 +31,7 @@ defmodule Appsignal.Config do
       accept accept-charset accept-encoding accept-language cache-control
       connection content-length range
     ),
+    report_oban_errors: "all",
     send_environment_metadata: true,
     send_params: true,
     transaction_debug_mode: false
@@ -211,6 +212,20 @@ defmodule Appsignal.Config do
     end
   end
 
+  def report_oban_errors do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, value} ->
+        case value[:report_oban_errors] do
+          "discard" -> "discard"
+          "none" -> "none"
+          _ -> "all"
+        end
+
+      _ ->
+        "all"
+    end
+  end
+
   defp default_ca_file_path do
     Path.join(:code.priv_dir(:appsignal), "cacert.pem")
   end
@@ -276,6 +291,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_OTP_APP" => :otp_app,
     "APPSIGNAL_PUSH_API_ENDPOINT" => :endpoint,
     "APPSIGNAL_PUSH_API_KEY" => :push_api_key,
+    "APPSIGNAL_REPORT_OBAN_ERRORS" => :report_oban_errors,
     "APPSIGNAL_REQUEST_HEADERS" => :request_headers,
     "APPSIGNAL_RUNNING_IN_CONTAINER" => :running_in_container,
     "APPSIGNAL_SEND_ENVIRONMENT_METADATA" => :send_environment_metadata,
@@ -292,7 +308,7 @@ defmodule Appsignal.Config do
     APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH
     APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_LEVEL APPSIGNAL_LOG_PATH
     APPSIGNAL_LOGGING_ENDPOINT APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH
-    APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION
+    APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION APPSIGNAL_REPORT_OBAN_ERRORS
   )
   @bool_keys ~w(
     APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -22,6 +22,9 @@ defmodule Appsignal.Config do
     ignore_actions: [],
     ignore_errors: [],
     ignore_namespaces: [],
+    instrument_ecto: true,
+    instrument_finch: true,
+    instrument_oban: true,
     log: "file",
     logging_endpoint: "https://appsignal-endpoint.net",
     request_headers: ~w(
@@ -175,14 +178,35 @@ defmodule Appsignal.Config do
 
   def minutely_probes_enabled? do
     case Application.fetch_env(:appsignal, :config) do
-      {:ok, value} -> !!value[:enable_minutely_probes]
+      {:ok, value} -> !!Map.get(value, :enable_minutely_probes, false)
       _ -> false
     end
   end
 
   def error_backend_enabled? do
     case Application.fetch_env(:appsignal, :config) do
-      {:ok, value} -> !!value[:enable_error_backend]
+      {:ok, value} -> !!Map.get(value, :enable_error_backend, true)
+      _ -> true
+    end
+  end
+
+  def instrument_ecto? do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, value} -> !!Map.get(value, :instrument_ecto, true)
+      _ -> true
+    end
+  end
+
+  def instrument_finch? do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, value} -> !!Map.get(value, :instrument_finch, true)
+      _ -> true
+    end
+  end
+
+  def instrument_oban? do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, value} -> !!Map.get(value, :instrument_oban, true)
       _ -> true
     end
   end
@@ -242,6 +266,9 @@ defmodule Appsignal.Config do
     "APPSIGNAL_IGNORE_ACTIONS" => :ignore_actions,
     "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
     "APPSIGNAL_IGNORE_NAMESPACES" => :ignore_namespaces,
+    "APPSIGNAL_INSTRUMENT_ECTO" => :instrument_ecto,
+    "APPSIGNAL_INSTRUMENT_FINCH" => :instrument_finch,
+    "APPSIGNAL_INSTRUMENT_OBAN" => :instrument_oban,
     "APPSIGNAL_LOG" => :log,
     "APPSIGNAL_LOG_LEVEL" => :log_level,
     "APPSIGNAL_LOG_PATH" => :log_path,
@@ -274,6 +301,7 @@ defmodule Appsignal.Config do
     APPSIGNAL_TRANSACTION_DEBUG_MODE APPSIGNAL_FILES_WORLD_ACCESSIBLE APPSIGNAL_SEND_PARAMS
     APPSIGNAL_ENABLE_MINUTELY_PROBES APPSIGNAL_ENABLE_STATSD APPSIGNAL_ENABLE_NGINX_METRICS
     APPSIGNAL_ENABLE_ERROR_BACKEND APPSIGNAL_SEND_ENVIRONMENT_METADATA
+    APPSIGNAL_INSTRUMENT_ECTO APPSIGNAL_INSTRUMENT_FINCH APPSIGNAL_INSTRUMENT_OBAN
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -33,8 +33,12 @@ defmodule Appsignal.Ecto do
       :ok ->
         Appsignal.IntegrationLogger.debug("Appsignal.Ecto attached to #{inspect(event)}")
 
+        :ok
+
       {:error, _} = error ->
         Logger.warn("Appsignal.Ecto not attached to #{inspect(event)}: #{inspect(error)}")
+
+        error
     end
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -259,6 +259,44 @@ defmodule Appsignal.ConfigTest do
     end
   end
 
+  describe "report_oban_errors" do
+    test "when discard" do
+      assert with_config(
+               %{report_oban_errors: "discard"},
+               &Config.report_oban_errors/0
+             ) == "discard"
+    end
+
+    test "when none" do
+      assert with_config(
+               %{report_oban_errors: "none"},
+               &Config.report_oban_errors/0
+             ) == "none"
+    end
+
+    test "when all" do
+      assert with_config(
+               %{report_oban_errors: "all"},
+               &Config.report_oban_errors/0
+             ) == "all"
+    end
+
+    test "when something else" do
+      assert with_config(
+               %{report_oban_errors: "foo"},
+               &Config.report_oban_errors/0
+             ) == "all"
+    end
+
+    test "when unset" do
+      assert with_config(%{}, &Config.report_oban_errors/0) == "all"
+    end
+
+    test "without an appsignal config" do
+      assert without_config(&Config.report_oban_errors/0) == "all"
+    end
+  end
+
   describe "log_level" do
     test "without an appsignal config" do
       assert without_config(&Config.log_level/0) == :info
@@ -1270,7 +1308,8 @@ defmodule Appsignal.ConfigTest do
       transaction_debug_mode: false,
       instrument_ecto: true,
       instrument_finch: true,
-      instrument_oban: true
+      instrument_oban: true,
+      report_oban_errors: "all"
     }
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -163,6 +163,102 @@ defmodule Appsignal.ConfigTest do
     end
   end
 
+  describe "error_backend_enabled?" do
+    test "when true" do
+      assert with_config(
+               %{enable_error_backend: true},
+               &Config.error_backend_enabled?/0
+             )
+    end
+
+    test "when false" do
+      refute with_config(
+               %{enable_error_backend: false},
+               &Config.error_backend_enabled?/0
+             )
+    end
+
+    test "when unset" do
+      assert with_config(%{}, &Config.error_backend_enabled?/0)
+    end
+
+    test "without an appsignal config" do
+      assert without_config(&Config.error_backend_enabled?/0)
+    end
+  end
+
+  describe "instrument_oban?" do
+    test "when true" do
+      assert with_config(
+               %{instrument_oban: true},
+               &Config.instrument_oban?/0
+             )
+    end
+
+    test "when false" do
+      refute with_config(
+               %{instrument_oban: false},
+               &Config.instrument_oban?/0
+             )
+    end
+
+    test "when unset" do
+      assert with_config(%{}, &Config.instrument_oban?/0)
+    end
+
+    test "without an appsignal config" do
+      assert without_config(&Config.instrument_oban?/0)
+    end
+  end
+
+  describe "instrument_ecto?" do
+    test "when true" do
+      assert with_config(
+               %{instrument_ecto: true},
+               &Config.instrument_ecto?/0
+             )
+    end
+
+    test "when false" do
+      refute with_config(
+               %{instrument_ecto: false},
+               &Config.instrument_ecto?/0
+             )
+    end
+
+    test "when unset" do
+      assert with_config(%{}, &Config.instrument_ecto?/0)
+    end
+
+    test "without an appsignal config" do
+      assert without_config(&Config.instrument_ecto?/0)
+    end
+  end
+
+  describe "instrument_finch?" do
+    test "when discard" do
+      assert with_config(
+               %{instrument_finch: true},
+               &Config.instrument_finch?/0
+             )
+    end
+
+    test "when false" do
+      refute with_config(
+               %{instrument_finch: false},
+               &Config.instrument_finch?/0
+             )
+    end
+
+    test "when unset" do
+      assert with_config(%{}, &Config.instrument_finch?/0)
+    end
+
+    test "without an appsignal config" do
+      assert without_config(&Config.instrument_finch?/0)
+    end
+  end
+
   describe "log_level" do
     test "without an appsignal config" do
       assert without_config(&Config.log_level/0) == :info
@@ -1171,7 +1267,10 @@ defmodule Appsignal.ConfigTest do
       send_params: true,
       send_session_data: true,
       skip_session_data: false,
-      transaction_debug_mode: false
+      transaction_debug_mode: false,
+      instrument_ecto: true,
+      instrument_finch: true,
+      instrument_oban: true
     }
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -267,25 +267,37 @@ defmodule Appsignal.ConfigTest do
              ) == "discard"
     end
 
-    test "when none" do
+    test "when none or false" do
       assert with_config(
                %{report_oban_errors: "none"},
                &Config.report_oban_errors/0
              ) == "none"
+
+      assert with_config(
+               %{report_oban_errors: "false"},
+               &Config.report_oban_errors/0
+             ) == "none"
     end
 
-    test "when all" do
+    test "when all or true" do
       assert with_config(
                %{report_oban_errors: "all"},
+               &Config.report_oban_errors/0
+             ) == "all"
+
+      assert with_config(
+               %{report_oban_errors: "true"},
                &Config.report_oban_errors/0
              ) == "all"
     end
 
     test "when something else" do
-      assert with_config(
-               %{report_oban_errors: "foo"},
-               &Config.report_oban_errors/0
-             ) == "all"
+      without_logger(fn ->
+        assert with_config(
+                 %{report_oban_errors: "foo"},
+                 &Config.report_oban_errors/0
+               ) == "all"
+      end)
     end
 
     test "when unset" do

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -7,6 +7,16 @@ defmodule Appsignal.EctoTest do
     assert attached?([:appsignal, :test, :repo, :query])
   end
 
+  test "is not attached automatically when :instrument_ecto is set to false" do
+    :telemetry.detach({Ecto, [:appsignal, :test, :repo, :query]})
+
+    with_config(%{instrument_ecto: false}, fn -> Appsignal.start([], []) end)
+
+    assert !attached?([:appsignal, :test, :repo, :query])
+
+    :ok = Ecto.attach()
+  end
+
   test "attach/0 attaches to configured repos" do
     assert with_config(
              %{ecto_repos: [Appsignal.Test.RepoOne, Appsignal.Test.RepoTwo]},

--- a/test/appsignal/finch_test.exs
+++ b/test/appsignal/finch_test.exs
@@ -1,11 +1,26 @@
 defmodule Appsignal.FinchTest do
   use ExUnit.Case
   alias Appsignal.{Span, Test}
+  import AppsignalTest.Utils, only: [with_config: 2]
 
   test "attaches to Finch events automatically" do
     assert attached?([:finch, :request, :start])
     assert attached?([:finch, :request, :stop])
     assert attached?([:finch, :request, :exception])
+  end
+
+  test "does not attach to Finch events when :instrument_finch is set to false" do
+    :telemetry.detach({Appsignal.Finch, [:finch, :request, :start]})
+    :telemetry.detach({Appsignal.Finch, [:finch, :request, :stop]})
+    :telemetry.detach({Appsignal.Finch, [:finch, :request, :exception]})
+
+    with_config(%{instrument_finch: false}, fn -> Appsignal.start([], []) end)
+
+    assert !attached?([:finch, :request, :start])
+    assert !attached?([:finch, :request, :stop])
+    assert !attached?([:finch, :request, :exception])
+
+    [:ok, :ok, :ok] = Appsignal.Finch.attach()
   end
 
   describe "finch_request_start/4, without a root span" do


### PR DESCRIPTION
Fixes appsignal/feature-requests#97.

### [Add config options to disable instrumentations](https://github.com/appsignal/appsignal-elixir/commit/a5b743f94d24e5ebe0fde8ecfcae43f185364d61)

Add the `instrument_ecto`, `instrument_finch` and `instrument_oban`
config options to disable the automatic Telemetry instrumentations.

### [Add report_oban_errors config option](https://github.com/appsignal/appsignal-elixir/commit/a3483e3ae57feff0f977537a4c8a7e6452a2630f)

Adds a config option that determines when Oban jobs report errors.
When set to `none`, no errors from exception events will be
reported. When set to `all`, all errors from exception events will
be reported. When set to `discard`, errors from exception events
will be reported if the state of the job has been set to `discard`.

If the `:state` metadata key is not present (v2.3.1 and below) then
`discard` will behave like `all`, assuming each event to be
discarded.

Change the behaviour of `Appsignal.Oban.attach/0` to deattach
existing handlers before attaching new handlers. This allows the
config option to be read only once, when the handlers are attached,
while still behaving correctly on config reload.

## To do:
- [x] Update diagnose tests -- https://github.com/appsignal/diagnose_tests/pull/80
- [x] Add changesets
- [x] Document config options (config options list + instrumentation pages) -- https://github.com/appsignal/appsignal-docs/pull/1059
- [ ] Notify customer who requested the feature