### PR TITLE
improvement: add `register_parent/1` to `Appsignal.Tracer`

### DIFF
--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -207,6 +207,25 @@ defmodule Appsignal.Tracer do
     :ok
   end
 
+  @doc """
+  Registers a span as the parent span for any spans started by this process.
+
+  This is necessary when you want to instrument asynchronous work.
+
+      parent = Appsignal.Tracer.current_span()
+
+      list
+      |> Task.async_stream(fn item ->
+        Appsignal.Tracer.register_parent(parent)
+
+        ...
+      end)
+      |> Stream.run()
+  """
+  def register_parent(span) do
+    register(%{span | pid: self()})
+  end
+
   defp register(%Span{pid: pid} = span) do
     if insert({pid, span}) do
       @monitor.add()


### PR DESCRIPTION
Need something like this for `ash_appsignal` which starts processes for you.

See #895 for context.