### PR TITLE
Reimplement ErlangProbe tests

### DIFF
--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -1,9 +1,6 @@
 defmodule Appsignal.Probes.ErlangProbe do
   @moduledoc false
-
   require Appsignal.Utils
-
-  @appsignal Appsignal.Utils.compile_env(:appsignal, :appsignal, Appsignal)
 
   def call(sample \\ nil) do
     next_sample = sample_schedulers()

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -8,50 +8,59 @@ defmodule Appsignal.Probes.ErlangProbe do
   def call(sample \\ nil) do
     next_sample = sample_schedulers()
 
-    io_metrics()
-    scheduler_metrics()
-    process_metrics()
-    memory_metrics()
-    atom_metrics()
-    run_queue_lengths()
-    scheduler_utilization_metrics(sample, next_sample)
+    sample
+    |> metrics(next_sample)
+    |> Enum.each(&set_gauge/1)
 
     next_sample
   end
 
+  defp metrics(sample, next_sample) do
+    io_metrics() ++
+      scheduler_metrics() ++
+      process_metrics() ++
+      memory_metrics() ++
+      atom_metrics() ++
+      run_queue_lengths() ++
+      scheduler_utilization_metrics(sample, next_sample)
+  end
+
   defp io_metrics do
     {{:input, input}, {:output, output}} = :erlang.statistics(:io)
-    set_gauge("erlang_io", Kernel.div(input, 1024), %{type: "input"})
-    set_gauge("erlang_io", Kernel.div(output, 1024), %{type: "output"})
+
+    [
+      {"erlang_io", Kernel.div(input, 1024), %{type: "input"}},
+      {"erlang_io", Kernel.div(output, 1024), %{type: "output"}}
+    ]
   end
 
   defp scheduler_metrics do
-    set_gauge("erlang_schedulers", :erlang.system_info(:schedulers), %{type: "total"})
-
-    set_gauge(
-      "erlang_schedulers",
-      :erlang.system_info(:schedulers_online),
-      %{type: "online"}
-    )
+    [
+      {"erlang_schedulers", :erlang.system_info(:schedulers), %{type: "total"}},
+      {"erlang_schedulers", :erlang.system_info(:schedulers_online), %{type: "online"}}
+    ]
   end
 
   defp process_metrics do
-    set_gauge("erlang_processes", :erlang.system_info(:process_limit), %{type: "limit"})
-
-    set_gauge("erlang_processes", :erlang.system_info(:process_count), %{type: "count"})
+    [
+      {"erlang_processes", :erlang.system_info(:process_limit), %{type: "limit"}},
+      {"erlang_processes", :erlang.system_info(:process_count), %{type: "count"}}
+    ]
   end
 
   defp memory_metrics do
     memory = :erlang.memory()
 
-    Enum.each(memory, fn {key, value} ->
-      set_gauge("erlang_memory", Kernel.div(value, 1024), %{type: to_string(key)})
+    Enum.map(memory, fn {key, value} ->
+      {"erlang_memory", Kernel.div(value, 1024), %{type: to_string(key)}}
     end)
   end
 
   defp atom_metrics do
-    set_gauge("erlang_atoms", :erlang.system_info(:atom_limit), %{type: "limit"})
-    set_gauge("erlang_atoms", :erlang.system_info(:atom_count), %{type: "count"})
+    [
+      {"erlang_atoms", :erlang.system_info(:atom_limit), %{type: "limit"}},
+      {"erlang_atoms", :erlang.system_info(:atom_count), %{type: "count"}}
+    ]
   end
 
   defp run_queue_lengths do
@@ -72,12 +81,14 @@ defmodule Appsignal.Probes.ErlangProbe do
         :erlang.statistics(:total_run_queue_lengths)
       end
 
-    set_gauge("total_run_queue_lengths", total, %{type: "total"})
-    set_gauge("total_run_queue_lengths", cpu, %{type: "cpu"})
-    set_gauge("total_run_queue_lengths", total - cpu, %{type: "io"})
+    [
+      {"total_run_queue_lengths", total, %{type: "total"}},
+      {"total_run_queue_lengths", cpu, %{type: "cpu"}},
+      {"total_run_queue_lengths", total - cpu, %{type: "io"}}
+    ]
   end
 
-  defp scheduler_utilization_metrics(nil, _), do: nil
+  defp scheduler_utilization_metrics(nil, _), do: []
 
   defp scheduler_utilization_metrics(sample, next_sample) do
     utilization = scheduler_utilization(sample, next_sample)
@@ -85,8 +96,8 @@ defmodule Appsignal.Probes.ErlangProbe do
     utilization
     |> Enum.map(&Tuple.to_list/1)
     |> Enum.filter(fn [type | _] -> type == :normal end)
-    |> Enum.each(fn [_, id, value, _] ->
-      set_gauge("erlang_scheduler_utilization", value * 100, %{type: "normal", id: "#{id}"})
+    |> Enum.map(fn [_, id, value, _] ->
+      {"erlang_scheduler_utilization", value * 100, %{type: "normal", id: "#{id}"}}
     end)
   end
 
@@ -115,7 +126,7 @@ defmodule Appsignal.Probes.ErlangProbe do
     end
   end
 
-  defp set_gauge(name, value, tags) do
+  defp set_gauge({name, value, tags}) do
     @appsignal.set_gauge(
       name,
       value,

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -285,9 +285,7 @@ defmodule Appsignal.Probes.ErlangProbeTest do
     test "does not gather scheduler utilization metrics on the first run", %{
       fake_appsignal: fake_appsignal
     } do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
-
-      assert Enum.empty?(metrics)
+      assert Enum.empty?(FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization"))
     end
 
     test "gathers scheduler utilization metrics on subsequent runs", %{
@@ -295,29 +293,19 @@ defmodule Appsignal.Probes.ErlangProbeTest do
       sample: sample
     } do
       ErlangProbe.call(sample)
-
       metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
 
-      scheduler_ids = Enum.to_list(1..:erlang.system_info(:schedulers))
-
-      scheduler_ids
-      |> Enum.map(fn scheduler_id -> "#{scheduler_id}" end)
-      |> Enum.each(fn scheduler_id ->
-        assert Enum.any?(
-                 metrics,
-                 &match?(
-                   %{
-                     key: "erlang_scheduler_utilization",
-                     tags: %{
-                       type: "normal",
-                       id: ^scheduler_id
-                     },
-                     value: _
-                   },
-                   &1
-                 )
+      assert Enum.any?(
+               metrics,
+               &match?(
+                 %{
+                   key: "erlang_scheduler_utilization",
+                   tags: %{type: "normal", id: _},
+                   value: _
+                 },
+                 &1
                )
-      end)
+             )
     end
   end
 

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -1,11 +1,7 @@
 defmodule Appsignal.Probes.ErlangProbeTest do
-  alias Appsignal.{FakeAppsignal, Probes, Probes.ErlangProbe}
+  alias Appsignal.{Probes, Probes.ErlangProbe}
   import AppsignalTest.Utils
   use ExUnit.Case
-
-  setup do
-    [fake_appsignal: start_supervised!(FakeAppsignal)]
-  end
 
   test "is added to the probes automatically" do
     until(fn ->

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -13,314 +13,114 @@ defmodule Appsignal.Probes.ErlangProbeTest do
     end)
   end
 
-  describe "call/1" do
+  describe "metrics/2" do
     setup do
-      Probes.unregister(:erlang)
-
-      on_exit(fn ->
-        Probes.register(:erlang, &ErlangProbe.call/1)
-      end)
-
-      [sample: ErlangProbe.call()]
+      [metrics: ErlangProbe.metrics(nil, nil)]
     end
 
-    test "gathers IO metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
+    test "returns io metrics", %{metrics: metrics} do
+      assert [{"erlang_io", input, %{type: "input"}}, {"erlang_io", output, %{type: "output"}}] =
+               Enum.filter(metrics, fn {key, _, _} -> key == "erlang_io" end)
 
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_io",
-                   tags: %{type: "output", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_io",
-                   tags: %{type: "input", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
+      assert is_number(input)
+      assert is_number(output)
     end
 
-    test "gathers scheduler metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_schedulers")
+    test "returns scheduler metrics", %{metrics: metrics} do
+      assert [
+               {"erlang_schedulers", total, %{type: "total"}},
+               {"erlang_schedulers", online, %{type: "online"}}
+             ] = Enum.filter(metrics, fn {key, _, _} -> key == "erlang_schedulers" end)
 
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_schedulers",
-                   tags: %{type: "online", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_schedulers",
-                   tags: %{type: "total", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
+      assert is_number(total)
+      assert is_number(online)
     end
 
-    test "gathers process metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_processes")
+    test "returns process metrics", %{metrics: metrics} do
+      assert [
+               {"erlang_processes", limit, %{type: "limit"}},
+               {"erlang_processes", count, %{type: "count"}}
+             ] = Enum.filter(metrics, fn {key, _, _} -> key == "erlang_processes" end)
 
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_processes",
-                   tags: %{type: "count", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_processes",
-                   tags: %{type: "limit", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
+      assert is_number(limit)
+      assert is_number(count)
     end
 
-    test "gathers memory metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_memory")
+    test "returns memory metrics", %{metrics: metrics} do
+      assert [
+               {"erlang_memory", total, %{type: "total"}},
+               {"erlang_memory", processes, %{type: "processes"}},
+               {"erlang_memory", processes_used, %{type: "processes_used"}},
+               {"erlang_memory", system, %{type: "system"}},
+               {"erlang_memory", atom, %{type: "atom"}},
+               {"erlang_memory", atom_used, %{type: "atom_used"}},
+               {"erlang_memory", binary, %{type: "binary"}},
+               {"erlang_memory", code, %{type: "code"}},
+               {"erlang_memory", ets, %{type: "ets"}}
+             ] = Enum.filter(metrics, fn {key, _, _} -> key == "erlang_memory" end)
 
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "ets", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "code", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "binary", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "atom_used", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "atom", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "system", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "processes_used", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "processes", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_memory",
-                   tags: %{type: "total", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
+      assert is_number(total)
+      assert is_number(processes)
+      assert is_number(processes_used)
+      assert is_number(system)
+      assert is_number(atom)
+      assert is_number(atom_used)
+      assert is_number(binary)
+      assert is_number(code)
+      assert is_number(ets)
     end
 
-    test "gathers atom metrics", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_atoms")
+    test "returns atom metrics", %{metrics: metrics} do
+      assert [
+               {"erlang_atoms", limit, %{type: "limit"}},
+               {"erlang_atoms", count, %{type: "count"}}
+             ] = Enum.filter(metrics, fn {key, _, _} -> key == "erlang_atoms" end)
 
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_atoms",
-                   tags: %{type: "count", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_atoms",
-                   tags: %{type: "limit", hostname: "Bobs-MBP.example.com"},
-                   value: _
-                 },
-                 &1
-               )
-             )
+      assert is_number(limit)
+      assert is_number(count)
     end
 
-    test "gathers run queue lengths", %{fake_appsignal: fake_appsignal} do
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "total_run_queue_lengths")
+    test "returns run queue lengths", %{metrics: metrics} do
+      assert [
+               {"total_run_queue_lengths", total, %{type: "total"}},
+               {"total_run_queue_lengths", cpu, %{type: "cpu"}},
+               {"total_run_queue_lengths", io, %{type: "io"}}
+             ] = Enum.filter(metrics, fn {key, _, _} -> key == "total_run_queue_lengths" end)
 
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "total_run_queue_lengths",
-                   tags: %{type: "io"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "total_run_queue_lengths",
-                   tags: %{type: "cpu"},
-                   value: _
-                 },
-                 &1
-               )
-             )
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "total_run_queue_lengths",
-                   tags: %{type: "total"},
-                   value: _
-                 },
-                 &1
-               )
-             )
+      assert is_number(total)
+      assert is_number(cpu)
+      assert is_number(io)
     end
 
-    test "does not gather scheduler utilization metrics on the first run", %{
-      fake_appsignal: fake_appsignal
-    } do
-      assert Enum.empty?(FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization"))
+    test "does not return scheduler utilization metrics", %{metrics: metrics} do
+      assert [] =
+               Enum.filter(metrics, fn {key, _, _} -> key == "erlang_scheduler_utilization" end)
     end
 
-    test "gathers scheduler utilization metrics on subsequent runs", %{
-      fake_appsignal: fake_appsignal,
-      sample: sample
-    } do
-      ErlangProbe.call(sample)
-      metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
-
-      assert Enum.any?(
-               metrics,
-               &match?(
-                 %{
-                   key: "erlang_scheduler_utilization",
-                   tags: %{type: "normal", id: _},
-                   value: _
-                 },
-                 &1
-               )
-             )
+    test "sets hostnames for all metrics", %{metrics: metrics} do
+      assert Enum.all?(metrics, fn {_, _, tags} ->
+               tags[:hostname] == "Bobs-MBP.example.com"
+             end)
     end
   end
 
-  describe "call/0, with a configured hostname" do
-    test "adds the configured hostname as a tag", %{fake_appsignal: fake_appsignal} do
-      with_config(%{hostname: "Alices-MBP.example.com"}, &ErlangProbe.call/0)
+  describe "metrics/2, when called with two scheduler samples" do
+    setup do
+      [
+        metrics:
+          ErlangProbe.metrics(ErlangProbe.sample_schedulers(), ErlangProbe.sample_schedulers())
+      ]
+    end
 
-      assert [%{tags: %{hostname: "Alices-MBP.example.com"}} | _] =
-               FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
+    test "returns scheduler utilization metrics", %{metrics: metrics} do
+      metrics = Enum.filter(metrics, fn {key, _, _} -> key == "erlang_scheduler_utilization" end)
+
+      assert Enum.any?(metrics)
+
+      Enum.each(metrics, fn {"erlang_scheduler_utilization", value, %{id: id, type: "normal"}} ->
+        assert is_number(value)
+        assert {_, _} = Integer.parse(id)
+      end)
     end
   end
 end

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -1,38 +1,16 @@
 defmodule Appsignal.Probes.ErlangProbeTest do
-  alias Appsignal.{FakeAppsignal, Probes.ErlangProbe}
+  alias Appsignal.{FakeAppsignal, Probes, Probes.ErlangProbe}
   import AppsignalTest.Utils
   use ExUnit.Case
 
   setup do
-    # Ensure the default probe is unregistered, that way we only record metrics
-    # from this test
-    Appsignal.Probes.unregister(:erlang)
-
     [fake_appsignal: start_supervised!(FakeAppsignal)]
   end
 
-  describe "when invoked by the scheduler" do
-    setup do
-      assert :ok == Appsignal.Probes.register(:erlang, &ErlangProbe.call/1)
-
-      on_exit(fn ->
-        assert :ok == Appsignal.Probes.unregister(:erlang)
-      end)
-    end
-
-    test "gathers any metrics", %{fake_appsignal: fake_appsignal} do
-      until(fn ->
-        metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_io")
-        refute Enum.empty?(metrics)
-      end)
-    end
-
-    test "gathers metrics using previous sample", %{fake_appsignal: fake_appsignal} do
-      until(fn ->
-        metrics = FakeAppsignal.get_gauges(fake_appsignal, "erlang_scheduler_utilization")
-        refute Enum.empty?(metrics)
-      end)
-    end
+  test "is added to the probes automatically" do
+    until(fn ->
+      assert Probes.probes()[:erlang] == (&ErlangProbe.call/1)
+    end)
   end
 
   describe "call/1" do

--- a/test/appsignal/probes/erlang_probe_test.exs
+++ b/test/appsignal/probes/erlang_probe_test.exs
@@ -15,6 +15,12 @@ defmodule Appsignal.Probes.ErlangProbeTest do
 
   describe "call/1" do
     setup do
+      Probes.unregister(:erlang)
+
+      on_exit(fn ->
+        Probes.register(:erlang, &ErlangProbe.call/1)
+      end)
+
       [sample: ErlangProbe.call()]
     end
 

--- a/test/appsignal/probes/probes_test.exs
+++ b/test/appsignal/probes/probes_test.exs
@@ -94,8 +94,4 @@ defmodule Appsignal.Probes.ProbesTest do
       run_probes()
     end
   end
-
-  defp run_probes do
-    send(Process.whereis(Probes), :run_probes)
-  end
 end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -131,4 +131,8 @@ defmodule AppsignalTest.Utils do
     :timer.sleep(10)
     repeatedly(assertion, retries - 1)
   end
+
+  def run_probes do
+    send(Process.whereis(Appsignal.Probes), :run_probes)
+  end
 end


### PR DESCRIPTION
This patch reimplements the ErlangProbe tests, so they’re no longer dependent on the FakeAppsignal module, which caused issues in the past. The implementation now exposes `metrics/2`, which is then tested on. 

This does leave a gap between extracting the data and actually sending it to the extension, which we used to do using the `FakeAppsignal` module. Aside from that, everything that was tested previously is present in the new tests.

This fixes the brittleness in the ErlangProbeTest, as shown in the [brittle](https://appsignal.semaphoreci.com/branches/f2dc647d-3c7d-45b7-8641-9b4916196050) branch, from which these fixes are extracted.

Part of https://github.com/appsignal/appsignal-elixir/issues/811.
[skip changeset]