### PR TITLE
Cast option values to string

### DIFF
--- a/.changesets/fix-config-options-set-with-atoms.md
+++ b/.changesets/fix-config-options-set-with-atoms.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix configuration options set with atoms. The options `log` and `log_level` can now be set as an Atom, and we'll cast them to a string internally to avoid any `ArgumentError` from the Nif.

--- a/.changesets/support-warning-log_level.md
+++ b/.changesets/support-warning-log_level.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix support for `warning` `log_level`. Only `warn` would work, now `warning` also works as documented.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -507,6 +507,7 @@ defmodule Appsignal.Config do
       "debug" -> :debug
       "info" -> :info
       "warn" -> :warn
+      "warning" -> :warn
       "error" -> :error
       _ -> deprecated_log_level(config)
     end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -471,8 +471,8 @@ defmodule Appsignal.Config do
       "elixir-" <> @language_integration_version
     )
 
-    Nif.env_put("_APPSIGNAL_LOG", config[:log])
-    Nif.env_put("_APPSIGNAL_LOG_LEVEL", config[:log_level] || "")
+    Nif.env_put("_APPSIGNAL_LOG", to_string(config[:log]))
+    Nif.env_put("_APPSIGNAL_LOG_LEVEL", to_string(config[:log_level] || ""))
     Nif.env_put("_APPSIGNAL_LOG_FILE_PATH", to_string(log_file_path()))
     Nif.env_put("_APPSIGNAL_LOGGING_ENDPOINT", config[:logging_endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")
@@ -502,7 +502,7 @@ defmodule Appsignal.Config do
   end
 
   defp log_level(config) do
-    case config[:log_level] do
+    case to_string(config[:log_level]) do
       "trace" -> :trace
       "debug" -> :debug
       "info" -> :info

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -472,7 +472,7 @@ defmodule Appsignal.Config do
     )
 
     Nif.env_put("_APPSIGNAL_LOG", to_string(config[:log]))
-    Nif.env_put("_APPSIGNAL_LOG_LEVEL", to_string(config[:log_level] || ""))
+    Nif.env_put("_APPSIGNAL_LOG_LEVEL", to_string(log_level(config)))
     Nif.env_put("_APPSIGNAL_LOG_FILE_PATH", to_string(log_file_path()))
     Nif.env_put("_APPSIGNAL_LOGGING_ENDPOINT", config[:logging_endpoint] || "")
     Nif.env_put("_APPSIGNAL_PUSH_API_ENDPOINT", config[:endpoint] || "")

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -366,6 +366,10 @@ defmodule Appsignal.ConfigTest do
       assert with_config(%{log_level: "warn"}, &Config.log_level/0) == :warn
     end
 
+    test "when log level is set to a known warning log level" do
+      assert with_config(%{log_level: "warning"}, &Config.log_level/0) == :warn
+    end
+
     test "when log level is set to an invalid value" do
       assert with_config(%{log_level: "foobar"}, &Config.log_level/0) == :info
     end

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -1249,7 +1249,7 @@ defmodule Appsignal.ConfigTest do
           ignore_errors: ~w(VerySpecificError AnotherError),
           ignore_namespaces: ~w(admin private_namespace),
           log: "stdout",
-          log_level: "warn",
+          log_level: "trace",
           log_path: "/tmp",
           logging_endpoint: "https://push.staging.lol",
           name: "AppSignal test suite app",
@@ -1289,7 +1289,7 @@ defmodule Appsignal.ConfigTest do
                    ~c"elixir-" ++ String.to_charlist(Mix.Project.config()[:version])
 
           assert Nif.env_get("_APPSIGNAL_LOG") == ~c"stdout"
-          assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == ~c"warn"
+          assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == ~c"trace"
           assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == ~c"/tmp/appsignal.log"
           assert Nif.env_get("_APPSIGNAL_LOGGING_ENDPOINT") == ~c"https://push.staging.lol"
           assert Nif.env_get("_APPSIGNAL_PUSH_API_ENDPOINT") == ~c"https://push.staging.lol"
@@ -1312,18 +1312,22 @@ defmodule Appsignal.ConfigTest do
     end
 
     @tag :skip_env_test_no_nif
-    test "name as atom" do
-      with_config(%{name: :appsignal_test_suite_app}, fn ->
+    test "option as atom" do
+      with_config(%{name: :appsignal_test_suite_app, log: :file, log_level: :trace}, fn ->
         write_to_environment()
         assert Nif.env_get("_APPSIGNAL_APP_NAME") == ~c"appsignal_test_suite_app"
+        assert Nif.env_get("_APPSIGNAL_LOG") == ~c"file"
+        assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == ~c"trace"
       end)
     end
 
     @tag :skip_env_test_no_nif
-    test "name as string" do
-      with_config(%{name: "AppSignal test suite app"}, fn ->
+    test "option as string" do
+      with_config(%{name: "AppSignal test suite app", log: "file", log_level: "trace"}, fn ->
         write_to_environment()
         assert Nif.env_get("_APPSIGNAL_APP_NAME") == ~c"AppSignal test suite app"
+        assert Nif.env_get("_APPSIGNAL_LOG") == ~c"file"
+        assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == ~c"trace"
       end)
     end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -1335,6 +1335,33 @@ defmodule Appsignal.ConfigTest do
       end)
     end
 
+    @tag :skip_env_test_no_nif
+    test "log_level as warning" do
+      with_config(%{log_level: "warning"}, fn ->
+        write_to_environment()
+        assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == ~c"warn"
+      end)
+    end
+
+    @tag :skip_env_test_no_nif
+    test "deprecated log level configuration" do
+      with_config(%{transaction_debug_mode: true}, fn ->
+        write_to_environment()
+        assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == ~c"trace"
+      end)
+
+      with_config(%{debug: true}, fn ->
+        write_to_environment()
+        assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == ~c"debug"
+      end)
+
+      # Default fallback if nothing is configured
+      with_config(%{log_level: nil}, fn ->
+        write_to_environment()
+        assert Nif.env_get("_APPSIGNAL_LOG_LEVEL") == ~c"info"
+      end)
+    end
+
     test "writes dns_servers to env if empty" do
       with_config(%{dns_servers: []}, fn ->
         write_to_environment()


### PR DESCRIPTION
## Cast config options to string values

We got a report that when the `log_level` option was set as an atom value it it would throw a ArgumentError.

Cast the config option to a string so this doesn't happen anymore.

```
** (Mix) Could not start application appsignal: exited in: Appsignal.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (ArgumentError) argument error
            (appsignal 2.7.9) Appsignal.Nif._env_put("_APPSIGNAL_LOG_LEVEL", :trace)
            (appsignal 2.7.9) lib/appsignal/config.ex:476: Appsignal.Config.write_to_environment/1
            (appsignal 2.7.9) lib/appsignal.ex:94: Appsignal.initialize/0
            (appsignal 2.7.9) lib/appsignal.ex:24: Appsignal.start/2
            (kernel 8.5.1) application_master.erl:293: :application_master.start_it_old/4
```

## Fix support for `warning` log_level

We have documented the `warning` log_level works in the integration, but it only works to set the log_level to warning in the agent. The integration didn't support it, because a case-statement arm was missing for `warning`.

## Ensure log_level is used in integration and agent

Use the `log_level` function as the single source of truth for which `log_level` is set.

This also then works to support the deprecated config options values translation to the new `log_level` values.
