### PR TITLE
Add statsd_port config option

### DIFF
--- a/.changesets/bump-agent-to-fd8ee9e.md
+++ b/.changesets/bump-agent-to-fd8ee9e.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to fd8ee9e.
+
+- Rely on APPSIGNAL_RUNNING_IN_CONTAINER config option value before other environment factors to determine if the app is running in a container.
+- Fix container detection for hosts running Docker itself.
+- Add APPSIGNAL_STATSD_PORT config option.

--- a/.changesets/statsd-port-config-option.md
+++ b/.changesets/statsd-port-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Allow configuration of the agent's StatsD server port through the `statsd_port` option.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "f9b0c15"
+  def version, do: "fd8ee9e"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "a830ab7b7729ecdcf77b79322d0f38f866fc42a96ca569d18923fc60ae212f9e",
+        checksum: "38731cb50e31377053618cd3687ab99d10cc991171b73ea81a40aab49d415fe1",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "a830ab7b7729ecdcf77b79322d0f38f866fc42a96ca569d18923fc60ae212f9e",
+        checksum: "38731cb50e31377053618cd3687ab99d10cc991171b73ea81a40aab49d415fe1",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "95b6004d2805e9c89a51bb921dbccf15b1fb0abbbc33ae496a1e1c05349db2af",
+        checksum: "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "95b6004d2805e9c89a51bb921dbccf15b1fb0abbbc33ae496a1e1c05349db2af",
+        checksum: "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "95b6004d2805e9c89a51bb921dbccf15b1fb0abbbc33ae496a1e1c05349db2af",
+        checksum: "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "3f8ff2aa9698520af0a5bef2ab79ec8a97bdda405f7398d33060f4dfbc94fb67",
+        checksum: "65ccb3ed4fdc7f55671ca4ff04beaa97bb01835e0f30b6a5f2e02dbe8b5c31f4",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "5543d922255c4b750fdf5463f941057c5e9812d3c6a71527275cf6b498012c57",
+        checksum: "849d2a2ff27814961e1ce9183877a0aedda263f538b0dbfa5e17357e2af00ba4",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "5543d922255c4b750fdf5463f941057c5e9812d3c6a71527275cf6b498012c57",
+        checksum: "849d2a2ff27814961e1ce9183877a0aedda263f538b0dbfa5e17357e2af00ba4",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "faea43a74e749ac84d0b1b85e065c7eee0694767e8b4f03340fb1b78dce058c4",
+        checksum: "907889dbc50c5f670c1edce503b6f1cdacc52127217611df56b4913137e814f1",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "3ee17af45f24d4bc828c958f4fa8fcadc799d5b2d38b44a14e8caec1ce78ffaf",
+        checksum: "f4b26fbee43be4bf15033cd3594d8a79d5cd73a95aa62e1949e3a0836345af03",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "d39384cf1deeb47d5ea35addd3ae3f44634cfd3ab034f27e45ed66e09180ba6f",
+        checksum: "d316c1a6a92963ba88c1c578a070eba505e1a466e3af768362122d935af31ccd",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "f41c97626d8e22797a6a1bda3c01c08b4c1d52b157cd1e7a22aed9f186324c30",
+        checksum: "c2d8f903e683ce77f608d7e8d1eadc98a0fd29d19f07110e04cc73c5d2cb887c",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "f41c97626d8e22797a6a1bda3c01c08b4c1d52b157cd1e7a22aed9f186324c30",
+        checksum: "c2d8f903e683ce77f608d7e8d1eadc98a0fd29d19f07110e04cc73c5d2cb887c",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -321,6 +321,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_SEND_PARAMS" => :send_params,
     "APPSIGNAL_SEND_SESSION_DATA" => :send_session_data,
     "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data,
+    "APPSIGNAL_STATSD_PORT" => :statsd_port,
     "APPSIGNAL_TRANSACTION_DEBUG_MODE" => :transaction_debug_mode,
     "APPSIGNAL_WORKING_DIRECTORY_PATH" => :working_directory_path,
     "APPSIGNAL_WORKING_DIR_PATH" => :working_dir_path,
@@ -331,7 +332,7 @@ defmodule Appsignal.Config do
     APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH
     APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_LEVEL APPSIGNAL_LOG_PATH
     APPSIGNAL_LOGGING_ENDPOINT APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH
-    APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION APPSIGNAL_REPORT_OBAN_ERRORS
+    APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION APPSIGNAL_REPORT_OBAN_ERRORS APPSIGNAL_STATSD_PORT
   )
   @bool_keys ~w(
     APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING
@@ -463,6 +464,7 @@ defmodule Appsignal.Config do
 
     Nif.env_put("_APPSIGNAL_SEND_PARAMS", to_string(config[:send_params]))
     Nif.env_put("_APPSIGNAL_SEND_SESSION_DATA", to_string(config[:send_session_data]))
+    Nif.env_put("_APPSIGNAL_STATSD_PORT", to_string(config[:statsd_port]))
     Nif.env_put("_APPSIGNAL_RUNNING_IN_CONTAINER", to_string(config[:running_in_container]))
     Nif.env_put("_APPSIGNAL_TRANSACTION_DEBUG_MODE", to_string(config[:transaction_debug_mode]))
     Nif.env_put("_APPSIGNAL_WORKING_DIRECTORY_PATH", to_string(config[:working_directory_path]))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -612,6 +612,10 @@ defmodule Appsignal.ConfigTest do
       assert output =~ "Deprecation warning: The `skip_session_data` config option is deprecated."
     end
 
+    test "statsd_port" do
+      assert %{statsd_port: "3000"} = with_config(%{statsd_port: "3000"}, &init_config/0)
+    end
+
     test "transaction_debug_mode" do
       assert %{transaction_debug_mode: true} =
                with_config(%{transaction_debug_mode: true}, &init_config/0)
@@ -926,6 +930,13 @@ defmodule Appsignal.ConfigTest do
       assert output =~ "Deprecation warning: The `skip_session_data` config option is deprecated."
     end
 
+    test "statsd_port" do
+      assert with_env(
+               %{"APPSIGNAL_STATSD_PORT" => "3000"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:statsd_port, "3000")
+    end
+
     test "transaction_debug_mode" do
       assert with_env(
                %{"APPSIGNAL_TRANSACTION_DEBUG_MODE" => "true"},
@@ -1148,6 +1159,7 @@ defmodule Appsignal.ConfigTest do
       assert Nif.env_get("_APPSIGNAL_WORKING_DIR_PATH") == ~c""
       assert Nif.env_get("_APPSIGNAL_WORKING_DIRECTORY_PATH") == ~c""
       assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == ~c""
+      assert Nif.env_get("_APPSIGNAL_STATSD_PORT") == ~c""
       assert Nif.env_get("_APP_REVISION") == ~c""
     end
 
@@ -1198,7 +1210,8 @@ defmodule Appsignal.ConfigTest do
           revision: "03bd9e",
           transaction_debug_mode: true,
           filter_parameters: ["password", "confirm_password"],
-          filter_session_data: ["key1", "key2"]
+          filter_session_data: ["key1", "key2"],
+          statsd_port: "3000"
         },
         fn ->
           without_logger(&write_to_environment/0)
@@ -1240,6 +1253,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_FILTER_PARAMETERS") == ~c"password,confirm_password"
           assert Nif.env_get("_APPSIGNAL_FILTER_SESSION_DATA") == ~c"key1,key2"
           assert Nif.env_get("_APPSIGNAL_SEND_ENVIRONMENT_METADATA") == ~c"true"
+          assert Nif.env_get("_APPSIGNAL_STATSD_PORT") == ~c"3000"
           assert Nif.env_get("_APP_REVISION") == ~c"03bd9e"
         end
       )


### PR DESCRIPTION
## Add statsd_port config option

Allow configuration of the agent's statsd server port through the statsd_port option.

Requires an agent update from https://github.com/appsignal/appsignal-agent/pull/995

## Bump agent to fd8ee9e

- Rely on APPSIGNAL_RUNNING_IN_CONTAINER config option value before
  other environment factors to determine if the app is running in a
  container.
- Fix container detection for hosts running Docker itself.
- Add APPSIGNAL_STATSD_PORT config option.
