### PR TITLE
Remove env var test in ReleaseUpgradeTest

### DIFF
--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -15,8 +15,6 @@ defmodule Appsignal.ReleaseUpgradeTest do
 
       # Sets config to Application environment
       assert config()[:name] == "AppSignal test suite app v1"
-      # Sets config to system environment variables
-      assert Nif.env_get("_APPSIGNAL_APP_NAME") == 'AppSignal test suite app v1'
 
       # The system reloads the application config (set in Mix) during the upgrade.
       new_config =
@@ -29,7 +27,6 @@ defmodule Appsignal.ReleaseUpgradeTest do
 
         until(fn ->
           assert config()[:name] == "AppSignal test suite app v2"
-          assert Nif.env_get("_APPSIGNAL_APP_NAME") == 'AppSignal test suite app v2'
         end)
       end)
     end)


### PR DESCRIPTION
The ReleaseUpgradeTest makes sure the configuration is reloaded when it's updated. The implementation simply stops the Nif and restarts it with the new configuration. Setting environment variables is not the release upgrade's concern, so the test can be removed to make the suite more stable.

This fixes the brittleness in the ReleaseUpgradeTest, as shown in the [brittle](https://appsignal.semaphoreci.com/branches/f2dc647d-3c7d-45b7-8641-9b4916196050) branch, from which this fix is extracted.

Part of https://github.com/appsignal/appsignal-elixir/issues/811.
[skip-changeset]