### PR TITLE
Fix brittleness in Oban tests

### DIFF
--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -3,6 +3,15 @@ defmodule Appsignal.ObanTest do
   alias Appsignal.{FakeAppsignal, Span, Test}
   import AppsignalTest.Utils, only: [with_config: 2]
 
+  setup do
+    start_supervised!(Test.Nif)
+    start_supervised!(Test.Tracer)
+    start_supervised!(Test.Span)
+    start_supervised!(Test.Monitor)
+
+    :ok
+  end
+
   test "attaches to Oban events automatically" do
     assert attached?([:oban, :job, :start])
     assert attached?([:oban, :job, :stop])
@@ -40,11 +49,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_start/4" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
-
       execute_job_start()
     end
 
@@ -78,11 +82,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_start/4, with a :tags metadata key (v2.1.0)" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
-
       execute_job_start(%{
         tags: ["foo", "bar"]
       })
@@ -96,10 +95,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_start/4, with a :job metadata key (v2.3.1)" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
       fake_appsignal = start_supervised!(FakeAppsignal)
 
       execute_job_start(%{
@@ -130,10 +125,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_stop/4" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
       fake_appsignal = start_supervised!(FakeAppsignal)
 
       execute_job_start()
@@ -183,10 +174,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_stop/4, with a :state metadata key (v2.4.0)" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
       fake_appsignal = start_supervised!(FakeAppsignal)
 
       execute_job_start()
@@ -230,11 +217,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_stop/4, with a :result metadata key (v2.5.0)" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
-
       execute_job_start()
 
       execute_job_stop(%{
@@ -249,10 +231,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_exception/4" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
       fake_appsignal = start_supervised!(FakeAppsignal)
 
       with_config(%{}, &Appsignal.Oban.attach/0)
@@ -316,10 +294,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_exception/4, with a :state metadata key (v2.4.0)" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
       fake_appsignal = start_supervised!(FakeAppsignal)
 
       with_config(%{}, &Appsignal.Oban.attach/0)
@@ -365,10 +339,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_discard/4, with no :state metadata key" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
       fake_appsignal = start_supervised!(FakeAppsignal)
 
       with_config(
@@ -406,10 +376,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_discard/4, with a :state metadata key set to discard" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
       fake_appsignal = start_supervised!(FakeAppsignal)
 
       with_config(
@@ -449,10 +415,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_job_discard/4, with a :state metadata key set to failure" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
       fake_appsignal = start_supervised!(FakeAppsignal)
 
       with_config(
@@ -531,11 +493,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_insert_job_start/4" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
-
       execute_insert_job(:start)
     end
 
@@ -558,11 +515,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_insert_job_start/4, without a changeset" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
-
       execute_insert_job(:start, %{})
     end
 
@@ -577,11 +529,6 @@ defmodule Appsignal.ObanTest do
 
   describe "oban_insert_job_stop/4 and oban_insert_job_exception/4" do
     setup do
-      start_supervised!(Test.Nif)
-      start_supervised!(Test.Tracer)
-      start_supervised!(Test.Span)
-      start_supervised!(Test.Monitor)
-
       execute_insert_job(:start)
 
       execute_insert_job(:stop)

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -44,7 +44,6 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
 
       execute_job_start()
     end
@@ -83,7 +82,6 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
 
       execute_job_start(%{
         tags: ["foo", "bar"]
@@ -236,7 +234,6 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
 
       execute_job_start()
 
@@ -565,7 +562,6 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
 
       execute_insert_job(:start, %{})
     end
@@ -585,7 +581,6 @@ defmodule Appsignal.ObanTest do
       start_supervised!(Test.Tracer)
       start_supervised!(Test.Span)
       start_supervised!(Test.Monitor)
-      start_supervised!(FakeAppsignal)
 
       execute_insert_job(:start)
 

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -12,24 +12,30 @@ defmodule Appsignal.ObanTest do
     assert attached?([:oban, :engine, :insert_job, :exception])
   end
 
-  test "does not attach to Oban events when :instrument_oban is set to false" do
-    :telemetry.detach({Appsignal.Oban, [:oban, :job, :start]})
-    :telemetry.detach({Appsignal.Oban, [:oban, :job, :stop]})
-    :telemetry.detach({Appsignal.Oban, [:oban, :job, :exception]})
-    :telemetry.detach({Appsignal.Oban, [:oban, :engine, :insert_job, :start]})
-    :telemetry.detach({Appsignal.Oban, [:oban, :engine, :insert_job, :stop]})
-    :telemetry.detach({Appsignal.Oban, [:oban, :engine, :insert_job, :exception]})
+  describe "when :instrument_oban is set to false" do
+    setup do
+      :telemetry.detach({Appsignal.Oban, [:oban, :job, :start]})
+      :telemetry.detach({Appsignal.Oban, [:oban, :job, :stop]})
+      :telemetry.detach({Appsignal.Oban, [:oban, :job, :exception]})
+      :telemetry.detach({Appsignal.Oban, [:oban, :engine, :insert_job, :start]})
+      :telemetry.detach({Appsignal.Oban, [:oban, :engine, :insert_job, :stop]})
+      :telemetry.detach({Appsignal.Oban, [:oban, :engine, :insert_job, :exception]})
 
-    with_config(%{instrument_oban: false}, fn -> Appsignal.start([], []) end)
+      with_config(%{instrument_oban: false}, fn -> Appsignal.start([], []) end)
 
-    assert !attached?([:oban, :job, :start])
-    assert !attached?([:oban, :job, :stop])
-    assert !attached?([:oban, :job, :exception])
-    assert !attached?([:oban, :engine, :insert_job, :start])
-    assert !attached?([:oban, :engine, :insert_job, :stop])
-    assert !attached?([:oban, :engine, :insert_job, :exception])
+      on_exit(fn ->
+        [:ok, :ok, :ok, :ok, :ok, :ok] = Appsignal.Oban.attach()
+      end)
+    end
 
-    [:ok, :ok, :ok, :ok, :ok, :ok] = Appsignal.Oban.attach()
+    test "does not attach to Oban events" do
+      assert !attached?([:oban, :job, :start])
+      assert !attached?([:oban, :job, :stop])
+      assert !attached?([:oban, :job, :exception])
+      assert !attached?([:oban, :engine, :insert_job, :start])
+      assert !attached?([:oban, :engine, :insert_job, :stop])
+      assert !attached?([:oban, :engine, :insert_job, :exception])
+    end
   end
 
   describe "oban_job_start/4" do


### PR DESCRIPTION
This patch fixes the brittleness in the ObanTest, as shown in the [brittle](https://appsignal.semaphoreci.com/branches/f2dc647d-3c7d-45b7-8641-9b4916196050) branch, from which these fixes are extracted.

Part of https://github.com/appsignal/appsignal-elixir/issues/811.
[skip changeset]