### PR TITLE
Do not create insert job root span

### DIFF
--- a/.changesets/avoid-creating-oban-insert-job-root-span.md
+++ b/.changesets/avoid-creating-oban-insert-job-root-span.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Avoid reporting an Oban insert job event as a new incident. This should fix an issue where "insert job" events with little information show up in AppSignal as their own incidents when Oban jobs are inserted from an uninstrumented context that has no parent spans.

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -160,7 +160,13 @@ defmodule Appsignal.Oban do
   end
 
   def oban_insert_job_start(_event, _measurements, metadata, _config) do
-    span = @tracer.create_span("oban", @tracer.current_span)
+    do_oban_insert_job_start(@tracer.current_span, metadata)
+  end
+
+  def do_oban_insert_job_start(nil, _metadata), do: nil
+
+  def do_oban_insert_job_start(current_span, metadata) do
+    span = @tracer.create_span("oban", current_span)
 
     @span.set_attribute(span, "appsignal:category", "insert_job.oban")
 


### PR DESCRIPTION
Only emit the "insert job" event if there is a current parent span. Fixes #890.