### PR TITLE
Add `RENDER_GIT_COMMIT` changeset

### DIFF
--- a/.changesets/use-render_git_commit-as-revision.md
+++ b/.changesets/use-render_git_commit-as-revision.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Use `RENDER_GIT_COMMIT` environment variable as revision if no revision is specified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [be411435](https://github.com/appsignal/appsignal-elixir/commit/be41143553a8d6a37e2af12e688f5625cb1d3de8) patch - Add `set_sample_data_if_nil` function to `Appsignal.Span`, allowing for parameters to be set only if they would not override other parameters.
+- [be411435](https://github.com/appsignal/appsignal-elixir/commit/be41143553a8d6a37e2af12e688f5625cb1d3de8) patch - Use `RENDER_GIT_COMMIT` environment variable as revision if no revision is specified.
 
 ## 2.7.5
 


### PR DESCRIPTION
See also appsignal/appsignal-docs#1370, which should have `since_notes` with the versions in which this behaviour was added.

---

Add a changeset entry for `RENDER_GIT_COMMIT` support. Support was added in the previous release, but not documented in the changelog.

(see: [elixir commit that updated the agent](https://github.com/appsignal/appsignal-elixir/commit/be41143553a8d6a37e2af12e688f5625cb1d3de8), [agent commits in release that it was updated to](https://github.com/appsignal/appsignal-agent/commits/v-9e1ad6b))