### PR TITLE
Fix atoms in transaction_event decorator

### DIFF
--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -107,6 +107,12 @@ defmodule Appsignal.Instrumentation.Decorators do
     instrument(body, context)
   end
 
+  def transaction_event(category, body, context) when is_atom(category) do
+    category
+    |> Atom.to_string()
+    |> transaction_event(body, context)
+  end
+
   def transaction_event(category, body, context) do
     do_instrument(body, Map.put(context, :category, category))
   end


### PR DESCRIPTION
Before this fix atom values in the transaction_event decorator were ignored because of the `is_binary(key)` guards and this pokemon clause: https://github.com/appsignal/appsignal-elixir/blob/main/lib/appsignal/span.ex#L168.

I am not sure why the pokemon clause but I would suggest removing it since it will hide bugs like this. Let me know if you want a separate PR for that.