### PR TITLE
Update agent to version 6f29190

### DIFF
--- a/.changesets/update-agent-6f29190.md
+++ b/.changesets/update-agent-6f29190.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update agent to version 6f29190.
+
+- Log revision config in boot debug log.
+- Update internal agent CLI start command.
+- Rename internal `_APPSIGNAL_ENVIRONMENT` variable to `_APPSIGNAL_APP_ENV` to be consistent with the public version.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "dee4fcb"
+  def version, do: "6f29190"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "d45bfc2eb38138c317b501c3156459b8dbbb15a59910f1e2ec3d2d02e461a147",
+        checksum: "022896c1f1e86376dab439b80c5c29075b8ee57e13bb53254b1d2724567e434d",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "d45bfc2eb38138c317b501c3156459b8dbbb15a59910f1e2ec3d2d02e461a147",
+        checksum: "022896c1f1e86376dab439b80c5c29075b8ee57e13bb53254b1d2724567e434d",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "1cd875e74ba18c2bc81533437a9eebdf08f624e0201427c13326c2be00f22907",
+        checksum: "551dfefd447ceb0bda5ea1d94cc2809296a5ae41789e96330fe9b88c4afe29f1",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "1cd875e74ba18c2bc81533437a9eebdf08f624e0201427c13326c2be00f22907",
+        checksum: "551dfefd447ceb0bda5ea1d94cc2809296a5ae41789e96330fe9b88c4afe29f1",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "1cd875e74ba18c2bc81533437a9eebdf08f624e0201427c13326c2be00f22907",
+        checksum: "551dfefd447ceb0bda5ea1d94cc2809296a5ae41789e96330fe9b88c4afe29f1",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "72fbfaa1c6ed72defea9eca59679372f53ddeab845a9b2f75d9d165e4983d69e",
+        checksum: "860dc4079f1bf2a9608523bef8d0cb8b6fadff7e83332fc09658eeb5d32eb3bc",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "c504a7233512c9285274a7ba0142ab91cf4637c6f5f57c58c6890137ba0f82de",
+        checksum: "fbf5d2869c9cce9ac35cffee6b139bd8d9b01018a7173417febff7c77599a7b2",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "c504a7233512c9285274a7ba0142ab91cf4637c6f5f57c58c6890137ba0f82de",
+        checksum: "fbf5d2869c9cce9ac35cffee6b139bd8d9b01018a7173417febff7c77599a7b2",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "f9e68dbbee7d38b255c5b9bc0cb75226764f79cd51421e4e00a9e7454b0c6ccb",
+        checksum: "8c4f2b96e2dd5c158bf46f46608901b9163998b6377a1795318ea9f366337eb1",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "8fa1d110d2544502509cc66ba8ec6685010d8c6d8373f4f14ebe721d4be157e0",
+        checksum: "2f3c5dfa997d9399032039e03ed8bd627892fecd3331367a3b83dc29d0c28497",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "a43895183baf017879332885a904208773befc14b9bd628efae6d1513052b782",
+        checksum: "abbc61bfe1009de9a7e11534647c7b60b38c2b35357e77356d7dfb1067acb4d0",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "1b992f770bdbced09f7b5f18d7aa721710218d4a76a131adc7affe44d68684f0",
+        checksum: "d286e1338c80ec5e6f0104e53f27dfe420b3994eb7bb16ac4b32c06ec1405f33",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "1b992f770bdbced09f7b5f18d7aa721710218d4a76a131adc7affe44d68684f0",
+        checksum: "d286e1338c80ec5e6f0104e53f27dfe420b3994eb7bb16ac4b32c06ec1405f33",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -421,7 +421,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_ENABLE_HOST_METRICS", to_string(config[:enable_host_metrics]))
     Nif.env_put("_APPSIGNAL_ENABLE_STATSD", to_string(config[:enable_statsd]))
     Nif.env_put("_APPSIGNAL_ENABLE_NGINX_METRICS", to_string(config[:enable_nginx_metrics]))
-    Nif.env_put("_APPSIGNAL_ENVIRONMENT", to_string(config[:env]))
+    Nif.env_put("_APPSIGNAL_APP_ENV", to_string(config[:env]))
     Nif.env_put("_APPSIGNAL_HOSTNAME", to_string(config[:hostname]))
     Nif.env_put("_APPSIGNAL_HTTP_PROXY", to_string(config[:http_proxy]))
     Nif.env_put("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -1186,7 +1186,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_DEBUG_LOGGING") == ~c"true"
           assert Nif.env_get("_APPSIGNAL_DNS_SERVERS") == ~c"8.8.8.8,8.8.4.4"
           assert Nif.env_get("_APPSIGNAL_ENABLE_HOST_METRICS") == ~c"false"
-          assert Nif.env_get("_APPSIGNAL_ENVIRONMENT") == ~c"prod"
+          assert Nif.env_get("_APPSIGNAL_APP_ENV") == ~c"prod"
           assert Nif.env_get("_APPSIGNAL_HOSTNAME") == ~c"My hostname"
           assert Nif.env_get("_APPSIGNAL_HTTP_PROXY") == ~c"http://10.10.10.10:8888"
 
@@ -1262,7 +1262,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_ACTIVE") == ~c"true"
           assert Nif.env_get("_APPSIGNAL_DEBUG_LOGGING") == ~c"false"
           assert Nif.env_get("_APPSIGNAL_ENABLE_HOST_METRICS") == ~c"true"
-          assert Nif.env_get("_APPSIGNAL_ENVIRONMENT") == ~c"prod"
+          assert Nif.env_get("_APPSIGNAL_APP_ENV") == ~c"prod"
           assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == ~c"false"
           assert Nif.env_get("_APPSIGNAL_FILES_WORLD_ACCESSIBLE") == ~c"false"
           assert Nif.env_get("_APPSIGNAL_TRANSACTION_DEBUG_MODE") == ~c"false"


### PR DESCRIPTION
## Rename APPSIGNAL_ENVIRONMENT to public env version

Rename the internal APPSIGNAL_ENVIRONMENT env var to the publicly known
APPSIGNAL_APP_ENV env var.

This makes all the agent config options consistent with each other.

[skip changeset] because it requires an agent update that will include
a changeset.

## Update agent to version 6f29190

- Log revision config in boot debug log.
- Update internal agent CLI start command.
- Rename internal `_APPSIGNAL_ENVIRONMENT` variable to
  `_APPSIGNAL_APP_ENV` to be consistent with the public version.

