### PR TITLE
Only test log length in PathsTest

### DIFF
--- a/test/appsignal/diagnose/paths_test.exs
+++ b/test/appsignal/diagnose/paths_test.exs
@@ -4,57 +4,39 @@ defmodule Mix.Tasks.Appsignal.Diagnose.PathsTest do
   alias Appsignal.Diagnose.Paths
 
   setup do
+    dir = System.tmp_dir()
+    path = Path.join(dir, "appsignal.log")
+
     Application.delete_env(:appsignal, :"$log_file_path")
-    :ok
+
+    on_exit(fn ->
+      File.rm(path)
+    end)
+
+    [dir: dir, path: path]
   end
 
   describe "with file bigger than 2 Mebibytes" do
-    setup do
-      path = System.tmp_dir()
-      file_path = Path.join(path, "appsignal.log")
-      bytes = more_than_two_mebibytes_of_data()
-      File.write!(file_path, bytes)
-
-      on_exit(fn ->
-        File.rm!(file_path)
-      end)
-
-      {:ok, %{path: path, bytes: bytes}}
+    setup %{path: path} do
+      File.write!(path, more_than_two_mebibytes_of_data())
     end
 
-    test "only reads the last 2 Mebibytes", %{path: path, bytes: bytes} do
-      log =
-        with_config(%{log_path: path}, fn ->
-          Paths.info()[:"appsignal.log"]
-        end)
+    test "only reads the last 2 Mebibytes", %{dir: dir} do
+      log = with_config(%{log_path: dir}, fn -> Paths.info()[:"appsignal.log"] end)
 
-      bytes_to_read = 2 * 1024 * 1024
-      max_length = byte_size(bytes)
-      {_, last} = String.split_at(bytes, max_length - bytes_to_read)
-      content = Enum.join(log[:content], "\n")
-      assert byte_size(bytes) > bytes_to_read
-      assert content == last
+      assert log[:content]
+             |> Enum.join("\n")
+             |> byte_size() == 2 * 1024 * 1024
     end
   end
 
   describe "with file smaller than 2 Mebibytes" do
-    setup do
-      path = System.tmp_dir()
-      file_path = Path.join(path, "appsignal.log")
-      File.write!(file_path, "line 1\nline 2\nline 3")
-
-      on_exit(fn ->
-        File.rm!(file_path)
-      end)
-
-      {:ok, %{path: path}}
+    setup %{path: path} do
+      File.write!(path, "line 1\nline 2\nline 3")
     end
 
-    test "reads the full file", %{path: path} do
-      log =
-        with_config(%{log_path: path}, fn ->
-          Paths.info()[:"appsignal.log"]
-        end)
+    test "reads the full file", %{dir: dir} do
+      log = with_config(%{log_path: dir}, fn -> Paths.info()[:"appsignal.log"] end)
 
       assert log[:content] == ["line 1", "line 2", "line 3"]
     end


### PR DESCRIPTION
Instead of making sure the contents of the files match exactly, check the length, which is what the test is actually asserting.

This fixes the brittleness in the PathsTest, as shown in the [brittle](https://appsignal.semaphoreci.com/branches/f2dc647d-3c7d-45b7-8641-9b4916196050) branch, from which this fix is extracted.

Part of https://github.com/appsignal/appsignal-elixir/issues/811.
[skip changeset]