### PR TITLE
Implement Tesla instrumentation

### DIFF
--- a/.changesets/add-tesla-integration.md
+++ b/.changesets/add-tesla-integration.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add automatic instrumentation for Tesla.

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -38,6 +38,10 @@ defmodule Appsignal do
       Appsignal.Oban.attach()
     end
 
+    if Config.instrument_tesla?() do
+      Appsignal.Tesla.attach()
+    end
+
     if Config.instrument_absinthe?() do
       Appsignal.Absinthe.attach()
     end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -26,6 +26,7 @@ defmodule Appsignal.Config do
     instrument_ecto: true,
     instrument_finch: true,
     instrument_oban: true,
+    instrument_tesla: true,
     log: "file",
     logging_endpoint: "https://appsignal-endpoint.net",
     request_headers: ~w(
@@ -213,6 +214,13 @@ defmodule Appsignal.Config do
     end
   end
 
+  def instrument_tesla? do
+    case Application.fetch_env(:appsignal, :config) do
+      {:ok, value} -> !!Map.get(value, :instrument_tesla, true)
+      _ -> true
+    end
+  end
+
   def report_oban_errors do
     case Application.fetch_env(:appsignal, :config) do
       {:ok, value} ->
@@ -307,6 +315,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_INSTRUMENT_ECTO" => :instrument_ecto,
     "APPSIGNAL_INSTRUMENT_FINCH" => :instrument_finch,
     "APPSIGNAL_INSTRUMENT_OBAN" => :instrument_oban,
+    "APPSIGNAL_INSTRUMENT_TESLA" => :instrument_tesla,
     "APPSIGNAL_LOG" => :log,
     "APPSIGNAL_LOG_LEVEL" => :log_level,
     "APPSIGNAL_LOG_PATH" => :log_path,
@@ -340,7 +349,7 @@ defmodule Appsignal.Config do
     APPSIGNAL_TRANSACTION_DEBUG_MODE APPSIGNAL_FILES_WORLD_ACCESSIBLE APPSIGNAL_SEND_PARAMS
     APPSIGNAL_ENABLE_MINUTELY_PROBES APPSIGNAL_ENABLE_STATSD APPSIGNAL_ENABLE_NGINX_METRICS
     APPSIGNAL_ENABLE_ERROR_BACKEND APPSIGNAL_SEND_ENVIRONMENT_METADATA
-    APPSIGNAL_INSTRUMENT_ECTO APPSIGNAL_INSTRUMENT_FINCH APPSIGNAL_INSTRUMENT_OBAN
+    APPSIGNAL_INSTRUMENT_ECTO APPSIGNAL_INSTRUMENT_FINCH APPSIGNAL_INSTRUMENT_OBAN APPSIGNAL_INSTRUMENT_TESLA
   )
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -12,7 +12,7 @@ defmodule Appsignal.Finch do
     handlers = %{
       [:finch, :request, :start] => &__MODULE__.finch_request_start/4,
       [:finch, :request, :stop] => &__MODULE__.finch_request_stop/4,
-      [:finch, :request, :exception] => &__MODULE__.finch_request_exception/4
+      [:finch, :request, :exception] => &__MODULE__.finch_request_stop/4
     }
 
     for {event, fun} <- handlers do
@@ -72,13 +72,5 @@ defmodule Appsignal.Finch do
 
   def finch_request_stop(_event, _measurements, _metadata, _config) do
     nil
-  end
-
-  def finch_request_exception(_event, _measurements, metadata, _config) do
-    @tracer.current_span()
-    |> @span.add_error(metadata[:kind], metadata[:reason], metadata[:stacktrace])
-    |> @tracer.close_span()
-
-    @tracer.ignore()
   end
 end

--- a/lib/appsignal/tesla.ex
+++ b/lib/appsignal/tesla.ex
@@ -12,7 +12,7 @@ defmodule Appsignal.Tesla do
     handlers = %{
       [:tesla, :request, :start] => &__MODULE__.tesla_request_start/4,
       [:tesla, :request, :stop] => &__MODULE__.tesla_request_stop/4,
-      [:tesla, :request, :exception] => &__MODULE__.tesla_request_exception/4
+      [:tesla, :request, :exception] => &__MODULE__.tesla_request_stop/4
     }
 
     for {event, fun} <- handlers do
@@ -167,13 +167,5 @@ defmodule Appsignal.Tesla do
 
   def tesla_request_stop(_event, _measurements, _metadata, _config) do
     @tracer.close_span(@tracer.current_span())
-  end
-
-  def tesla_request_exception(_event, _measurements, metadata, _config) do
-    @tracer.current_span()
-    |> @span.add_error(metadata[:kind], metadata[:reason], metadata[:stacktrace])
-    |> @tracer.close_span()
-
-    @tracer.ignore()
   end
 end

--- a/lib/appsignal/tesla.ex
+++ b/lib/appsignal/tesla.ex
@@ -1,0 +1,179 @@
+defmodule Appsignal.Tesla do
+  require Appsignal.Utils
+
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+
+  @moduledoc false
+
+  require Logger
+
+  def attach do
+    handlers = %{
+      [:tesla, :request, :start] => &__MODULE__.tesla_request_start/4,
+      [:tesla, :request, :stop] => &__MODULE__.tesla_request_stop/4,
+      [:tesla, :request, :exception] => &__MODULE__.tesla_request_exception/4
+    }
+
+    for {event, fun} <- handlers do
+      case :telemetry.attach({__MODULE__, event}, event, fun, :ok) do
+        :ok ->
+          _ = Appsignal.IntegrationLogger.debug("Appsignal.Tesla attached to #{inspect(event)}")
+
+          :ok
+
+        {:error, _} = error ->
+          Logger.warn("Appsignal.Tesla not attached to #{inspect(event)}: #{inspect(error)}")
+
+          error
+      end
+    end
+  end
+
+  def tesla_request_start(
+        _event,
+        _measurements,
+        %{env: env},
+        _config
+      ) do
+    do_tesla_request_start(@tracer.current_span(), env)
+  end
+
+  defp do_tesla_request_start(nil, _env), do: nil
+
+  defp do_tesla_request_start(parent, env) do
+    %{method: method, url: url} = env
+
+    middlewares = env_middlewares(env)
+    base_url = middleware_base_url(middlewares)
+    use_full_path = path_params?(middlewares)
+
+    sanitised_url = sanitise_url(url, base_url, use_full_path)
+
+    upcased_method = String.upcase(Atom.to_string(method))
+
+    name = "#{upcased_method} #{sanitised_url}"
+
+    "http_request"
+    |> @tracer.create_span(parent)
+    |> @span.set_name(name)
+    |> @span.set_attribute("appsignal:category", "request.tesla")
+  end
+
+  # Sanitises an URL by keeping only its scheme, host and port.
+  #
+  # The `use_full_path` parameter is set to true for enhanced grouping
+  # when `Tesla.Middleware.PathParams` is present.
+  #
+  # If the URL does not contain a host, and a base URL is provided by
+  # `Tesla.Middleware.BaseUrl`, then the base URL's scheme, host,
+  # port and path are used instead.
+  def sanitise_url(url, base_url, use_full_path) do
+    do_sanitise_url(URI.parse(url || ""), URI.parse(base_url || ""), use_full_path)
+  end
+
+  # Users can specify a host in the request's URL, which overrides the
+  # base URL in the BaseURL middleware. Only use the base URL if the URL
+  # in the telemetry event does not already have a host.
+  #
+  # When using the base URL, its path fragment will be used, regardless
+  # of the value of `use_full_path`.
+  #
+  # If `use_full_path` is true, then the path fragments of the base URL
+  # and the URL are concatenated together.
+  defp do_sanitise_url(%URI{host: nil, path: path}, base_uri, true) do
+    do_sanitise_url(base_uri, "#{base_uri.path}#{path}")
+  end
+
+  defp do_sanitise_url(%URI{host: nil}, base_uri, _) do
+    do_sanitise_url(base_uri, base_uri.path)
+  end
+
+  defp do_sanitise_url(uri, _, true) do
+    do_sanitise_url(uri, uri.path)
+  end
+
+  defp do_sanitise_url(uri, _, _) do
+    do_sanitise_url(uri, nil)
+  end
+
+  defp do_sanitise_url(%URI{scheme: scheme, host: host, port: port}, path) do
+    URI.to_string(%URI{scheme: scheme, host: host, port: port, path: path})
+  end
+
+  def env_middlewares(env) do
+    # Use the same middleware order implemented in `Tesla.prepare`, but ignore
+    # `post` client middlewares, which are not relevant to our use case:
+    # https://github.com/elixir-tesla/tesla/blob/9fbf221/lib/tesla.ex#L116-L120
+    normalize_middlewares(client_pre_middlewares(env) ++ module_middlewares(env))
+  end
+
+  defp module_middlewares(env) do
+    module = Map.get(env, :__module__)
+
+    if module != nil and function_exported?(module, :__middleware__, 0) do
+      module.__middleware__
+    end || []
+  end
+
+  defp client_pre_middlewares(env) do
+    client = Map.get(env, :__client__)
+
+    if client != nil do
+      Map.get(client, :pre, [])
+    end || []
+  end
+
+  defp normalize_middlewares(middlewares) do
+    # The `Tesla.Env.runtime()` type obtained from the `__middleware__`
+    # property in the module and the `pre` property in the client can
+    # contain middlewares and adapters of different shapes. Keep only
+    # module-based middlewares and their arguments, if any, using an
+    # unified value shape.
+
+    middlewares
+    |> Enum.map(fn
+      {:fn, _} -> nil
+      {middleware, _, opts} -> {middleware, opts}
+      {middleware, _} -> {middleware, nil}
+      _ -> nil
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp middleware_base_url(normalized_middlewares) do
+    Enum.find_value(normalized_middlewares, fn {middleware, opts} ->
+      if middleware == Tesla.Middleware.BaseUrl, do: List.first(opts)
+    end)
+  end
+
+  def path_params?(normalized_middlewares) do
+    path_params_position =
+      middleware_position(normalized_middlewares, Tesla.Middleware.PathParams)
+
+    telemetry_position = middleware_position(normalized_middlewares, Tesla.Middleware.Telemetry)
+
+    # If the PathParams middleware appears before the Telemetry middleware,
+    # the URL in the telemetry event will already have the parameter values
+    # interpolated into it, and therefore it cannot be used for grouping.
+    path_params_position && telemetry_position < path_params_position
+  end
+
+  defp middleware_position(normalized_middlewares, expected_middleware) do
+    Enum.find_index(normalized_middlewares, fn {middleware, _opts} ->
+      middleware == expected_middleware
+    end)
+  end
+
+  def tesla_request_stop(_event, _measurements, _metadata, _config) do
+    @tracer.close_span(@tracer.current_span())
+  end
+
+  def tesla_request_exception(_event, _measurements, metadata, _config) do
+    @tracer.current_span()
+    |> @span.add_error(metadata[:kind], metadata[:reason], metadata[:stacktrace])
+    |> @tracer.close_span()
+
+    @tracer.ignore()
+  end
+end

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -259,6 +259,30 @@ defmodule Appsignal.ConfigTest do
     end
   end
 
+  describe "instrument_tesla?" do
+    test "when discard" do
+      assert with_config(
+               %{instrument_tesla: true},
+               &Config.instrument_tesla?/0
+             )
+    end
+
+    test "when false" do
+      refute with_config(
+               %{instrument_tesla: false},
+               &Config.instrument_tesla?/0
+             )
+    end
+
+    test "when unset" do
+      assert with_config(%{}, &Config.instrument_tesla?/0)
+    end
+
+    test "without an appsignal config" do
+      assert without_config(&Config.instrument_tesla?/0)
+    end
+  end
+
   describe "instrument_absinthe?" do
     test "when true" do
       assert with_config(
@@ -1349,6 +1373,7 @@ defmodule Appsignal.ConfigTest do
       instrument_ecto: true,
       instrument_finch: true,
       instrument_oban: true,
+      instrument_tesla: true,
       report_oban_errors: "all"
     }
   end

--- a/test/appsignal/finch_test.exs
+++ b/test/appsignal/finch_test.exs
@@ -171,27 +171,16 @@ defmodule Appsignal.FinchTest do
       start_supervised!(Test.Monitor)
 
       Appsignal.Tracer.create_span("http_request")
-      reason = %RuntimeError{message: "Exception!"}
 
       :telemetry.execute(
         [:finch, :request, :exception],
         %{},
-        %{kind: :error, reason: reason, stacktrace: []}
+        %{request: %{}}
       )
-
-      [reason: reason]
-    end
-
-    test "adds an error to the current span", %{reason: reason} do
-      assert {:ok, [{%Span{}, :error, ^reason, []}]} = Test.Span.get(:add_error)
     end
 
     test "closes the span" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
-    end
-
-    test "ignores the process in the registry" do
-      assert :ets.lookup(:"$appsignal_registry", self()) == [{self(), :ignore}]
     end
   end
 

--- a/test/appsignal/tesla_test.exs
+++ b/test/appsignal/tesla_test.exs
@@ -1,0 +1,324 @@
+defmodule Appsignal.FakeTeslaBuilder do
+  # A mock of a module that uses `Tesla.Builder` (`use Tesla`),
+  # implementing `__middleware__`.
+  def __middleware__ do
+    [
+      {Appsignal.FakeTeslaBuilderMiddleware, :call}
+    ]
+  end
+end
+
+defmodule Appsignal.TeslaTest do
+  use ExUnit.Case
+  alias Appsignal.{Span, Test}
+  import AppsignalTest.Utils, only: [with_config: 2]
+
+  test "attaches to Tesla events automatically" do
+    assert attached?([:tesla, :request, :start])
+    assert attached?([:tesla, :request, :stop])
+    assert attached?([:tesla, :request, :exception])
+  end
+
+  test "does not attach to Tesla events when :instrument_tesla is set to false" do
+    :telemetry.detach({Appsignal.Tesla, [:tesla, :request, :start]})
+    :telemetry.detach({Appsignal.Tesla, [:tesla, :request, :stop]})
+    :telemetry.detach({Appsignal.Tesla, [:tesla, :request, :exception]})
+
+    with_config(%{instrument_tesla: false}, fn -> Appsignal.start([], []) end)
+
+    assert !attached?([:tesla, :request, :start])
+    assert !attached?([:tesla, :request, :stop])
+    assert !attached?([:tesla, :request, :exception])
+
+    [:ok, :ok, :ok] = Appsignal.Tesla.attach()
+  end
+
+  describe "path_params?/1" do
+    test "is false when the Telemetry middleware is absent" do
+      refute Appsignal.Tesla.path_params?([
+               {Tesla.Middleware.PathParams, nil}
+             ])
+    end
+
+    test "is false when the PathParams middleware is absent" do
+      refute Appsignal.Tesla.path_params?([
+               {Tesla.Middleware.Telemetry, nil}
+             ])
+    end
+
+    test "is false when the PathParams middleware appears before the Telemetry middleware" do
+      refute Appsignal.Tesla.path_params?([
+               {Tesla.Middleware.PathParams, nil},
+               {Tesla.Middleware.Telemetry, nil}
+             ])
+    end
+
+    test "is true when the Telemetry middleware appears before the PathParams middleware" do
+      assert Appsignal.Tesla.path_params?([
+               {Tesla.Middleware.Telemetry, nil},
+               {Tesla.Middleware.PathParams, nil}
+             ])
+    end
+  end
+
+  describe "sanitise_url/3, with no base URL" do
+    test "when use_full_path is false, it keeps the scheme, host and port" do
+      assert "https://hex.pm" ==
+               Appsignal.Tesla.sanitise_url(
+                 "https://hex.pm/packages/appsignal",
+                 nil,
+                 false
+               )
+    end
+
+    test "when use_full_path is true, it keeps the scheme, host, port and path" do
+      assert "https://hex.pm/packages/appsignal" ==
+               Appsignal.Tesla.sanitise_url(
+                 "https://hex.pm/packages/appsignal",
+                 nil,
+                 true
+               )
+    end
+  end
+
+  describe "sanitise_url/3, with a base URL" do
+    test "when the URL has a host, the base URL is ignored" do
+      assert "https://appsignal.com" ==
+               Appsignal.Tesla.sanitise_url(
+                 "https://appsignal.com/docs",
+                 "https://hex.pm/packages",
+                 false
+               )
+    end
+
+    test "when the URL does not have a host, the base URL's scheme, host, port and path are used" do
+      assert "https://hex.pm/packages" ==
+               Appsignal.Tesla.sanitise_url(
+                 "/appsignal",
+                 "https://hex.pm/packages",
+                 false
+               )
+    end
+
+    test "when use_full_path is true, the paths are joined" do
+      assert "https://hex.pm/packages/:package" ==
+               Appsignal.Tesla.sanitise_url(
+                 "/:package",
+                 "https://hex.pm/packages",
+                 true
+               )
+    end
+  end
+
+  describe "env_middlewares/1" do
+    test "it concatenates and normalises middlewares from the module and the client" do
+      env =
+        env(nil, [
+          {Appsignal.FakeTeslaClientMiddleware, :call, :some_argument}
+        ])
+
+      assert Appsignal.Tesla.env_middlewares(env) == [
+               # Normalised three element tuple middleware
+               {Appsignal.FakeTeslaClientMiddleware, :some_argument},
+               # Normalised two element tuple middleware
+               {Appsignal.FakeTeslaBuilderMiddleware, nil}
+             ]
+    end
+
+    test "it removes function adapters from the middleware chain" do
+      env =
+        env(nil, [
+          {:fn, fn -> nil end},
+          {:fn, fn _ -> nil end}
+        ])
+
+      assert Appsignal.Tesla.env_middlewares(env) == [
+               {Appsignal.FakeTeslaBuilderMiddleware, nil}
+             ]
+    end
+  end
+
+  describe "tesla_request_start/4, without a root span" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      :telemetry.execute(
+        [:tesla, :request, :start],
+        %{},
+        %{env: env("https://hex.pm/packages/appsignal")}
+      )
+    end
+
+    test "does not create a span" do
+      assert Test.Tracer.get(:create_span) == :error
+    end
+  end
+
+  describe "tesla_request_start/4, and tesla_request_stop/4 with a root span" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      Appsignal.Tracer.create_span("http_request")
+
+      :telemetry.execute([:tesla, :request, :start], %{}, %{env: env("https://example.com")})
+      :telemetry.execute([:tesla, :request, :stop], %{}, %{})
+    end
+
+    test "creates a span with a parent" do
+      assert {:ok, [{"http_request", %Span{}}]} = Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "GET https://example.com"}]} = Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert attribute?("appsignal:category", "request.tesla")
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
+  describe "tesla_request_start/4, with the PathParams middleware" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      Appsignal.Tracer.create_span("http_request")
+
+      :telemetry.execute([:tesla, :request, :start], %{}, %{
+        env:
+          env("https://example.com/foo/:bar", [
+            {Tesla.Middleware.Telemetry, :call, nil},
+            {Tesla.Middleware.PathParams, :call, nil}
+          ])
+      })
+
+      :telemetry.execute([:tesla, :request, :stop], %{}, %{})
+    end
+
+    test "sets the span's name with the URL's path" do
+      assert {:ok, [{%Span{}, "GET https://example.com/foo/:bar"}]} = Test.Span.get(:set_name)
+    end
+  end
+
+  describe "tesla_request_start/4, with the BaseUrl middleware" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      Appsignal.Tracer.create_span("http_request")
+
+      :telemetry.execute([:tesla, :request, :start], %{}, %{
+        env:
+          env("/bar", [
+            {Tesla.Middleware.Telemetry, :call, nil},
+            {Tesla.Middleware.BaseUrl, :call, ["https://example.com/foo"]}
+          ])
+      })
+
+      :telemetry.execute([:tesla, :request, :stop], %{}, %{})
+    end
+
+    test "sets the span's name with the base URL" do
+      assert {:ok, [{%Span{}, "GET https://example.com/foo"}]} = Test.Span.get(:set_name)
+    end
+  end
+
+  describe "tesla_request_start/4, with the PathParams and BaseUrl middlewares" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      Appsignal.Tracer.create_span("http_request")
+
+      :telemetry.execute([:tesla, :request, :start], %{}, %{
+        env:
+          env("/:bar", [
+            {Tesla.Middleware.Telemetry, :call, nil},
+            {Tesla.Middleware.BaseUrl, :call, ["https://example.com/foo"]},
+            {Tesla.Middleware.PathParams, :call, nil}
+          ])
+      })
+
+      :telemetry.execute([:tesla, :request, :stop], %{}, %{})
+    end
+
+    test "sets the span's name with the base URL and the URL's path" do
+      assert {:ok, [{%Span{}, "GET https://example.com/foo/:bar"}]} = Test.Span.get(:set_name)
+    end
+  end
+
+  describe "tesla_request_exception/4" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      Appsignal.Tracer.create_span("http_request")
+      reason = %RuntimeError{message: "Exception!"}
+
+      :telemetry.execute(
+        [:tesla, :request, :exception],
+        %{},
+        %{kind: :error, reason: reason, stacktrace: []}
+      )
+
+      [reason: reason]
+    end
+
+    test "adds an error to the current span", %{reason: reason} do
+      assert {:ok, [{%Span{}, :error, ^reason, []}]} = Test.Span.get(:add_error)
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+
+    test "ignores the process in the registry" do
+      assert :ets.lookup(:"$appsignal_registry", self()) == [{self(), :ignore}]
+    end
+  end
+
+  defp env(url, client_middlewares \\ []) do
+    %{
+      __module__: Appsignal.FakeTeslaBuilder,
+      __client__: %{
+        pre: client_middlewares
+      },
+      method: :get,
+      url: url
+    }
+  end
+
+  defp attribute?(asserted_key, asserted_data) do
+    {:ok, attributes} = Test.Span.get(:set_attribute)
+
+    Enum.any?(attributes, fn {%Span{}, key, data} ->
+      key == asserted_key and data == asserted_data
+    end)
+  end
+
+  defp attached?(event) do
+    event
+    |> :telemetry.list_handlers()
+    |> Enum.any?(fn %{id: id} ->
+      id == {Appsignal.Tesla, event}
+    end)
+  end
+end

--- a/test/appsignal/tesla_test.exs
+++ b/test/appsignal/tesla_test.exs
@@ -271,27 +271,12 @@ defmodule Appsignal.TeslaTest do
       start_supervised!(Test.Monitor)
 
       Appsignal.Tracer.create_span("http_request")
-      reason = %RuntimeError{message: "Exception!"}
 
-      :telemetry.execute(
-        [:tesla, :request, :exception],
-        %{},
-        %{kind: :error, reason: reason, stacktrace: []}
-      )
-
-      [reason: reason]
-    end
-
-    test "adds an error to the current span", %{reason: reason} do
-      assert {:ok, [{%Span{}, :error, ^reason, []}]} = Test.Span.get(:add_error)
+      :telemetry.execute([:tesla, :request, :exception], %{}, %{})
     end
 
     test "closes the span" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
-    end
-
-    test "ignores the process in the registry" do
-      assert :ets.lookup(:"$appsignal_registry", self()) == [{self(), :ignore}]
     end
   end
 


### PR DESCRIPTION
Part of https://github.com/appsignal/support/issues/257. See [test setup](https://github.com/appsignal/test-setups/pull/113) and [server changes](https://github.com/appsignal/appsignal-server/pull/9562) and [diagnose changes](https://github.com/appsignal/diagnose_tests/pull/87).

Implement an instrumentation for the Tesla HTTP client library, based on our existing Finch instrumentation.

If the Tesla.Middleware.PathParams middleware is used, a template is used as the URL, and parameters are passed separately, to be interpolated by this middleware. If the instrumentation detects that the PathParams middleware is being used correctly, it will send the template URL as part of the sanitised URL. Otherwise, it will only send the scheme, host and port of the URL.

If the Tesla.Middleware.BaseUrl middleware is used, it will be used to form the sanitised URL. Its path will be included in the sanitised URL, as it is assumed to be static. If the PathParams middleware is also being used, the template URL's path fragment will be appended to the base URL. This allows for some "better than nothing" grouping for users who use BaseUrl but not PathParams (e.g. `github.com/users`, instead of just `github.com`)

Caveats
-------

This instrumentation relies on Tesla.Middleware.Telemetry being used before any other middleware. The instrumentation benefits from seeing what the user-intended request was, before the middleware modifies it. Using other middlewares before Telemetry degrades its functionality.

If PathParams is used before Telemetry, the template will already have been interpolated, resulting in a high-cardinality URL. To prevent this, the order of the middlewares is taken into account to determine whether PathParams is being used correctly and whether to include the path fragment of the URL as part of the URL.

If BaseUrl is used before Telemetry, it will have no effect, as the URL will have already been prefixed with the base URL. The base URL will be ignored.

If MethodOverride is used before Telemetry, the method shown will be the actual HTTP method sent over the wire (GET or POST) instead of the semantically intended request method, which is sent in the `X-HTTP-Method-Override` header.

Using Tesla.Middleware.Telemetry before any other middlewares prevents these functionality degradations.