### PR TITLE
Lock Dialyxir to 1.3 for older Elixir versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -144,7 +144,7 @@ defmodule Appsignal.Mixfile do
       {:bypass, "~> 0.6.0", only: [:test, :test_no_nif]},
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},
       {:credo, "~> 1.6", only: [:test, :dev], runtime: false},
-      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:telemetry, telemetry_version}
     ] ++ mime_dependency
   end


### PR DESCRIPTION
Newer versions of Dialyxir use the
[Kernel.then/2](https://hexdocs.pm/elixir/Kernel.html#then/2) syntax introduced in Elixir 1.12.

Lock the package to 1.3, so we can run it on older versions while we still support them.

See also #881 for dropping those older versions.

[skip changeset]