### PR TITLE
Add Erlang :logger handler

### DIFF
--- a/.changesets/implement-erlang-logger-handler.md
+++ b/.changesets/implement-erlang-logger-handler.md
@@ -1,0 +1,20 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Implement an Erlang :logger handler for sending logs from AppSignal, in
+preparation for the eventual deprecation of Elixir logger backends.
+
+Add a convenience method to configure this logger handler automatically,
+with the right settings for AppSignal:
+
+```elixir
+Appsignal.Logger.Handler.add("my_app", :plaintext)
+```
+
+To remove the logging handler, call the `.remove` method:
+
+```elixir
+Appsignal.Logger.Handler.remove()
+```

--- a/lib/appsignal/logger/handler.ex
+++ b/lib/appsignal/logger/handler.ex
@@ -1,0 +1,39 @@
+defmodule Appsignal.Logger.Handler do
+  def log(
+        %{
+          meta: metadata,
+          level: level
+        } = event,
+        %{
+          config: %{
+            group: group,
+            format: format
+          },
+          formatter: {formatter, formatter_config}
+        }
+      ) do
+    Appsignal.Logger.log(
+      level,
+      group,
+      IO.chardata_to_string(formatter.format(event, formatter_config)),
+      Enum.into(metadata, %{}),
+      format
+    )
+  end
+
+  def add(group, format \\ :plaintext) do
+    :logger.add_handler(:appsignal_log, __MODULE__, %{
+      config: %{
+        group: group,
+        format: format
+      },
+      formatter:
+        Logger.Formatter.new(
+          format: "$message",
+          colors: [enabled: false]
+        )
+    })
+  end
+
+  def remove, do: :logger.remove_handler(:appsignal_log)
+end

--- a/test/appsignal/logger/handler_test.exs
+++ b/test/appsignal/logger/handler_test.exs
@@ -1,0 +1,33 @@
+defmodule Appsignal.Logger.HandlerTest do
+  use ExUnit.Case
+  require Logger
+
+  setup do
+    Appsignal.Logger.Handler.add("some_group")
+    start_supervised!(Appsignal.Test.Nif)
+    on_exit(fn -> Appsignal.Logger.Handler.remove() end)
+    :ok
+  end
+
+  case Version.compare(System.version(), "1.15.0") do
+    :lt ->
+      nil
+
+    _ ->
+      test "add/2 sets up a :logger handler" do
+        Logger.error("A bad thing happened!")
+
+        assert [
+                 {"some_group", 6, 0, "A bad thing happened!", _}
+               ] = Appsignal.Test.Nif.get!(:log)
+      end
+
+      test "remove/0 removes the :logger handler" do
+        :logger.remove_handler(:appsignal_log)
+
+        Logger.error("A bad thing happened!")
+
+        assert :error = Appsignal.Test.Nif.get(:log)
+      end
+  end
+end


### PR DESCRIPTION
Add an Erlang-style :logger handler as recommended for Elixir 1.15 and above. Include an `Appsignal.Logger.Handler.add/2` method for convenience to save users from manually declaring an appropriate configuration for the handler.

Fixes #883.

### To do

- [x] Write docs -- https://github.com/appsignal/appsignal-docs/pull/1582