### PR TITLE
Add host_role config option

### DIFF
--- a/.changesets/add-role-config-option.md
+++ b/.changesets/add-role-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add the `host_role` config option. This config option can be set per host to generate some metrics automatically per host and possibly do things like grouping in the future.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -316,6 +316,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_FILTER_SESSION_DATA" => :filter_session_data,
     "APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH" => :frontend_error_catching_path,
     "APPSIGNAL_HOSTNAME" => :hostname,
+    "APPSIGNAL_HOST_ROLE" => :host_role,
     "APPSIGNAL_HTTP_PROXY" => :http_proxy,
     "APPSIGNAL_IGNORE_ACTIONS" => :ignore_actions,
     "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
@@ -347,7 +348,7 @@ defmodule Appsignal.Config do
 
   @string_keys ~w(
     APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH
-    APPSIGNAL_HOSTNAME APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_LEVEL APPSIGNAL_LOG_PATH
+    APPSIGNAL_HOSTNAME APPSIGNAL_HOST_ROLE APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_LEVEL APPSIGNAL_LOG_PATH
     APPSIGNAL_LOGGING_ENDPOINT APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH
     APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION APPSIGNAL_REPORT_OBAN_ERRORS APPSIGNAL_STATSD_PORT
     APPSIGNAL_BIND_ADDRESS
@@ -451,6 +452,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_ENABLE_NGINX_METRICS", to_string(config[:enable_nginx_metrics]))
     Nif.env_put("_APPSIGNAL_APP_ENV", to_string(config[:env]))
     Nif.env_put("_APPSIGNAL_HOSTNAME", to_string(config[:hostname]))
+    Nif.env_put("_APPSIGNAL_HOST_ROLE", to_string(config[:host_role]))
     Nif.env_put("_APPSIGNAL_HTTP_PROXY", to_string(config[:http_proxy]))
     Nif.env_put("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
     Nif.env_put("_APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -547,6 +547,11 @@ defmodule Appsignal.ConfigTest do
                with_config(%{hostname: "Bobs-MBP.example.com"}, &init_config/0)
     end
 
+    test "host_role" do
+      assert %{host_role: "host role"} =
+               with_config(%{host_role: "host role"}, &init_config/0)
+    end
+
     test "http_proxy" do
       assert %{http_proxy: "http://10.10.10.10:8888"} =
                with_config(%{http_proxy: "http://10.10.10.10:8888"}, &init_config/0)
@@ -827,6 +832,13 @@ defmodule Appsignal.ConfigTest do
                %{"APPSIGNAL_HOSTNAME" => "Bobs-MBP.example.com"},
                &init_config/0
              ) == default_configuration() |> Map.put(:hostname, "Bobs-MBP.example.com")
+    end
+
+    test "host_role" do
+      assert with_env(
+               %{"APPSIGNAL_HOST_ROLE" => "host role"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:host_role, "host role")
     end
 
     test "http_proxy" do
@@ -1228,6 +1240,7 @@ defmodule Appsignal.ConfigTest do
           env: :prod,
           push_api_key: "00000000-0000-0000-0000-000000000000",
           hostname: "My hostname",
+          host_role: "host role",
           http_proxy: "http://10.10.10.10:8888",
           ignore_actions: ~w(
             ExampleApplication.PageController#ignored
@@ -1263,6 +1276,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_ENABLE_HOST_METRICS") == ~c"false"
           assert Nif.env_get("_APPSIGNAL_APP_ENV") == ~c"prod"
           assert Nif.env_get("_APPSIGNAL_HOSTNAME") == ~c"My hostname"
+          assert Nif.env_get("_APPSIGNAL_HOST_ROLE") == ~c"host role"
           assert Nif.env_get("_APPSIGNAL_HTTP_PROXY") == ~c"http://10.10.10.10:8888"
 
           assert Nif.env_get("_APPSIGNAL_IGNORE_ACTIONS") ==


### PR DESCRIPTION
Allow users to configure a role for a host. It's not used a lot in the product yet, but we generate a metric for it and we can do some more stuff with it in the future.

Part of https://github.com/appsignal/appsignal-agent/issues/1020