### PR TITLE
Update MonitorTest to fix brittleness

### DIFF
--- a/test/appsignal/monitor_test.exs
+++ b/test/appsignal/monitor_test.exs
@@ -13,25 +13,27 @@ defmodule Appsignal.MonitorTest do
   end
 
   test "monitors a process" do
-    {:monitors, previous} = Process.info(monitor_pid(), :monitors)
-
     Monitor.add()
 
     until(fn ->
-      assert Process.info(monitor_pid(), :monitors) ==
-               {:monitors, previous ++ [{:process, self()}]}
+      {:monitors, monitors} = Process.info(monitor_pid(), :monitors)
+
+      assert Enum.any?(monitors, fn {:process, pid} ->
+               pid == self()
+             end)
     end)
   end
 
   test "does not monitor a process more than once" do
-    {:monitors, previous} = Process.info(monitor_pid(), :monitors)
-
     Monitor.add()
     Monitor.add()
 
     until(fn ->
-      assert Process.info(monitor_pid(), :monitors) ==
-               {:monitors, previous ++ [{:process, self()}]}
+      {:monitors, monitors} = Process.info(monitor_pid(), :monitors)
+
+      assert Enum.count(monitors, fn {:process, pid} ->
+               pid == self()
+             end) == 1
     end)
   end
 

--- a/test/appsignal/monitor_test.exs
+++ b/test/appsignal/monitor_test.exs
@@ -51,19 +51,6 @@ defmodule Appsignal.MonitorTest do
     end)
   end
 
-  test "automatically removes pids that don't exist from the monitor list" do
-    pid = :erlang.list_to_pid('<0.999.0>')
-    GenServer.cast(Appsignal.Monitor, {:monitor, pid})
-
-    until(fn ->
-      assert MapSet.member?(:sys.get_state(Appsignal.Monitor), pid)
-    end)
-
-    until(fn ->
-      refute MapSet.member?(:sys.get_state(Appsignal.Monitor), pid)
-    end)
-  end
-
   test "syncs the monitors list" do
     Monitor.add()
     :sys.replace_state(Appsignal.Monitor, fn _ -> MapSet.new() end)


### PR DESCRIPTION
This pull request removes a complicated and unnecessary test, and updates a test with an assertion that’s too specific. Together, they fix the brittleness in the MonitorTest, as shown in the [brittle](https://appsignal.semaphoreci.com/branches/f2dc647d-3c7d-45b7-8641-9b4916196050) branch, from which these fixes are extracted.

Part of https://github.com/appsignal/appsignal-elixir/issues/811.
[skip changeset]