### PR TITLE
Allow passing the current span across processes

### DIFF
--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -207,6 +207,24 @@ defmodule Appsignal.Tracer do
     :ok
   end
 
+  @doc false
+  def register_current(span) do
+    # Registers a span as the current span for this process.
+    #
+    # This is necessary when you want to instrument asynchronous work.
+    #
+    #     parent = Appsignal.Tracer.current_span()
+    #
+    #     list
+    #     |> Task.async_stream(fn item ->
+    #       Appsignal.Tracer.register_current(parent)
+    #       # ...
+    #     end)
+    #     |> Stream.run()
+
+    register(%{span | pid: self()})
+  end
+
   defp register(%Span{pid: pid} = span) do
     if insert({pid, span}) do
       @monitor.add()

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -465,6 +465,23 @@ defmodule Appsignal.TracerTest do
     end
   end
 
+  describe "register_current/1" do
+    test "carries over the current span to a new PID" do
+      span = Tracer.create_span("http_request")
+
+      task =
+        Task.async(fn ->
+          Tracer.register_current(span)
+          Tracer.current_span()
+        end)
+
+      task_current_span = Task.await(task)
+
+      assert Map.fetch!(span, :pid) != Map.fetch!(task_current_span, :pid)
+      assert Map.fetch!(span, :reference) == Map.fetch!(task_current_span, :reference)
+    end
+  end
+
   defp create_root_span(_context) do
     [span: Tracer.create_span("http_request")]
   end


### PR DESCRIPTION
Taking over #894 to implement our little bikesheds about it. (ping @zachdaniel for visibility)

Add `register_current/1` to `Appsignal.Tracer`. This is needed by the `ash_appsignal` instrumentation, as Ash starts processes for you.

[skip changeset] as it is `@doc false`