### PR TITLE
Implement `set_sample_data_if_nil` method

### DIFF
--- a/.changesets/add-set-sample-data-if-nil-function.md
+++ b/.changesets/add-set-sample-data-if-nil-function.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add `set_sample_data_if_nil` function to `Appsignal.Span`, allowing for parameters to be set only if they would not override other parameters.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "fd8ee9e"
+  def version, do: "9e1ad6b"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "38731cb50e31377053618cd3687ab99d10cc991171b73ea81a40aab49d415fe1",
+        checksum: "dcbe4b05f84f56e376d99ce7febfa777a2d016670139af5dd7d62b2d8544fb53",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "38731cb50e31377053618cd3687ab99d10cc991171b73ea81a40aab49d415fe1",
+        checksum: "dcbe4b05f84f56e376d99ce7febfa777a2d016670139af5dd7d62b2d8544fb53",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
+        checksum: "a015987b5b7df028ce38d9a00a637f13afd30ffd639f6487447f2319359a61aa",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
+        checksum: "a015987b5b7df028ce38d9a00a637f13afd30ffd639f6487447f2319359a61aa",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
+        checksum: "a015987b5b7df028ce38d9a00a637f13afd30ffd639f6487447f2319359a61aa",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "65ccb3ed4fdc7f55671ca4ff04beaa97bb01835e0f30b6a5f2e02dbe8b5c31f4",
+        checksum: "aa27f9402c80bd5e241dce61f093eef291cde7c9866f724ac513f00c79ac00de",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "849d2a2ff27814961e1ce9183877a0aedda263f538b0dbfa5e17357e2af00ba4",
+        checksum: "5de40c1cf697abcbbb875cdd02d28eef51453f8537d3cbb7abf17bc1dcc74403",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "849d2a2ff27814961e1ce9183877a0aedda263f538b0dbfa5e17357e2af00ba4",
+        checksum: "5de40c1cf697abcbbb875cdd02d28eef51453f8537d3cbb7abf17bc1dcc74403",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "907889dbc50c5f670c1edce503b6f1cdacc52127217611df56b4913137e814f1",
+        checksum: "754fa65f8539e77e2c548dff689a1d04c13306799eb79353a7821ef3d3cf1fb4",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "f4b26fbee43be4bf15033cd3594d8a79d5cd73a95aa62e1949e3a0836345af03",
+        checksum: "159fc5e3a9fdd01addabfc16f5c6b3e0e5c0ce2bf030b443fa739df9e987b656",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "d316c1a6a92963ba88c1c578a070eba505e1a466e3af768362122d935af31ccd",
+        checksum: "75469fd7d2b5da23be2b7763c171f76cef8f7aaafd9b2980a578348775949b52",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "c2d8f903e683ce77f608d7e8d1eadc98a0fd29d19f07110e04cc73c5d2cb887c",
+        checksum: "5fe5c746800db955096713dbab5120d3e07d3c54a8801a9c55796ea4825f15ee",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "c2d8f903e683ce77f608d7e8d1eadc98a0fd29d19f07110e04cc73c5d2cb887c",
+        checksum: "5fe5c746800db955096713dbab5120d3e07d3c54a8801a9c55796ea4825f15ee",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -1185,6 +1185,34 @@ static ERL_NIF_TERM _set_span_sample_data(ErlNifEnv* env, int argc, const ERL_NI
     return ok_atom;
 }
 
+static ERL_NIF_TERM _set_span_sample_data_if_nil(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    span_ptr *ptr;
+    ErlNifBinary key;
+    data_ptr *data_ptr;
+
+    if (argc != 3) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_get_resource(env, argv[0], appsignal_span_type, (void**) &ptr)) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_inspect_iolist_as_binary(env, argv[1], &key)) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_get_resource(env, argv[2], appsignal_data_type, (void**) &data_ptr)) {
+      return enif_make_badarg(env);
+    }
+
+    appsignal_set_span_sample_data_if_nil(
+        ptr->span,
+        make_appsignal_string(key),
+        data_ptr->data
+    );
+
+    return ok_atom;
+}
+
 static ERL_NIF_TERM _add_span_error(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
     span_ptr *ptr;
     ErlNifBinary error, message;
@@ -1424,6 +1452,7 @@ static ErlNifFunc nif_funcs[] =
     {"_set_span_attribute_double", 3, _set_span_attribute_double, 0},
     {"_set_span_attribute_sql_string", 3, _set_span_attribute_sql_string, 0},
     {"_set_span_sample_data", 3, _set_span_sample_data, 0},
+    {"_set_span_sample_data_if_nil", 3, _set_span_sample_data_if_nil, 0},
     {"_add_span_error", 4, _add_span_error, 0},
     {"_close_span", 1, _close_span, 0},
     {"_close_span_with_timestamp", 3, _close_span_with_timestamp, 0},

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -232,6 +232,10 @@ defmodule Appsignal.Nif do
     _set_span_sample_data(reference, key, value)
   end
 
+  def set_span_sample_data_if_nil(reference, key, value) do
+    _set_span_sample_data_if_nil(reference, key, value)
+  end
+
   def add_span_error(reference, name, message, backtrace) do
     _add_span_error(reference, name, message, backtrace)
   end
@@ -469,6 +473,10 @@ defmodule Appsignal.Nif do
   end
 
   def _set_span_sample_data(_reference, _key, _value) do
+    :ok
+  end
+
+  def _set_span_sample_data_if_nil(_reference, _key, _value) do
     :ok
   end
 

--- a/lib/appsignal/test/span.ex
+++ b/lib/appsignal/test/span.ex
@@ -33,6 +33,11 @@ defmodule Appsignal.Test.Span do
     Span.set_sample_data(span, key, value)
   end
 
+  def set_sample_data_if_nil(span, key, value) do
+    add(:set_sample_data_if_nil, {span, key, value})
+    Span.set_sample_data_if_nil(span, key, value)
+  end
+
   def set_attribute(span, key, value) do
     add(:set_attribute, {span, key, value})
     Span.set_attribute(span, key, value)

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -1,6 +1,7 @@
 defmodule AppsignalSpanTest do
   use ExUnit.Case
   alias Appsignal.{Span, Test}
+  import AppsignalTest.Utils, only: [with_config: 2]
 
   setup do
     start_supervised(Test.Nif)
@@ -439,14 +440,9 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_params: false})
-
-      try do
+      with_config(%{send_params: false}, fn ->
         Span.set_sample_data(span, "key", %{foo: "bar"})
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
+      end)
 
       :ok
     end
@@ -461,14 +457,9 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_params: false})
-
-      try do
+      with_config(%{send_params: false}, fn ->
         Span.set_sample_data(span, "params", %{foo: "bar"})
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
+      end)
 
       :ok
     end
@@ -483,14 +474,9 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_session_data: false})
-
-      try do
+      with_config(%{send_session_data: false}, fn ->
         Span.set_sample_data(span, "key", %{foo: "bar"})
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
+      end)
 
       :ok
     end
@@ -505,14 +491,9 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_session_data: false})
-
-      try do
+      with_config(%{send_session_data: false}, fn ->
         Span.set_sample_data(span, "session_data", %{foo: "bar"})
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
+      end)
 
       :ok
     end
@@ -610,14 +591,9 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_params: false})
-
-      try do
+      with_config(%{send_params: false}, fn ->
         Span.set_sample_data_if_nil(span, "key", %{foo: "bar"})
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
+      end)
 
       :ok
     end
@@ -632,14 +608,9 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_params: false})
-
-      try do
+      with_config(%{send_params: false}, fn ->
         Span.set_sample_data_if_nil(span, "params", %{foo: "bar"})
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
+      end)
 
       :ok
     end
@@ -654,14 +625,9 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_session_data: false})
-
-      try do
+      with_config(%{send_session_data: false}, fn ->
         Span.set_sample_data_if_nil(span, "key", %{foo: "bar"})
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
+      end)
 
       :ok
     end
@@ -676,14 +642,9 @@ defmodule AppsignalSpanTest do
     setup :create_root_span
 
     setup %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_session_data: false})
-
-      try do
+      with_config(%{send_session_data: false}, fn ->
         Span.set_sample_data_if_nil(span, "session_data", %{foo: "bar"})
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
+      end)
 
       :ok
     end


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-elixir/issues/862.

See also [agent PR](https://github.com/appsignal/appsignal-agent/pull/1018) -- if there are changes in that PR, the agent version bundled in this PR at the time of writing this might need to be updated.

---

Update the agent to a version where `set_span_sample_data_if_nil` is implemented, and implement the `set_sample_data_if_nil` function for `Appsignal.Span`.