### PR TITLE
Reduce number of reductions in Appsignal.Instrumentation.instrument/3

### DIFF
--- a/.changesets/improve-tracer-performance-by-removing-duplicate-runtime-configuration-and-storage-checks.md
+++ b/.changesets/improve-tracer-performance-by-removing-duplicate-runtime-configuration-and-storage-checks.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Improve Tracer performance by removing duplicate runtime configuration and storage checks

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -137,14 +137,18 @@ defmodule Appsignal.Config do
   """
   @spec valid?() :: boolean
   def valid? do
-    do_valid?(Application.get_env(:appsignal, :config)[:push_api_key])
+    :appsignal
+    |> Application.get_env(:config)
+    |> valid?
   end
 
-  defp do_valid?(push_api_key) when is_binary(push_api_key) do
-    !empty?(String.trim(push_api_key))
+  defp valid?(%{push_api_key: key}) when is_binary(key) do
+    !(key
+      |> String.trim()
+      |> empty?())
   end
 
-  defp do_valid?(_push_api_key), do: false
+  defp valid?(_config), do: false
 
   @doc """
   Returns true if the configuration is valid and the AppSignal agent is
@@ -154,11 +158,14 @@ defmodule Appsignal.Config do
   def active? do
     :appsignal
     |> Application.get_env(:config, @default_config)
-    |> do_active?
+    |> active?
   end
 
-  defp do_active?(%{active: true}), do: valid?()
-  defp do_active?(_), do: false
+  defp active?(%{active: true} = config) do
+    valid?(config)
+  end
+
+  defp active?(_config), do: false
 
   @doc """
   Returns true if debug mode is turned on, false otherwise.

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -98,10 +98,8 @@ defmodule Appsignal.Span do
   """
   def set_name(%Span{reference: reference} = span, name)
       when is_reference(reference) and is_binary(name) do
-    if Config.active?() do
-      :ok = @nif.set_span_name(reference, name)
-      span
-    end
+    :ok = @nif.set_span_name(reference, name)
+    span
   end
 
   def set_name(span, _name), do: span
@@ -268,17 +266,15 @@ defmodule Appsignal.Span do
 
   @doc false
   def do_add_error(%Span{reference: reference} = span, name, message, stacktrace) do
-    if Config.active?() do
-      :ok =
-        @nif.add_span_error(
-          reference,
-          name,
-          message,
-          Appsignal.Utils.DataEncoder.encode(stacktrace)
-        )
+    :ok =
+      @nif.add_span_error(
+        reference,
+        name,
+        message,
+        Appsignal.Utils.DataEncoder.encode(stacktrace)
+      )
 
-      span
-    end
+    span
   end
 
   def do_add_error(nil, _name, _message, _stacktrace), do: nil

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -22,15 +22,9 @@ defmodule Appsignal.Span do
       Appsignal.Span.create_root("http_request", self())
 
   """
-  def create_root(namespace, pid) do
-    if Config.active?() do
-      {:ok, reference} = @nif.create_root_span(namespace)
+  def create_root(namespace, pid), do: create_root(namespace, pid, nil)
 
-      %Span{reference: reference, pid: pid}
-    end
-  end
-
-  @spec create_root(String.t(), pid(), integer()) :: t() | nil
+  @spec create_root(String.t(), pid(), integer() | nil) :: t() | nil
   @doc """
   Create a root `Appsignal.Span` with a namespace, a pid and an explicit start time.
 
@@ -40,6 +34,14 @@ defmodule Appsignal.Span do
       Appsignal.Span.create_root("http_request", self(), :os.system_time())
 
   """
+  def create_root(namespace, pid, nil) do
+    if Config.active?() do
+      {:ok, reference} = @nif.create_root_span(namespace)
+
+      %Span{reference: reference, pid: pid}
+    end
+  end
+
   def create_root(namespace, pid, start_time) do
     if Config.active?() do
       sec = :erlang.convert_time_unit(start_time, :native, :second)
@@ -59,15 +61,9 @@ defmodule Appsignal.Span do
       |> Appsignal.Span.create_child(self())
 
   """
-  def create_child(%Span{reference: parent}, pid) do
-    if Config.active?() do
-      {:ok, reference} = @nif.create_child_span(parent)
+  def create_child(span, pid), do: create_child(span, pid, nil)
 
-      %Span{reference: reference, pid: pid}
-    end
-  end
-
-  @spec create_child(t() | nil, pid(), integer()) :: t() | nil
+  @spec create_child(t() | nil, pid(), integer() | nil) :: t() | nil
   @doc """
   Create a child `Appsignal.Span` with an explicit start time.
 
@@ -76,6 +72,14 @@ defmodule Appsignal.Span do
       |> Appsignal.Span.create_child(self(), :os.system_time())
 
   """
+  def create_child(%Span{reference: parent}, pid, nil) do
+    if Config.active?() do
+      {:ok, reference} = @nif.create_child_span(parent)
+
+      %Span{reference: reference, pid: pid}
+    end
+  end
+
   def create_child(%Span{reference: parent}, pid, start_time) do
     if Config.active?() do
       sec = :erlang.convert_time_unit(start_time, :native, :second)

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -50,13 +50,9 @@ defmodule Appsignal.Tracer do
     pid = Keyword.get(options, :pid, self())
 
     unless ignored?(pid) do
-      span =
-        case Keyword.get(options, :start_time) do
-          nil -> Span.create_root(namespace, pid)
-          timestamp -> Span.create_root(namespace, pid, timestamp)
-        end
-
-      register(span)
+      namespace
+      |> Span.create_root(pid, options[:start_time])
+      |> register()
     end
   end
 
@@ -64,13 +60,9 @@ defmodule Appsignal.Tracer do
     pid = Keyword.get(options, :pid, self())
 
     unless ignored?(pid) do
-      span =
-        case Keyword.get(options, :start_time) do
-          nil -> Span.create_child(parent, pid)
-          timestamp -> Span.create_child(parent, pid, timestamp)
-        end
-
-      register(span)
+      parent
+      |> Span.create_child(pid, options[:start_time])
+      |> register()
     end
   end
 

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -77,9 +77,13 @@ defmodule Appsignal.Tracer do
   @doc """
   Finds the span in the registry table.
   """
-  @spec lookup(pid()) :: list()
+  @spec lookup(pid()) :: list() | []
   def lookup(pid) do
-    if running?(), do: :ets.lookup(@table, pid)
+    try do
+      :ets.lookup(@table, pid)
+    rescue
+      ArgumentError -> []
+    end
   end
 
   @doc """

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -194,22 +194,6 @@ defmodule AppsignalSpanTest do
     end
   end
 
-  describe ".set_name/2, when disabled" do
-    setup [:create_root_span, :disable_appsignal]
-
-    setup %{span: span} do
-      [return: Span.set_name(span, "test")]
-    end
-
-    test "returns nil", %{return: return} do
-      assert return == nil
-    end
-
-    test "does not set the name through the Nif" do
-      assert Test.Nif.get(:set_span_name) == :error
-    end
-  end
-
   describe ".set_namespace/2" do
     setup :create_root_span
 
@@ -314,29 +298,6 @@ defmodule AppsignalSpanTest do
     end
   end
 
-  describe ".add_error/3, when disabled" do
-    setup [:create_root_span, :disable_appsignal]
-
-    setup %{span: span} do
-      return =
-        try do
-          raise "Exception!"
-        rescue
-          exception -> Span.add_error(span, exception, __STACKTRACE__)
-        end
-
-      [return: return]
-    end
-
-    test "returns nil", %{return: return} do
-      assert return == nil
-    end
-
-    test "does not set the error through the Nif" do
-      assert Test.Nif.get(:add_span_error) == :error
-    end
-  end
-
   describe ".add_error/4" do
     setup :create_root_span
 
@@ -391,29 +352,6 @@ defmodule AppsignalSpanTest do
           raise "Exception!"
         catch
           kind, reason -> Span.add_error(nil, kind, reason, __STACKTRACE__)
-        end
-
-      [return: return]
-    end
-
-    test "returns nil", %{return: return} do
-      assert return == nil
-    end
-
-    test "does not set the error through the Nif" do
-      assert Test.Nif.get(:add_span_error) == :error
-    end
-  end
-
-  describe ".add_error/4, when disabled" do
-    setup [:create_root_span, :disable_appsignal]
-
-    setup %{span: span} do
-      return =
-        try do
-          raise "Exception!"
-        catch
-          kind, reason -> Span.add_error(span, kind, reason, __STACKTRACE__)
         end
 
       [return: return]


### PR DESCRIPTION
As reported in https://github.com/appsignal/appsignal-elixir/issues/845, the instrumentation helper did some unnecessary reductions. This pull request is the result of looking into the reductions report and removing some defensive programming we didn't really need, _without_ changing any functionality.

## eprof

Elixir's `profile.eprof` mix task evaluates a piece of code with the [eprof](https://www.erlang.org/doc/man/eprof.html) profiling tool enabled. After running the code, it outputs a time profile report, which shoes the number of calls to each function, as well as the amount of time spent in each.

To look into the `Appsignal.Instrumentation.instrument/3` function, we evaluated the following code snippet through the eprof task:

```shell
mix profile.eprof -e "(1..1_000) |> Enum.each(fn _ -> Appsignal.Instrumentation.instrument(\"name\", \"category\", fn -> :ok end) end)"
```

For convenience, this is the executed code, which calls the `instrument/3` function a thousand times to get rid of any outliers.

```elixir
(1..1_000)
|> Enum.each(fn _ ->
  Appsignal.Instrumentation.instrument(\"name\", \"category\", fn -> :ok end)
end)
```

<a id="org69b9b93"></a>

## The report

Running the report for the first time produced the following result:

```
Profile results of #PID<0.315.0>
#                                                        CALLS     %  TIME µS/CALL
Total                                                    11701 100.0 53586    0.46
anonymous fn/0 in :elixir_compiler_2.__FILE__/1              1  0.00     1    1.00
:erlang.apply/2                                              1  0.01     3    3.00
Enum.each/2                                                  1  0.01     7    7.00
anonymous fn/0 in :elixir_compiler_2.__FILE__/1           1000  0.22   117    0.12
Appsignal.Nif.close_span/1                                1000  0.22   119    0.12
Keyword.get/2                                             1000  0.22   119    0.12
Appsignal.Nif.set_span_attribute_string/3                 1000  0.22   120    0.12
List.last/1                                               1000  0.23   122    0.12
Appsignal.Nif.create_root_span/1                          1000  0.23   125    0.13
Appsignal.Nif.set_span_name/2                             1000  0.24   126    0.13
GenServer.cast_msg/1                                      1000  0.25   132    0.13
Appsignal.Instrumentation.instrument/3                    1000  0.25   135    0.14
Appsignal.Tracer.create_span/2                            1000  0.25   136    0.14
Appsignal.Tracer.current_span/0                           1000  0.28   152    0.15
anonymous fn/1 in :elixir_compiler_2.__FILE__/1           1000  0.28   152    0.15
Appsignal.Monitor.add/0                                   1000  0.29   156    0.16
Appsignal.Tracer.current_span/1                           1000  0.43   233    0.23
Application.get_env/2                                     2000  0.44   234    0.12
Access.get/2                                              2000  0.44   237    0.12
String.trim_trailing/1                                    2000  0.45   241    0.12
String.trim_leading/1                                     2000  0.46   244    0.12
String.Break.trim_leading/1                               2000  0.48   258    0.13
Appsignal.Tracer.deregister/1                             1000  0.51   271    0.27
String.Break.trim_trailing/1                              2000  0.52   276    0.14
Enum.reduce_range/5                                       1001  0.53   285    0.28
GenServer.do_send/2                                       1000  0.54   287    0.29
:lists.keyfind/3                                          2000  0.54   288    0.14
Appsignal.Span.close/1                                    1000  0.54   288    0.29
GenServer.cast/2                                          1000  0.54   290    0.29
Appsignal.Config.do_active?/1                             2000  0.55   296    0.15
anonymous fn/3 in Enum.each/2                             1000  0.56   298    0.30
Appsignal.Instrumentation.call_with_optional_argument/2   2000  0.56   300    0.15
Appsignal.Span.set_attribute/3                            1000  0.56   300    0.30
Access.get/3                                              2000  0.58   310    0.16
Appsignal.Nif._set_span_name/2                            1000  0.61   327    0.33
Appsignal.Config.empty?/1                                 2000  0.62   330    0.17
Appsignal.Tracer.current/1                                2000  0.67   358    0.18
String.Break.do_trim_leading/1                            2000  0.69   371    0.19
Appsignal.Tracer.ignored?/1                               2000  0.73   393    0.20
Appsignal.Tracer.register/1                               1000  0.74   394    0.39
anonymous fn/4 in Appsignal.Instrumentation.instrument/3  1000  0.74   396    0.40
:ets.delete_object/2                                      1003  0.77   411    0.41
Appsignal.Span.set_name/2                                 1000  0.78   419    0.42
Appsignal.Span.create_root/2                              1000  0.80   431    0.43
:ets.insert/2                                             1003  0.84   449    0.45
Application.maybe_warn_on_app_env_key/2                   4000  0.88   472    0.12
Keyword.get/3                                             2000  0.90   484    0.24
:application.get_env/2                                    4000  0.90   484    0.12
Appsignal.Tracer.close_span/1                             1000  0.95   510    0.51
Appsignal.Config.active?/0                                2000  1.00   535    0.27
String.trim/1                                             2000  1.01   540    0.27
String.Break.do_trim_trailing_l/1                         2000  1.02   544    0.27
:erlang.send/2                                            1000  1.13   603    0.60
String.Break.trim_trailing/2                              2000  1.24   662    0.33
Appsignal.Instrumentation.instrument/1                    1000  1.28   688    0.69
Appsignal.Config.do_valid?/1                              2000  1.30   694    0.35
Appsignal.Tracer.lookup/1                                 2000  1.32   707    0.35
Appsignal.Config.valid?/0                                 2000  1.40   749    0.37
:erlang.whereis/1                                         4000  1.40   751    0.19
Appsignal.Tracer.create_span/3                            1000  1.50   802    0.80
Appsignal.Nif._set_span_attribute_string/3                1000  1.68   901    0.90
:application.get_env/3                                    4000  1.77   949    0.24
Process.whereis/1                                         4000  1.82   977    0.24
Application.get_env/3                                     4000  1.85   994    0.25
:application_controller.get_env/2                         4000  1.91  1026    0.26
Appsignal.Tracer.running?/0                               4000  2.13  1143    0.29
:ets.lookup/2                                             6000  7.62  4083    0.68
Appsignal.Nif._create_root_span/1                         1000 13.82  7404    7.40
Appsignal.Nif._close_span/1                               1000 29.76 15947   15.95
```

The report shows all function calls, ordered by thir execution times. The rightmost column shows the time per call in microseconds, showing that the `Appsignal.Nif._close_span/1` and `Appsignal.Nif._create_root_span/1` functions take the most time, at roughly 16 and 7 microseconds per call. Both functions are called 1000 times, which makes sense because that's the amount of spans that are started and stopped. Although there might be some performance gain to be had here, we're skipping these function calls, as they're called a reasonable amount of times.


<a id="org9fade91"></a>

## `:ets.lookup/2`

One place above these is `:ets.lookup/2`, which only takes 0.68 microseconds per call, but it's called 6000 times, or $6n$. Although AppSignal uses ets internally to store the currently open spans, some of these calls actually originated from checking the configuration.

Internally, the integration had a check to see if it's active before calling `Span.set_name/2`, which is the function used to set the name for a span. However, this call was unneeded, as calling this function with a `nil` value instead of a span is a no-op. When the integration isn't active, nils are passed around instead of spans, so this extra check can be safely removed.

This reduced the number calls by $2n$, leaving $4n$:

```
:ets.lookup/2                                             4000  5.06  2458    0.61
Appsignal.Nif._create_root_span/1                         1000 16.30  7922    7.92
Appsignal.Nif._close_span/1                               1000 32.91 16001   16.00
```

Another :ets lookup was caused by a duplicate call to `Application.get_env/1`. Since the application environment is also stored in ets, each `get_env/1` call also does a lookup.

In AppSignal, the environment was once in the call to `active?/0`, which checks in the config is configured to be, and once in `valid?/0`, which checks if the API key is valid. If either of these is false, the integration is disabled. This patch includes a fix that passes the environment that was already fetched by calling `active?/0` to `valid?/1`, saving another reduction:

```
:erlang.whereis/1                                         4000  1.88   757    0.19
Appsignal.Nif._set_span_attribute_string/3                1000  1.90   766    0.77
Appsignal.Tracer.create_span/3                            1000  2.02   813    0.81
Process.whereis/1                                         4000  2.17   875    0.22
Appsignal.Tracer.running?/0                               4000  2.30   926    0.23
:ets.lookup/2                                             3001  3.91  1576    0.53
Appsignal.Nif._create_root_span/1                         1000 17.12  6903    6.90
Appsignal.Nif._close_span/1                               1000 33.97 13696   13.70
```

Now, the number of calls to `:ets.lookup/2` is $3n$. One call to try and find the parent, another call to see if the current PID is ignored, and a last call to check if the integration is currently active.

It might be possible to remove the check to see if the integration is active that happens before starting every span. However, this patch only consisting of performance enhancements, changes in functionality aren't included.


<a id="orgf64075e"></a>

## `Appsignal.Tracer.running?/0`

A line above the `:ets.lookup/2` function is `Appsignal.Tracer.running?/0`, a function that's called to make sure ets is running before executing lookups, inserts and deletions. Because ets produces an `ArgumentError` when it's not active, the integration called this check to make sure the registry was running every time an evaluation was done on the table.

This patch removes those checks and adds error handling around each function that calls out to ets, which removes `Appsignal.Tracer.running?/0` completely.

Closes #845.
