### PR TITLE
Unset exit on error in bin/setup when done

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -39,3 +39,6 @@ elixir -v
 mix local.rebar
 mix local.hex --force
 mix deps.get
+
+# Unset exit on error so the shell is usable after running this script
+set +e


### PR DESCRIPTION
We source the `bin/setup` file, which means the `set -e` config option is also set on the shell session. If the shell runs into any kind of error with this setting the session closes immediately. That's not great user experience, so let's unset it before the script ends.

[skip changeset]