### PR TITLE
Add changeset for agent bump to dee4fcb

### DIFF
--- a/.changesets/bump-agent-to-dee4fcb.md
+++ b/.changesets/bump-agent-to-dee4fcb.md
@@ -1,0 +1,9 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to dee4fcb.
+
+- Support cgroups v2. Used by newer Docker engines to report host metrics. Upgrade if you receive no host metrics for Docker containers.
+- Remove trailing comments in SQL queries, ensuring queries are grouped consistently.


### PR DESCRIPTION
The agent bump was pushed directly on the main branch without a changeset. Add a changeset so it's more clear that the agent was updated and what changes it brought.

[skip ci]