### PR TITLE
Never register cowboy error reports

### DIFF
--- a/.changesets/add-handling-for-cowboy-error-edge-cases-to-prevent-error-backend-crashes.md
+++ b/.changesets/add-handling-for-cowboy-error-edge-cases-to-prevent-error-backend-crashes.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Add handling for cowboy error edge cases to prevent error backend crashes

--- a/lib/appsignal/stacktrace.ex
+++ b/lib/appsignal/stacktrace.ex
@@ -18,8 +18,12 @@ defmodule Appsignal.Stacktrace do
   @doc ~S"""
   Parses the given stacktrace into a backtrace list.
   """
-  def format(stacktrace) do
+  def format(stacktrace) when is_list(stacktrace) do
     Enum.map(stacktrace, &format_stacktrace_entry/1)
+  end
+
+  def format(_stacktrace) do
+    []
   end
 
   defp format_stacktrace_entry(entry) when is_binary(entry), do: entry

--- a/test/appsignal/stacktrace_test.exs
+++ b/test/appsignal/stacktrace_test.exs
@@ -58,4 +58,10 @@ defmodule Appsignal.StacktraceTest do
 
     assert Stacktrace.format(stacktrace) == stacktrace
   end
+
+  test "does not handle non-lists" do
+    assert Stacktrace.format(
+             {:gen_server, :call, [:image_magick_pool, {:checkout, self(), true}, 5000]}
+           ) == []
+  end
 end


### PR DESCRIPTION
Previously, the handle_report/1 function checked if the report had a
:cowboy domain, but only if there was no conn included in the
report. This patch fixes that, to make sure all cowboy reports are
filtered out.

Closes https://github.com/appsignal/appsignal-elixir/issues/850.