### PR TITLE
Don't match econnrefused in ReportTest exactly

### DIFF
--- a/test/appsignal/diagnose/report_test.exs
+++ b/test/appsignal/diagnose/report_test.exs
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose.ReportTest do
     end
 
     test "sends the diagnostics report to AppSignal and returns an error" do
-      assert send() == {:error, %{reason: :econnrefused}}
+      assert {:error, %{reason: _}} = send()
     end
   end
 end


### PR DESCRIPTION
One of the error scenarios in the diagnose reports is when an unexpected error occurs. In the tests, this is simulated by taking the test diagnose server down, resulting in a :econnrefused.

In some situations, the error thrown is a :closed, which made this test brittle. To fix that, the test no longer explicitly tests for a :econnrefused. Rather, it just tests if an error with a reason key is returned when this happens.

This fixes the brittleness in the ReportTest, as shown in the [brittle](https://appsignal.semaphoreci.com/branches/f2dc647d-3c7d-45b7-8641-9b4916196050) branch, from which this fix is extracted.

Part of https://github.com/appsignal/appsignal-elixir/issues/811.
[skip changeset]