### PR TITLE
Allow JSON and Logfmt log messages

### DIFF
--- a/.changesets/allow-json-and-logfmt-log-messages.md
+++ b/.changesets/allow-json-and-logfmt-log-messages.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Allow JSON and Logfmt log messages

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -6,47 +6,97 @@ defmodule Appsignal.Logger do
   @type log_level ::
           :debug | :info | :notice | :warning | :error | :critical | :alert | :emergency
 
-  @spec debug(String.t(), String.t(), %{}) :: :ok
-  def debug(group, message, metadata \\ %{}) do
+  @type format :: :json | :logfmt | :plaintext
+
+  @spec debug(String.t(), String.t(), %{} | format()) :: :ok
+  def debug(group, message, metadata_or_format \\ %{})
+
+  def debug(group, message, format) when is_atom(format) do
+    log(:debug, group, message, %{}, format)
+  end
+
+  def debug(group, message, metadata) do
     log(:debug, group, message, metadata)
   end
 
-  @spec info(String.t(), String.t(), %{}) :: :ok
-  def info(group, message, metadata \\ %{}) do
+  @spec info(String.t(), String.t(), %{} | format()) :: :ok
+  def info(group, message, metadata_or_format \\ %{})
+
+  def info(group, message, format) when is_atom(format) do
+    log(:info, group, message, %{}, format)
+  end
+
+  def info(group, message, metadata) do
     log(:info, group, message, metadata)
   end
 
-  @spec notice(String.t(), String.t(), %{}) :: :ok
-  def notice(group, message, metadata \\ %{}) do
+  @spec notice(String.t(), String.t(), %{} | format()) :: :ok
+  def notice(group, message, metadata_or_format \\ %{})
+
+  def notice(group, message, format) when is_atom(format) do
+    log(:notice, group, message, %{}, format)
+  end
+
+  def notice(group, message, metadata) do
     log(:notice, group, message, metadata)
   end
 
-  @spec warning(String.t(), String.t(), %{}) :: :ok
-  def warning(group, message, metadata \\ %{}) do
+  @spec warning(String.t(), String.t(), %{} | format()) :: :ok
+  def warning(group, message, metadata_or_format \\ %{})
+
+  def warning(group, message, format) when is_atom(format) do
+    log(:warning, group, message, %{}, format)
+  end
+
+  def warning(group, message, metadata) do
     log(:warning, group, message, metadata)
   end
 
-  @spec error(String.t(), String.t(), %{}) :: :ok
-  def error(group, message, metadata \\ %{}) do
+  @spec error(String.t(), String.t(), %{} | format()) :: :ok
+  def error(group, message, metadata_or_format \\ %{})
+
+  def error(group, message, format) when is_atom(format) do
+    log(:error, group, message, %{}, format)
+  end
+
+  def error(group, message, metadata) do
     log(:error, group, message, metadata)
   end
 
-  @spec critical(String.t(), String.t(), %{}) :: :ok
-  def critical(group, message, metadata \\ %{}) do
+  @spec critical(String.t(), String.t(), %{} | format()) :: :ok
+  def critical(group, message, metadata_or_format \\ %{})
+
+  def critical(group, message, format) when is_atom(format) do
+    log(:critical, group, message, %{}, format)
+  end
+
+  def critical(group, message, metadata) do
     log(:critical, group, message, metadata)
   end
 
-  @spec alert(String.t(), String.t(), %{}) :: :ok
-  def alert(group, message, metadata \\ %{}) do
+  @spec alert(String.t(), String.t(), %{} | format()) :: :ok
+  def alert(group, message, metadata_or_format \\ %{})
+
+  def alert(group, message, format) when is_atom(format) do
+    log(:alert, group, message, %{}, format)
+  end
+
+  def alert(group, message, metadata) do
     log(:alert, group, message, metadata)
   end
 
-  @spec emergency(String.t(), String.t(), %{}) :: :ok
-  def emergency(group, message, metadata \\ %{}) do
+  @spec emergency(String.t(), String.t(), %{} | format()) :: :ok
+  def emergency(group, message, metadata_or_format \\ %{})
+
+  def emergency(group, message, format) when is_atom(format) do
+    log(:emergency, group, message, %{}, format)
+  end
+
+  def emergency(group, message, metadata) do
     log(:emergency, group, message, metadata)
   end
 
-  @spec log(log_level(), String.t(), String.t(), %{}, atom()) :: :ok
+  @spec log(log_level(), String.t(), String.t(), %{}, format()) :: :ok
   def log(log_level, group, message, metadata, format \\ :plaintext) do
     encoded_metadata = Appsignal.Utils.DataEncoder.encode(metadata)
 
@@ -64,6 +114,8 @@ defmodule Appsignal.Logger do
   defp severity(:emergency), do: 9
   defp severity(_), do: 3
 
+  defp format(:json), do: 2
   defp format(:logfmt), do: 1
+  defp format(:plaintext), do: 0
   defp format(_), do: 0
 end

--- a/test/appsignal/logger_test.exs
+++ b/test/appsignal/logger_test.exs
@@ -7,7 +7,7 @@ defmodule Appsignal.LoggerTest do
     :ok
   end
 
-  test "log/5 sends the log calls through the extension" do
+  test "log/5 sends the right severity through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.log(:debug, "app", "This is a debug", metadata)
@@ -22,80 +22,144 @@ defmodule Appsignal.LoggerTest do
     Logger.log(:rhubarb, "app", "This is a... rhubarb?", metadata)
 
     assert [
-             {"app", 3, 0, "This is a... rhubarb?", _},
-             {"app", 9, 0, "This is an emergency", _},
-             {"app", 8, 0, "This is an alert", _},
-             {"app", 7, 0, "This is a critical", _},
-             {"app", 6, 0, "This is an error", _},
-             {"app", 5, 0, "This is a warn", _},
-             {"app", 5, 0, "This is a warning", _},
-             {"app", 4, 0, "This is a notice", _},
+             {"app", 2, 0, "This is a debug", _},
              {"app", 3, 0, "This is an info", _},
-             {"app", 2, 0, "This is a debug", _}
-           ] = Test.Nif.get!(:log)
+             {"app", 4, 0, "This is a notice", _},
+             {"app", 5, 0, "This is a warning", _},
+             {"app", 5, 0, "This is a warn", _},
+             {"app", 6, 0, "This is an error", _},
+             {"app", 7, 0, "This is a critical", _},
+             {"app", 8, 0, "This is an alert", _},
+             {"app", 9, 0, "This is an emergency", _},
+             {"app", 3, 0, "This is a... rhubarb?", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
+  end
+
+  test "log/5 sends the right format through the extension" do
+    metadata = %{some: "metadata"}
+
+    Logger.log(:debug, "app", "Hi this is plaintext", metadata)
+    Logger.log(:debug, "app", "Hi this is also plaintext", %{}, :plaintext)
+    Logger.log(:debug, "app", "msg=\"Hi\" this=logfmt", %{}, :logfmt)
+    Logger.log(:debug, "app", "{\"msg\":\"Hi\",\"this\":\"json\"", %{}, :json)
+
+    assert [
+             {"app", 2, 0, "Hi this is plaintext", _},
+             {"app", 2, 0, "Hi this is also plaintext", _},
+             {"app", 2, 1, "msg=\"Hi\" this=logfmt", _},
+             {"app", 2, 2, "{\"msg\":\"Hi\",\"this\":\"json\"", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 
   test "debug/3 sends the debug log call through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.debug("app", "This is a debug", metadata)
+    Logger.debug("app", "this=debug", :logfmt)
+    Logger.debug("app", "{\"this\":\"debug\"}", :json)
 
-    assert [{"app", 2, 0, "This is a debug", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [
+             {"app", 2, 0, "This is a debug", _},
+             {"app", 2, 1, "this=debug", _},
+             {"app", 2, 2, "{\"this\":\"debug\"}", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 
-  test "info/3 sends the info call through the extension" do
+  test "info/3 sends the info log call through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.info("app", "This is an info", metadata)
+    Logger.info("app", "this=info", :logfmt)
+    Logger.info("app", "{\"this\":\"info\"}", :json)
 
-    assert [{"app", 3, 0, "This is an info", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [
+             {"app", 3, 0, "This is an info", _},
+             {"app", 3, 1, "this=info", _},
+             {"app", 3, 2, "{\"this\":\"info\"}", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 
   test "notice/3 sends the notice log call through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.notice("app", "This is a notice", metadata)
+    Logger.notice("app", "this=notice", :logfmt)
+    Logger.notice("app", "{\"this\":\"notice\"}", :json)
 
-    assert [{"app", 4, 0, "This is a notice", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [
+             {"app", 4, 0, "This is a notice", _},
+             {"app", 4, 1, "this=notice", _},
+             {"app", 4, 2, "{\"this\":\"notice\"}", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 
   test "warning/3 sends the warning log call through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.warning("app", "This is a warning", metadata)
+    Logger.warning("app", "this=warning", :logfmt)
+    Logger.warning("app", "{\"this\":\"warning\"}", :json)
 
-    assert [{"app", 5, 0, "This is a warning", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [
+             {"app", 5, 0, "This is a warning", _},
+             {"app", 5, 1, "this=warning", _},
+             {"app", 5, 2, "{\"this\":\"warning\"}", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 
   test "error/3 sends the error log call through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.error("app", "This is an error", metadata)
+    Logger.error("app", "this=error", :logfmt)
+    Logger.error("app", "{\"this\":\"error\"}", :json)
 
-    assert [{"app", 6, 0, "This is an error", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [
+             {"app", 6, 0, "This is an error", _},
+             {"app", 6, 1, "this=error", _},
+             {"app", 6, 2, "{\"this\":\"error\"}", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 
   test "critical/3 sends the critical log call through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.critical("app", "This is a critical", metadata)
+    Logger.critical("app", "this=critical", :logfmt)
+    Logger.critical("app", "{\"this\":\"critical\"}", :json)
 
-    assert [{"app", 7, 0, "This is a critical", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [
+             {"app", 7, 0, "This is a critical", _},
+             {"app", 7, 1, "this=critical", _},
+             {"app", 7, 2, "{\"this\":\"critical\"}", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 
   test "alert/3 sends the alert log call through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.alert("app", "This is an alert", metadata)
+    Logger.alert("app", "this=alert", :logfmt)
+    Logger.alert("app", "{\"this\":\"alert\"}", :json)
 
-    assert [{"app", 8, 0, "This is an alert", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [
+             {"app", 8, 0, "This is an alert", _},
+             {"app", 8, 1, "this=alert", _},
+             {"app", 8, 2, "{\"this\":\"alert\"}", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 
   test "emergency/3 sends the emergency log call through the extension" do
     metadata = %{some: "metadata"}
 
     Logger.emergency("app", "This is an emergency", metadata)
+    Logger.emergency("app", "this=emergency", :logfmt)
+    Logger.emergency("app", "{\"this\":\"emergency\"}", :json)
 
-    assert [{"app", 9, 0, "This is an emergency", _encoded_metadata}] = Test.Nif.get!(:log)
+    assert [
+             {"app", 9, 0, "This is an emergency", _},
+             {"app", 9, 1, "this=emergency", _},
+             {"app", 9, 2, "{\"this\":\"emergency\"}", _}
+           ] = Enum.reverse(Test.Nif.get!(:log))
   end
 end


### PR DESCRIPTION
Instead of passing metadata to the convenience methods, a format can be passed which will be used to parse metadata out of the message in the Logfmt or JSON format.

Fixes appsignal/support#244.