### PR TITLE
Hardcode log format to plaintext

### DIFF
--- a/.changesets/bump-agent-to-8d042e2.md
+++ b/.changesets/bump-agent-to-8d042e2.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 8d042e2.
+
+- Support multiple log formats.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "0d593d5"
+  def version, do: "8d042e2"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "8e63a3b1ee61165914e6dbb8654c1ad7f096079c77d0559c1733dff15103f4ab",
+        checksum: "e0142859f35e31b52dcc57418636c05bcb21940ad499bbe255f90a1cf7359bf7",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "8e63a3b1ee61165914e6dbb8654c1ad7f096079c77d0559c1733dff15103f4ab",
+        checksum: "e0142859f35e31b52dcc57418636c05bcb21940ad499bbe255f90a1cf7359bf7",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "cdf323d1b411f45084c13dc4a2c0f980599273d64ab91a28cd07bbc48b3293f6",
+        checksum: "5a1ab02452497b29222d580f3e9d3649eb547b8c90338858462d4f221dd18ff9",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "cdf323d1b411f45084c13dc4a2c0f980599273d64ab91a28cd07bbc48b3293f6",
+        checksum: "5a1ab02452497b29222d580f3e9d3649eb547b8c90338858462d4f221dd18ff9",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "cdf323d1b411f45084c13dc4a2c0f980599273d64ab91a28cd07bbc48b3293f6",
+        checksum: "5a1ab02452497b29222d580f3e9d3649eb547b8c90338858462d4f221dd18ff9",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "a6baf7c586722c71c9d5ec885c8ca17da6b9fc9c5d7ab154a7b667f28d082a0f",
+        checksum: "0e85a0a13b9457c4ee1f316e92e8d95de9125bbaff90ceb826bcefaaffa413d9",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "c102053fe1f68af84d0b362bd892256981bc4a2dec7e12fec27ea57ba0efbda2",
+        checksum: "0e8a0490ca960bb8e57183156ed4999afbd70cf13c640fe96f9b0e25556075f1",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "c102053fe1f68af84d0b362bd892256981bc4a2dec7e12fec27ea57ba0efbda2",
+        checksum: "0e8a0490ca960bb8e57183156ed4999afbd70cf13c640fe96f9b0e25556075f1",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "8f3987d22f0fcbd466377e624aa645c5b9b0f4bbc88855ddb7076b09b9a8d42a",
+        checksum: "4eec193edeae76e0793789846112ac9127870c90a8ae6e47aa2a8490163733aa",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "e353e165f828cb788c85199adb1b39f15c26406da948117a34b4944f6eabfabc",
+        checksum: "d91d1ed6e775cc00319fca0a4144dff064d31fb6a8a28dbb5027add44e4dab02",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "b08c5d65fbff05ac6838aa0ed4614b669701f009826652f7d67ab423fede0e44",
+        checksum: "0ff6702bd976871f610f39ff6c2dd73c4535b12c15c81c0d0afab7650e75922d",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "f516b4c84274b9c56cbcb11c252685a4ef97b68b9fec6c189dde96fd37bbf515",
+        checksum: "d973edc7f13cdad2993c415f17a680a4de3288ce57fc5ae0c69ef3a1ccbb2856",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "f516b4c84274b9c56cbcb11c252685a4ef97b68b9fec6c189dde96fd37bbf515",
+        checksum: "d973edc7f13cdad2993c415f17a680a4de3288ce57fc5ae0c69ef3a1ccbb2856",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -1288,6 +1288,7 @@ static ERL_NIF_TERM _log(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   appsignal_log(
     make_appsignal_string(group),
     severity,
+    0,
     make_appsignal_string(message),
     data_ptr->data
   );


### PR DESCRIPTION
Use latest agent build with an extra argument for format. Unused in the Elixir integration at the moment.