### PR TITLE
Bump agent to 8f31b1a

### DIFF
--- a/.changesets/error-metrics.md
+++ b/.changesets/error-metrics.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix missing error metrics for the error rate and error count graphs in some scenarios, like with Node.js Koa apps.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "aa4daed"
+  def version, do: "8f31b1a"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "8216a8c083ffb7f286fd249c82fb63fe45527276a8a616c0921da3f3e8b9073a",
+        checksum: "b81667a886ef89319a9d177749dc4acf48814d0f834c2974d0d2b4639dd664e6",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "8216a8c083ffb7f286fd249c82fb63fe45527276a8a616c0921da3f3e8b9073a",
+        checksum: "b81667a886ef89319a9d177749dc4acf48814d0f834c2974d0d2b4639dd664e6",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "5f1782b53f24e2d8f8e0681eb7934af93532f84475c44b7389b2fe88ac34630d",
+        checksum: "a1b4aa1d7aaf756bcdc7bcec615033002531c6fb44aa7a2d00abda567bd4e9ab",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "5f1782b53f24e2d8f8e0681eb7934af93532f84475c44b7389b2fe88ac34630d",
+        checksum: "a1b4aa1d7aaf756bcdc7bcec615033002531c6fb44aa7a2d00abda567bd4e9ab",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "5f1782b53f24e2d8f8e0681eb7934af93532f84475c44b7389b2fe88ac34630d",
+        checksum: "a1b4aa1d7aaf756bcdc7bcec615033002531c6fb44aa7a2d00abda567bd4e9ab",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "0743450b2ad48971ec3251565898e33b9af214b4d2db36e12b7089ff3d3b8f3e",
+        checksum: "ce212c1672c247d1b72b92aee71a256c1270bb1d52ff7e91c5d48da423b6701d",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "32a72c3a9745348251fe20e8e8d10f52476e8cec47ea3b2495c14d1ca4a30ac5",
+        checksum: "e2a394ee9b9e4d11572e48cb3dd457f077453e87b8520f54e8150b889b4d7d43",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "32a72c3a9745348251fe20e8e8d10f52476e8cec47ea3b2495c14d1ca4a30ac5",
+        checksum: "e2a394ee9b9e4d11572e48cb3dd457f077453e87b8520f54e8150b889b4d7d43",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "8804bdd137e87576f0f32e565ecafc395da118e1d427155c38f27cc7d222777d",
+        checksum: "0e4152b1b5e0924a70a3a24604d11bfa2c4df8faea43b30546d6e880b41f9a51",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "09f97d946a7d1c45f24824e8c0c296ac49fdbf0a8e9869e45176838bc82929c5",
+        checksum: "26c4e0b857efe69b774cfe68a68ab97a91aee58c3c23ffd32955ca16f8c020fa",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "e0f942c8053e2939cffce722c35160d8798d867d91902b6cb9b6ccf7513d0059",
+        checksum: "8b39b9180ac16ca7b99eb226e43fe9be74340fb07b2c002fe1054cb6d2e6b010",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "c105e18399df06884983ec58602a848369a98806ba8264e6dc2b7a06476dd582",
+        checksum: "2a0456b860c446938aae1d605193e6732578a39ef0df2a1247266335adc019e9",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "c105e18399df06884983ec58602a848369a98806ba8264e6dc2b7a06476dd582",
+        checksum: "2a0456b860c446938aae1d605193e6732578a39ef0df2a1247266335adc019e9",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }


### PR DESCRIPTION
Fixes issue with error metrics for apps like Node.js Koa. Could affect Elixir spans as well.

[skip review]