### PR TITLE
Create Finch span without root span

### DIFF
--- a/.changesets/always-create-a-finch-span-for-a--finch-request.md
+++ b/.changesets/always-create-a-finch-span-for-a--finch-request.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Always create a Finch span for a Finch request, regardless of whether there's a current active span.

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -55,12 +55,10 @@ defmodule Appsignal.Finch do
     nil
   end
 
-  defp do_finch_request_start(nil, _name, _request), do: nil
-
   defp do_finch_request_start(parent, _name, request) do
     uri = %URI{scheme: Atom.to_string(request.scheme), host: request.host, port: request.port}
 
-    "http_request"
+    "finch"
     |> @tracer.create_span(parent)
     |> @span.set_name("#{request.method} #{URI.to_string(uri)}")
     |> @span.set_attribute("appsignal:category", "request.finch")
@@ -71,6 +69,8 @@ defmodule Appsignal.Finch do
   end
 
   def finch_request_stop(_event, _measurements, _metadata, _config) do
+    # See comment for `finch_request_start` above.
+
     nil
   end
 

--- a/test/appsignal/finch_test.exs
+++ b/test/appsignal/finch_test.exs
@@ -47,8 +47,8 @@ defmodule Appsignal.FinchTest do
       )
     end
 
-    test "does not create a span" do
-      assert Test.Tracer.get(:create_span) == :error
+    test "creates a root span" do
+      assert {:ok, [{"finch", nil}]} = Test.Tracer.get(:create_span)
     end
   end
 
@@ -147,7 +147,7 @@ defmodule Appsignal.FinchTest do
     end
 
     test "creates a span with a parent" do
-      assert {:ok, [{"http_request", %Span{}}]} = Test.Tracer.get(:create_span)
+      assert {:ok, [{"finch", %Span{}}]} = Test.Tracer.get(:create_span)
     end
 
     test "sets the span's name" do


### PR DESCRIPTION
Even if there is no current active span, create a Finch root span. This behaviour should be easier to understand and debug for users, and should lead to request counts that better match their expectations.

Use the `finch` namespace to avoid polluting the main performance view with Finch root spans.

See the motivation for this change in this ~rant~ [Slack thread](https://appsignal.slack.com/archives/CNPP953E2/p1683706918934089). If you think this is a bad idea, please tell me.