### PR TITLE
Bump agent to version 6ac961d

### DIFF
--- a/.changesets/trim-sql-attributes-in-spans.md
+++ b/.changesets/trim-sql-attributes-in-spans.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Trim SQL attributes in spans. This fixes an issue where very big payloads are sent from the Elixir integration.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "4a0a036"
+  def version, do: "6ac961d"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "b5bd080e409cc2fb9031281363c8a85272af65277ac8c7aeb49c14c2272eedde",
+        checksum: "f9da1f120dd09c57f236d3f442a24dc6f91104f87217ce3227c763386fb80608",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "b5bd080e409cc2fb9031281363c8a85272af65277ac8c7aeb49c14c2272eedde",
+        checksum: "f9da1f120dd09c57f236d3f442a24dc6f91104f87217ce3227c763386fb80608",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "b39d9192cf4f20b97ba0ffc794045433f02c2814a69c5a5b72e2fb414ce30085",
+        checksum: "e2a7ed02f628389cce6da7b0854abb0a88a11d4ed5464aaa4de6b57d914f4049",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "b39d9192cf4f20b97ba0ffc794045433f02c2814a69c5a5b72e2fb414ce30085",
+        checksum: "e2a7ed02f628389cce6da7b0854abb0a88a11d4ed5464aaa4de6b57d914f4049",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "b39d9192cf4f20b97ba0ffc794045433f02c2814a69c5a5b72e2fb414ce30085",
+        checksum: "e2a7ed02f628389cce6da7b0854abb0a88a11d4ed5464aaa4de6b57d914f4049",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "b6c9317fa17063f25c73a6464ae84d4da1677cfa711538c8fd58b9198f04ac31",
+        checksum: "0c54cf8fd771c1ab4a8296dadd3310ab22ba3a2d1de0e21045c54bd7d5ddbbcc",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "b3b5d9217df1f40eb1187ea6188f5aaf55a17f91ece4a749bd9bf316b63ff09c",
+        checksum: "c1df0c787ff637e5583e233a348c713e207691dd9a76cf9f13395cd47a24eca8",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "b3b5d9217df1f40eb1187ea6188f5aaf55a17f91ece4a749bd9bf316b63ff09c",
+        checksum: "c1df0c787ff637e5583e233a348c713e207691dd9a76cf9f13395cd47a24eca8",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "bbc9bb6fe66a562b0ad36dc8d0a79ea0e6bd8bf9e7df5d5d4ba0a3b22de84460",
+        checksum: "3b4d6bc3f6bf81f6036c3eadeb7d085cae08dbdc90948d95dad82106e5ba40d9",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "34ee2de65a2509847d72a9a5a649b0714dbba6431e4bfa0c81c7d6280320bfd4",
+        checksum: "c429a06360396a7a81d4c2a45f5ac4a50a7dd48c43f745fd4df0e3ad2c0c3745",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "495367c3190b0f03d0aaa3c9bdfd51edb1da2ac08312e1b246cbd9ff1ff462f5",
+        checksum: "0919bd046151966d53332025bc2c25245ab2f50c7146556d7f1ba0f898922cd9",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "fac3a7cb98fba93a63d47b49345c71c88806ed914417bb18ba12b5c9a02975d9",
+        checksum: "892ab353756631be9cc763a78031755e72880dd9b9f2d1b9efc553cb3f282c41",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "fac3a7cb98fba93a63d47b49345c71c88806ed914417bb18ba12b5c9a02975d9",
+        checksum: "892ab353756631be9cc763a78031755e72880dd9b9f2d1b9efc553cb3f282c41",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }


### PR DESCRIPTION
This includes a fix for the `set_attribute_sql_string` to truncate very long SQL strings, preventing very big payload sizes.