### PR TITLE
Logger backend

### DIFF
--- a/.changesets/add-logger-backend.md
+++ b/.changesets/add-logger-backend.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add Logger backend to redirect Elixir logs to AppSignal.

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -57,7 +57,7 @@ defmodule Appsignal.Logger do
   end
 
   @spec log(log_level(), String.t(), String.t(), %{}) :: :ok
-  defp log(log_level, group, message, metadata) do
+  def log(log_level, group, message, metadata) do
     severity = @severity[log_level]
     encoded_metadata = Appsignal.Utils.DataEncoder.encode(metadata)
 

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -6,6 +6,7 @@ defmodule Appsignal.Logger do
     debug: 2,
     info: 3,
     notice: 4,
+    warn: 5,
     warning: 5,
     error: 6,
     critical: 7,

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -2,17 +2,6 @@ defmodule Appsignal.Logger do
   require Appsignal.Utils
 
   @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
-  @severity %{
-    debug: 2,
-    info: 3,
-    notice: 4,
-    warn: 5,
-    warning: 5,
-    error: 6,
-    critical: 7,
-    alert: 8,
-    emergency: 9
-  }
 
   @type log_level ::
           :debug | :info | :notice | :warning | :error | :critical | :alert | :emergency
@@ -59,14 +48,19 @@ defmodule Appsignal.Logger do
 
   @spec log(log_level(), String.t(), String.t(), %{}) :: :ok
   def log(log_level, group, message, metadata) do
-    severity = @severity[log_level]
     encoded_metadata = Appsignal.Utils.DataEncoder.encode(metadata)
 
-    @nif.log(
-      group,
-      severity,
-      message,
-      encoded_metadata
-    )
+    @nif.log(group, severity(log_level), message, encoded_metadata)
   end
+
+  defp severity(:debug), do: 2
+  defp severity(:info), do: 3
+  defp severity(:notice), do: 4
+  defp severity(:warn), do: 5
+  defp severity(:warning), do: 5
+  defp severity(:error), do: 6
+  defp severity(:critical), do: 7
+  defp severity(:alert), do: 8
+  defp severity(:emergency), do: 9
+  defp severity(_), do: 3
 end

--- a/lib/appsignal/logger/backend.ex
+++ b/lib/appsignal/logger/backend.ex
@@ -1,20 +1,22 @@
 defmodule Appsignal.Logger.Backend do
   @behaviour :gen_event
 
-  def init({__MODULE__, group}) do
-    {:ok, group}
+  def init({__MODULE__, options}) do
+    {:ok, Keyword.merge([group: "app"], options)}
   end
 
-  def init(_) do
-    {:ok, "app"}
+  def handle_event({level, _gl, {Logger, message, _timestamp, metadata}}, options) do
+    Appsignal.Logger.log(
+      level,
+      options[:group],
+      IO.chardata_to_string(message),
+      Enum.into(metadata, %{})
+    )
+
+    {:ok, options}
   end
 
-  def handle_event({level, _gl, {Logger, message, _timestamp, metadata}}, group) do
-    Appsignal.Logger.log(level, group, IO.chardata_to_string(message), Enum.into(metadata, %{}))
-    {:ok, group}
-  end
-
-  def handle_call(_messsage, group) do
-    {:ok, nil, group}
+  def handle_call(_messsage, options) do
+    {:ok, nil, options}
   end
 end

--- a/lib/appsignal/logger/backend.ex
+++ b/lib/appsignal/logger/backend.ex
@@ -6,7 +6,7 @@ defmodule Appsignal.Logger.Backend do
   end
 
   def init(_) do
-    {:ok, "phoenix"}
+    {:ok, "app"}
   end
 
   def handle_event({level, _gl, {Logger, message, _timestamp, metadata}}, group) do

--- a/lib/appsignal/logger/backend.ex
+++ b/lib/appsignal/logger/backend.ex
@@ -1,0 +1,20 @@
+defmodule Appsignal.Logger.Backend do
+  @behaviour :gen_event
+
+  def init({__MODULE__, group}) do
+    {:ok, group}
+  end
+
+  def init(_) do
+    {:ok, "phoenix"}
+  end
+
+  def handle_event({level, _gl, {Logger, message, _timestamp, metadata}}, group) do
+    Appsignal.Logger.log(level, group, IO.chardata_to_string(message), Enum.into(metadata, %{}))
+    {:ok, group}
+  end
+
+  def handle_call(_messsage, group) do
+    {:ok, nil, group}
+  end
+end

--- a/test/appsignal/logger/backend_test.exs
+++ b/test/appsignal/logger/backend_test.exs
@@ -1,0 +1,39 @@
+defmodule Appsignal.Logger.BackendTest do
+  use ExUnit.Case
+
+  setup do
+    start_supervised!(Appsignal.Test.Nif)
+    :ok
+  end
+
+  test "handle_event/2 sends logs to the extension" do
+    Appsignal.Logger.Backend.handle_event(
+      {
+        :info,
+        self(),
+        {
+          Logger,
+          ~c"foo bar baz",
+          {{2023, 2, 23}, {14, 25, 56, 241}},
+          [
+            erl_level: :info,
+            application: :phoenix,
+            domain: [:elixir],
+            file: "lib/phoenix/logger.ex",
+            function: "phoenix_endpoint_start/4",
+            gl: self(),
+            line: 211,
+            mfa: {Phoenix.Logger, :phoenix_endpoint_start, 4},
+            module: Phoenix.Logger,
+            pid: self(),
+            request_id: "F0Z3jGx7KNZWD9gAAAFD",
+            time: 1_677_159_356_241_326
+          ]
+        }
+      },
+      "phoenix"
+    )
+
+    assert [{"phoenix", 3, "foo bar baz", _}] = Appsignal.Test.Nif.get!(:log)
+  end
+end

--- a/test/appsignal/logger/backend_test.exs
+++ b/test/appsignal/logger/backend_test.exs
@@ -31,7 +31,7 @@ defmodule Appsignal.Logger.BackendTest do
           ]
         }
       },
-      "phoenix"
+      group: "phoenix"
     )
 
     assert [{"phoenix", 3, "foo bar baz", _}] = Appsignal.Test.Nif.get!(:log)

--- a/test/appsignal/logger_test.exs
+++ b/test/appsignal/logger_test.exs
@@ -7,6 +7,30 @@ defmodule Appsignal.LoggerTest do
     :ok
   end
 
+  test "log/4 sends the log calls through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.log(:debug, "app", "This is a debug", metadata)
+    Logger.log(:info, "app", "This is an info", metadata)
+    Logger.log(:notice, "app", "This is a notice", metadata)
+    Logger.log(:warning, "app", "This is a warning", metadata)
+    Logger.log(:error, "app", "This is an error", metadata)
+    Logger.log(:critical, "app", "This is a critical", metadata)
+    Logger.log(:alert, "app", "This is an alert", metadata)
+    Logger.log(:emergency, "app", "This is an emergency", metadata)
+
+    assert [
+             {"app", 9, "This is an emergency", _},
+             {"app", 8, "This is an alert", _},
+             {"app", 7, "This is a critical", _},
+             {"app", 6, "This is an error", _},
+             {"app", 5, "This is a warning", _},
+             {"app", 4, "This is a notice", _},
+             {"app", 3, "This is an info", _},
+             {"app", 2, "This is a debug", _}
+           ] = Test.Nif.get!(:log)
+  end
+
   test "debug/3 sends the debug log call through the extension" do
     metadata = %{some: "metadata"}
 

--- a/test/appsignal/logger_test.exs
+++ b/test/appsignal/logger_test.exs
@@ -14,6 +14,7 @@ defmodule Appsignal.LoggerTest do
     Logger.log(:info, "app", "This is an info", metadata)
     Logger.log(:notice, "app", "This is a notice", metadata)
     Logger.log(:warning, "app", "This is a warning", metadata)
+    Logger.log(:warn, "app", "This is a warn", metadata)
     Logger.log(:error, "app", "This is an error", metadata)
     Logger.log(:critical, "app", "This is a critical", metadata)
     Logger.log(:alert, "app", "This is an alert", metadata)
@@ -24,6 +25,7 @@ defmodule Appsignal.LoggerTest do
              {"app", 8, "This is an alert", _},
              {"app", 7, "This is a critical", _},
              {"app", 6, "This is an error", _},
+             {"app", 5, "This is a warn", _},
              {"app", 5, "This is a warning", _},
              {"app", 4, "This is a notice", _},
              {"app", 3, "This is an info", _},

--- a/test/appsignal/logger_test.exs
+++ b/test/appsignal/logger_test.exs
@@ -19,8 +19,10 @@ defmodule Appsignal.LoggerTest do
     Logger.log(:critical, "app", "This is a critical", metadata)
     Logger.log(:alert, "app", "This is an alert", metadata)
     Logger.log(:emergency, "app", "This is an emergency", metadata)
+    Logger.log(:rhubarb, "app", "This is a... rhubarb?", metadata)
 
     assert [
+             {"app", 3, "This is a... rhubarb?", _},
              {"app", 9, "This is an emergency", _},
              {"app", 8, "This is an alert", _},
              {"app", 7, "This is a critical", _},


### PR DESCRIPTION
With the new logger backend, users can redirect their logs to AppSignal by attaching the backend in their application.ex files:

``` elixir
Logger.add_backend({Appsignal.Logger.Backend, [group: "phoenix"]})
```


Closes #800.