### PR TITLE
Bump agent to e8207c1

### DIFF
--- a/.changesets/bump-agent-to-e8207c1.md
+++ b/.changesets/bump-agent-to-e8207c1.md
@@ -1,0 +1,11 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to e8207c1.
+
+- Add `memory_in_percentages` and `swap_in_percentages` host metrics that represents metrics in percentages.
+- Ignore `/snap/` disk mountpoints.
+- Fix issue with the open span count in logs being logged as a negative number.
+- Fix agent's TCP server getting stuck when two requests are made within the same fraction of a second.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "6133900"
+  def version, do: "e8207c1"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
+        checksum: "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
+        checksum: "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
+        checksum: "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
+        checksum: "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
+        checksum: "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "cdd75637940fcfd369b569e873048c7d37a3844d9d31d783e4459b375b78ee0e",
+        checksum: "dfecb037362aac064d6a697c3e4ce293136a8e459894b2928c0120c6393db22a",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
+        checksum: "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
+        checksum: "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "bd625ed84100d0632b298ac602b152463628c41afe56a8621745cdae626f8413",
+        checksum: "3350aec725af61a3eeb83971c0ee1da6dee761df3f2099945dd5ced9a0193a50",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "7988c4a2a6ba5d59be2186ce9bf51ab50b6537a60888b08c8e9066172516e59d",
+        checksum: "eaab36b010bdc5b06ac4646b6d4ebb94523a9f852a2a2cbaba7738b3fade64d1",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "8e5fe2a8bc4cb7de4ba7d61fec48f15aa0cd580050f67752f07625853636eb16",
+        checksum: "ad371eabe4e2484f7fb980e8bb53d7b079a473d615cbb738271d36f7ad81c71f",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
+        checksum: "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
+        checksum: "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }


### PR DESCRIPTION
- Add `memory_in_percentages` and `swap_in_percentages` host metrics that represents metrics in percentages.
- Ignore `/snap/` disk mountpoints.
- Fix issue with the open span count in logs being logged as a negative number.
- Fix agent's TCP server getting stuck when two requests are made within the same fraction of a second.

[skip review]