### PR TITLE
Bump agent to b604345

### DIFF
--- a/.changesets/bump-agent-to-b604345.md
+++ b/.changesets/bump-agent-to-b604345.md
@@ -1,0 +1,12 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to b604345.
+
+- Add an exponential backoff to the retry sleep time to bind to the StatsD, NGINX and OpenTelemetry exporter ports. This gives the agent a longer time to connect to the ports if they become available within a 4 minute window.
+- Changes to the agent logger:
+  - Logs from the agent and extension now use a more consistent format in logs for spans and transactions.
+  - Logs that are for more internal use are moved to the trace log level and logs that are useful for debugging most support issues are moved to the debug log level. It should not be necessary to use log level 'trace' as often anymore. The 'debug' log level should be enough.
+- Add `running_in_container` to agent diagnose report, to be used primarily by the Python package as a way to detect if an app's host is a container or not.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "e8207c1"
+  def version, do: "b604345"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
+        checksum: "98ac31aa2ca05a18e5eb94a8ecee75b83bb7d973f0f7565a36815b95577aa727",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
+        checksum: "98ac31aa2ca05a18e5eb94a8ecee75b83bb7d973f0f7565a36815b95577aa727",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+        checksum: "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+        checksum: "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+        checksum: "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "dfecb037362aac064d6a697c3e4ce293136a8e459894b2928c0120c6393db22a",
+        checksum: "aa36f82e040b86743fed514268dc1c7d83b14739dd65337a05bf2d994b83a3aa",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
+        checksum: "7ce2f5ed5a0f0b4ad574e897d6cd0e5912928b211b307b20b6837c1bcbfaf640",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
+        checksum: "7ce2f5ed5a0f0b4ad574e897d6cd0e5912928b211b307b20b6837c1bcbfaf640",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "3350aec725af61a3eeb83971c0ee1da6dee761df3f2099945dd5ced9a0193a50",
+        checksum: "a597e674a8285871df3c42dc98400a8adff969737d23f8336b10d68a5d70081b",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "eaab36b010bdc5b06ac4646b6d4ebb94523a9f852a2a2cbaba7738b3fade64d1",
+        checksum: "ce8e4aa510880f533f17d62c53386ddf8222d2e5cd325b29f53c68661e76eea3",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "ad371eabe4e2484f7fb980e8bb53d7b079a473d615cbb738271d36f7ad81c71f",
+        checksum: "2923da7c60ffc78f22c583e4653d904c11254c2ddd030face089b5e22e15ede2",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
+        checksum: "59d341ed55ae705f034fbfa0007488e2e4c92c8e8ce0cc20604e467f252c9fd1",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
+        checksum: "59d341ed55ae705f034fbfa0007488e2e4c92c8e8ce0cc20604e467f252c9fd1",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }


### PR DESCRIPTION
Include changelog notes for this release, but not release 8260fa1 as it was OpenTelemetry specific, which the Elixir package doesn't support.

[skip review]