### PR TITLE
Remove unneeded _APPSIGNAL_DIAGNOSE env vars

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -2,7 +2,7 @@ lib/appsignal/json.ex:31: Unknown function 'Elixir.Jason':encode/1
 lib/appsignal/json.ex:32: Unknown function 'Elixir.Jason':'encode!'/1
 lib/appsignal/json.ex:33: Unknown function 'Elixir.Jason':decode/1
 lib/appsignal/json.ex:34: Unknown function 'Elixir.Jason':'decode!'/1
-lib/appsignal/diagnose/agent.ex:14: The call 'Elixir.Appsignal.Json':decode(_report_string@1::'error') will never return since it differs in the 1st argument from the success typing arguments: (binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | []))
+lib/appsignal/diagnose/agent.ex:12: The call 'Elixir.Appsignal.Json':decode(_report_string@1::'error') will never return since it differs in the 1st argument from the success typing arguments: (binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | []))
 lib/mix/tasks/appsignal.diagnose.ex:55: The pattern {'ok', _agent_report@1} can never match the type {'error','nif_not_loaded'}
 lib/mix/tasks/appsignal.diagnose.ex:64: The pattern {'error', _raw_report@1} can never match since previous clauses completely covered the type {'error','nif_not_loaded'}
 lib/mix/tasks/appsignal.diagnose.ex:244: Function print_agent_diagnostics/1 will never be called

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -7,17 +7,12 @@ defmodule Appsignal.Diagnose.Agent do
 
   def report do
     if @nif.loaded?() do
-      Appsignal.Nif.env_put("_APPSIGNAL_DIAGNOSE", "true")
       report_string = @nif.diagnose()
 
-      report =
-        case Appsignal.Json.decode(report_string) do
-          {:ok, report} -> {:ok, report}
-          {:error, _} -> {:error, report_string}
-        end
-
-      Appsignal.Nif.env_delete("_APPSIGNAL_DIAGNOSE")
-      report
+      case Appsignal.Json.decode(report_string) do
+        {:ok, report} -> {:ok, report}
+        {:error, _} -> {:error, report_string}
+      end
     else
       {:error, :nif_not_loaded}
     end


### PR DESCRIPTION
The agent and extension no longer needs these env vars. It works without it, because it now tell the agent to run the diagnose command by using the `appsignal-agent diagnose` subcommand (as called by the extension).

I came across this when taking a brief look at the related dialyzer issues reported in #853.

Update dialyzer warning because the stacktrace changed.

[skip changeset] because it's a small internal refactor.