### PR TITLE
Absinthe support

### DIFF
--- a/.changesets/add-absinthe-instrumentation.md
+++ b/.changesets/add-absinthe-instrumentation.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add Absinthe instrumentation

--- a/.changesets/add-absinthe-instrumentation.md
+++ b/.changesets/add-absinthe-instrumentation.md
@@ -1,6 +1,0 @@
----
-bump: "minor"
-type: "add"
----
-
-Add Absinthe instrumentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AppSignal for Elixir changelog
 
+## 2.7.0-beta.1
+
+### Added
+
+- [45deeedd](https://github.com/appsignal/appsignal-elixir/commit/45deeedd82273df88812fd96e25260dab9f71a00) minor - Add Absinthe instrumentation
+
 ## 2.6.1
 
 ### Fixed

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -38,6 +38,10 @@ defmodule Appsignal do
       Appsignal.Oban.attach()
     end
 
+    if Config.instrument_absinthe?() do
+      Appsignal.Absinthe.attach()
+    end
+
     children = [
       {Appsignal.Tracer, []},
       {Appsignal.Monitor, []},

--- a/lib/appsignal/absinthe.ex
+++ b/lib/appsignal/absinthe.ex
@@ -1,0 +1,53 @@
+defmodule Appsignal.Absinthe do
+  require Appsignal.Utils
+
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+
+  @moduledoc false
+
+  require Logger
+
+  def attach do
+    handlers = %{
+      [:absinthe, :execute, :operation, :start] => &__MODULE__.absinthe_execute_operation_start/4,
+      [:absinthe, :execute, :operation, :stop] => &__MODULE__.absinthe_execute_operation_stop/4
+    }
+
+    for {event, fun} <- handlers do
+      detach = :telemetry.detach({__MODULE__, event})
+      attach = :telemetry.attach({__MODULE__, event}, event, fun, :ok)
+
+      case {detach, attach} do
+        {:ok, :ok} ->
+          _ =
+            Appsignal.IntegrationLogger.debug(
+              "Appsignal.Absinthe reattached to #{inspect(event)}"
+            )
+
+          :ok
+
+        {{:error, :not_found}, :ok} ->
+          _ =
+            Appsignal.IntegrationLogger.debug("Appsignal.Absinthe attached to #{inspect(event)}")
+
+          :ok
+
+        {_, {:error, _} = error} ->
+          Logger.warn("Appsignal.Absinthe not attached to #{inspect(event)}: #{inspect(error)}")
+
+          error
+      end
+    end
+  end
+
+  def absinthe_execute_operation_start(_event, _measurements, _metadata, _config) do
+    @tracer.create_span("absinthe")
+    |> @span.set_name("graphql")
+    |> @span.set_attribute("appsignal:category", "call.graphql")
+  end
+
+  def absinthe_execute_operation_stop(_event, _measurements, _metadata, _config) do
+    @tracer.close_span(@tracer.current_span())
+  end
+end

--- a/lib/appsignal/absinthe.ex
+++ b/lib/appsignal/absinthe.ex
@@ -42,7 +42,7 @@ defmodule Appsignal.Absinthe do
   end
 
   def absinthe_execute_operation_start(_event, _measurements, _metadata, _config) do
-    @tracer.create_span("absinthe")
+    @tracer.create_span("http_request")
     |> @span.set_name("graphql")
     |> @span.set_attribute("appsignal:category", "call.graphql")
   end

--- a/lib/appsignal/absinthe.ex
+++ b/lib/appsignal/absinthe.ex
@@ -42,7 +42,8 @@ defmodule Appsignal.Absinthe do
   end
 
   def absinthe_execute_operation_start(_event, _measurements, _metadata, _config) do
-    @tracer.create_span("http_request")
+    "http_request"
+    |> @tracer.create_span(@tracer.current_span())
     |> @span.set_name("graphql")
     |> @span.set_attribute("appsignal:category", "call.graphql")
   end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -22,6 +22,7 @@ defmodule Appsignal.Config do
     ignore_actions: [],
     ignore_errors: [],
     ignore_namespaces: [],
+    instrument_absinthe: true,
     instrument_ecto: true,
     instrument_finch: true,
     instrument_oban: true,
@@ -238,6 +239,13 @@ defmodule Appsignal.Config do
 
       _ ->
         "all"
+    end
+  end
+
+  def instrument_absinthe? do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, value} -> !!Map.get(value, :instrument_absinthe, true)
+      _ -> true
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Appsignal.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/appsignal/appsignal-elixir"
-  @version "2.6.1"
+  @version "2.7.0-beta.1"
 
   def project do
     [

--- a/test/appsignal/absinthe_test.exs
+++ b/test/appsignal/absinthe_test.exs
@@ -1,0 +1,123 @@
+defmodule Appsignal.AbsintheTest do
+  use ExUnit.Case
+  alias Appsignal.{FakeAppsignal, Span, Test, Tracer}
+  import AppsignalTest.Utils, only: [with_config: 2]
+
+  setup do
+    start_supervised!(Test.Nif)
+    start_supervised!(Test.Tracer)
+    start_supervised!(Test.Span)
+    start_supervised!(Test.Monitor)
+
+    :ok
+  end
+
+  test "attaches to Absinthe events automatically" do
+    assert attached?([:absinthe, :execute, :operation, :start])
+    assert attached?([:absinthe, :execute, :operation, :stop])
+  end
+
+  describe "when :instrument_absinthe is set to false" do
+    setup do
+      :telemetry.detach({Appsignal.Absinthe, [:absinthe, :execute, :operation, :start]})
+      :telemetry.detach({Appsignal.Absinthe, [:absinthe, :execute, :operation, :stop]})
+
+      with_config(%{instrument_absinthe: false}, fn -> Appsignal.start([], []) end)
+
+      on_exit(fn ->
+        [:ok, :ok] = Appsignal.Absinthe.attach()
+      end)
+    end
+
+    test "does not attach to Absinthe events" do
+      assert !attached?([:absinthe, :execute, :operation, :start])
+      assert !attached?([:absinthe, :execute, :operation, :stop])
+    end
+  end
+
+  describe "absinthe_execute_operation_start/4" do
+    setup do
+      execute_operation_start()
+    end
+
+    test "creates a span" do
+      assert {:ok, [{"http_request", nil}]} = Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "graphql"}]} = Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert attribute?("appsignal:category", "call.graphql")
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:absinthe, :execute, :operation, :start])
+    end
+  end
+
+  describe "execute_operation_stop/4" do
+    setup do
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      execute_operation_start()
+      span = Tracer.current_span()
+      execute_operation_stop()
+
+      [span: span, fake_appsignal: fake_appsignal]
+    end
+
+    test "closes the span", %{span: span} do
+      {:ok, closed_spans} = Test.Tracer.get(:close_span)
+      assert Enum.member?(closed_spans, {span})
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:absinthe, :execute, :operation, :stop])
+    end
+  end
+
+  defp attribute?(asserted_key, asserted_data) do
+    {:ok, attributes} = Test.Span.get(:set_attribute)
+
+    Enum.any?(attributes, fn {%Span{}, key, data} ->
+      key == asserted_key and data == asserted_data
+    end)
+  end
+
+  defp has_attribute?(asserted_key) do
+    {:ok, attributes} = Test.Span.get(:set_attribute)
+
+    Enum.any?(attributes, fn {%Span{}, key, _data} ->
+      key == asserted_key
+    end)
+  end
+
+  defp attached?(event, function \\ nil) do
+    event
+    |> :telemetry.list_handlers()
+    |> Enum.any?(fn %{id: id} ->
+      case function do
+        nil -> true
+        f -> function == f
+      end && id == {Appsignal.Absinthe, event}
+    end)
+  end
+
+  defp execute_operation_start(additional_metadata \\ %{}) do
+    :telemetry.execute(
+      [:absinthe, :execute, :operation, :start],
+      %{},
+      %{}
+    )
+  end
+
+  defp execute_operation_stop(additional_metadata \\ %{}) do
+    :telemetry.execute(
+      [:absinthe, :execute, :operation, :stop],
+      %{duration: 123 * 1_000_000},
+      %{}
+    )
+  end
+end

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -259,6 +259,30 @@ defmodule Appsignal.ConfigTest do
     end
   end
 
+  describe "instrument_absinthe?" do
+    test "when true" do
+      assert with_config(
+               %{instrument_absinthe: true},
+               &Config.instrument_absinthe?/0
+             )
+    end
+
+    test "when false" do
+      refute with_config(
+               %{instrument_absinthe: false},
+               &Config.instrument_absinthe?/0
+             )
+    end
+
+    test "when unset" do
+      assert with_config(%{}, &Config.instrument_absinthe?/0)
+    end
+
+    test "without an appsignal config" do
+      assert without_config(&Config.instrument_absinthe?/0)
+    end
+  end
+
   describe "report_oban_errors" do
     test "when discard" do
       assert with_config(
@@ -1321,6 +1345,7 @@ defmodule Appsignal.ConfigTest do
       send_session_data: true,
       skip_session_data: false,
       transaction_debug_mode: false,
+      instrument_absinthe: true,
       instrument_ecto: true,
       instrument_finch: true,
       instrument_oban: true,


### PR DESCRIPTION
Continuation of https://github.com/appsignal/appsignal-elixir/pull/834, which wasn’t supposed to be released yet, as we’re still working on documentation. Consider this a tracking issue.

- [ ] ~Update changelog: the absinthe support was previously released as a beta, so the changeset was removed. This probably needs a new changeset to bump it to 2.7.0.~
- [ ] Documentation: https://github.com/appsignal/appsignal-docs/issues/1288
- [ ] Blogpost: To be determined, discussing with @mmaksimovic and @noccor tomorrow. https://github.com/appsignal/appsignal-nextjs-blog/issues/860

[skip-review]