### PR TITLE
Explicitly order configuration options in diagnose

### DIFF
--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -252,7 +252,9 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
     # the config option. It's a private config option.
     filtered_options = Enum.reject(config[:options], fn {key, _} -> key == :diagnose_endpoint end)
 
-    Enum.each(filtered_options, fn {key, _} = option ->
+    filtered_options
+    |> Enum.sort
+    |> Enum.each(fn {key, _} = option ->
       config_label = configuration_option_label(option)
       option_sources = config[:sources]
       sources = sources_for_option(key, option_sources)


### PR DESCRIPTION
Maps over 32 items drop their ordering, so this patch explicitly orders items before printing them.
Part of #834.

[skip changeset]