### PR TITLE
Add string cast to agent diagnose

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -2,7 +2,3 @@ lib/appsignal/json.ex:31: Unknown function 'Elixir.Jason':encode/1
 lib/appsignal/json.ex:32: Unknown function 'Elixir.Jason':'encode!'/1
 lib/appsignal/json.ex:33: Unknown function 'Elixir.Jason':decode/1
 lib/appsignal/json.ex:34: Unknown function 'Elixir.Jason':'decode!'/1
-lib/appsignal/diagnose/agent.ex:12: The call 'Elixir.Appsignal.Json':decode(_report_string@1::'error') will never return since it differs in the 1st argument from the success typing arguments: (binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | []))
-lib/mix/tasks/appsignal.diagnose.ex:55: The pattern {'ok', _agent_report@1} can never match the type {'error','nif_not_loaded'}
-lib/mix/tasks/appsignal.diagnose.ex:64: The pattern {'error', _raw_report@1} can never match since previous clauses completely covered the type {'error','nif_not_loaded'}
-lib/mix/tasks/appsignal.diagnose.ex:244: Function print_agent_diagnostics/1 will never be called

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -7,7 +7,7 @@ defmodule Appsignal.Diagnose.Agent do
 
   def report do
     if @nif.loaded?() do
-      report_string = @nif.diagnose()
+      report_string = to_string(@nif.diagnose)
 
       case Appsignal.Json.decode(report_string) do
         {:ok, report} -> {:ok, report}


### PR DESCRIPTION
Explicitly casting the NIF's diagnose return type to string makes dialyzer happy in 1.15.

---

This is clearly a hack-ish workaround. Couldn't get a better solution for it. Another option would be to make the `_diagnose` function from the unloaded NIF return other than an atom, but I think this PR's implementation is cleaner.

Fixes: #853 

[skip changeset]
