### PR TITLE
Improve `Ecto.Multi` instrumentation

### DIFF
--- a/.changesets/improve-ecto-transaction-instrumentation.md
+++ b/.changesets/improve-ecto-transaction-instrumentation.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Improve Ecto transaction instrumentation. Queries performed as part of an
+`Ecto.Multi` or an `Ecto.Repo.transaction` were already individually
+instrumented, but now they are displayed in the event timeline as child events
+of a broader transaction event. An additional event is added at the end of the
+transaction, to denote whether the transaction was committed or rolled back.


### PR DESCRIPTION
Instead of discarding `begin` and `commit` queries, use them as the start and end point of a parent span that groups the transaction.

Handle `rollback` queries as well by adding them to this transaction group, quickly showing at a glance whether the transaction succeeded or failed.