### PR TITLE
Handle unexpected events in Error.Backend

### DIFF
--- a/.changesets/handle-unexpected-events-in-logger-backend.md
+++ b/.changesets/handle-unexpected-events-in-logger-backend.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Handle unexpected events in Logger backend

--- a/lib/appsignal/logger/backend.ex
+++ b/lib/appsignal/logger/backend.ex
@@ -17,6 +17,10 @@ defmodule Appsignal.Logger.Backend do
     {:ok, options}
   end
 
+  def handle_event(_event, options) do
+    {:ok, options}
+  end
+
   def handle_call(_messsage, options) do
     {:ok, nil, options}
   end

--- a/test/appsignal/error/backend_test.exs
+++ b/test/appsignal/error/backend_test.exs
@@ -207,6 +207,12 @@ defmodule Appsignal.Error.BackendTest do
     end
   end
 
+  describe "handle_event/2, with an unexpected event" do
+    test "replies with :ok" do
+      assert Backend.handle_event(:event, %{}) == {:ok, %{}}
+    end
+  end
+
   describe "handle_call/2" do
     test "replies with :ok" do
       assert Backend.handle_call(:call, %{}) == {:ok, :ok, %{}}


### PR DESCRIPTION
As reported in #836, the error backend crashes when it receives an unexpected event. This patch adds a catch all so these events call a noop.

To test this, switch your appsignal dependency to the `logger-backend-error` branch:

``` elixir
{:appsignal, github: "appsignal/appsignal-elixir", branch: "logger-backend-error", override: true},
```