### PR TITLE
Add bind_address config option for the agent

### DIFF
--- a/.changesets/allow-bind_address-configuration.md
+++ b/.changesets/allow-bind_address-configuration.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Allow configuration of the agent's TCP and UDP servers using the `bind_address` config option. This is by default set to `127.0.0.1`, which only makes it accessible from the same host. If you want it to be accessible from other machines, use `0.0.0.0` or a specific IP address.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -300,6 +300,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_ACTIVE" => :active,
     "APPSIGNAL_APP_ENV" => :env,
     "APPSIGNAL_APP_NAME" => :name,
+    "APPSIGNAL_BIND_ADDRESS" => :bind_address,
     "APPSIGNAL_CA_FILE_PATH" => :ca_file_path,
     "APPSIGNAL_DEBUG" => :debug,
     "APPSIGNAL_DIAGNOSE_ENDPOINT" => :diagnose_endpoint,
@@ -349,6 +350,7 @@ defmodule Appsignal.Config do
     APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_LEVEL APPSIGNAL_LOG_PATH
     APPSIGNAL_LOGGING_ENDPOINT APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH
     APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION APPSIGNAL_REPORT_OBAN_ERRORS APPSIGNAL_STATSD_PORT
+    APPSIGNAL_BIND_ADDRESS
   )
   @bool_keys ~w(
     APPSIGNAL_ACTIVE APPSIGNAL_DEBUG APPSIGNAL_INSTRUMENT_NET_HTTP APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING
@@ -440,6 +442,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_AGENT_PATH", List.to_string(:code.priv_dir(:appsignal)))
     Nif.env_put("_APPSIGNAL_APP_NAME", to_string(config[:name]))
     Nif.env_put("_APPSIGNAL_APP_PATH", List.to_string(:code.priv_dir(:appsignal)))
+    Nif.env_put("_APPSIGNAL_BIND_ADDRESS", to_string(config[:bind_address]))
     Nif.env_put("_APPSIGNAL_CA_FILE_PATH", to_string(config[:ca_file_path]))
     Nif.env_put("_APPSIGNAL_DEBUG_LOGGING", to_string(config[:debug]))
     Nif.env_put("_APPSIGNAL_DNS_SERVERS", config[:dns_servers] |> Enum.join(","))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -443,6 +443,10 @@ defmodule Appsignal.ConfigTest do
       assert %{active: true} = with_config(%{active: true}, &init_config/0)
     end
 
+    test "bind_address" do
+      assert %{bind_address: "0.0.0.0"} = with_config(%{bind_address: "0.0.0.0"}, &init_config/0)
+    end
+
     test "ca_file_path" do
       assert %{ca_file_path: "/foo/bar/baz.ca"} =
                with_config(%{ca_file_path: "/foo/bar/baz.ca"}, &init_config/0)
@@ -693,6 +697,13 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_ACTIVE" => "true"},
                &init_config/0
              ) == default_configuration() |> Map.put(:active, true)
+    end
+
+    test "bind_address" do
+      assert with_env(
+               %{"APPSIGNAL_BIND_ADDRESS" => "0.0.0.0"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:bind_address, "0.0.0.0")
     end
 
     test "ca_file_path" do
@@ -1175,6 +1186,7 @@ defmodule Appsignal.ConfigTest do
     test "empty config options get written to the env" do
       write_to_environment()
       assert Nif.env_get("_APPSIGNAL_APP_NAME") == ~c""
+      assert Nif.env_get("_APPSIGNAL_BIND_ADDRESS") == ~c""
       assert Nif.env_get("_APPSIGNAL_HTTP_PROXY") == ~c""
       assert Nif.env_get("_APPSIGNAL_IGNORE_ACTIONS") == ~c""
       assert Nif.env_get("_APPSIGNAL_IGNORE_ERRORS") == ~c""
@@ -1207,6 +1219,7 @@ defmodule Appsignal.ConfigTest do
       with_config(
         %{
           active: true,
+          bind_address: "0.0.0.0",
           ca_file_path: "/foo/bar/zab.ca",
           debug: true,
           dns_servers: ["8.8.8.8", "8.8.4.4"],
@@ -1243,6 +1256,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_ACTIVE") == ~c"true"
           assert Nif.env_get("_APPSIGNAL_AGENT_PATH") == :code.priv_dir(:appsignal)
           assert Nif.env_get("_APPSIGNAL_APP_NAME") == ~c"AppSignal test suite app"
+          assert Nif.env_get("_APPSIGNAL_BIND_ADDRESS") == ~c"0.0.0.0"
           assert Nif.env_get("_APPSIGNAL_CA_FILE_PATH") == ~c"/foo/bar/zab.ca"
           assert Nif.env_get("_APPSIGNAL_DEBUG_LOGGING") == ~c"true"
           assert Nif.env_get("_APPSIGNAL_DNS_SERVERS") == ~c"8.8.8.8,8.8.4.4"


### PR DESCRIPTION
This feature has been available in the agent's standalone mode for a while now.

I'm cleaning up old issues and picking up this small one.

Part of https://github.com/appsignal/appsignal-agent/issues/915