### PR TITLE
Fix Credo issue about function naming

### DIFF
--- a/test/appsignal/nif_test.exs
+++ b/test/appsignal/nif_test.exs
@@ -5,7 +5,7 @@ end
 defmodule Appsignal.NifTest do
   alias Appsignal.Nif
   use ExUnit.Case, async: true
-  import AppsignalTest.Utils, only: [is_reference_or_binary: 1]
+  import AppsignalTest.Utils, only: [reference_or_binary?: 1]
 
   test "whether the agent starts" do
     assert :ok = Nif.start()
@@ -18,7 +18,7 @@ defmodule Appsignal.NifTest do
   @tag :skip_env_test_no_nif
   test "starting transaction returns a reference to the transaction resource" do
     assert {:ok, reference} = Nif.start_transaction("transaction id", "http_request")
-    assert is_reference_or_binary(reference)
+    assert reference_or_binary?(reference)
   end
 
   if Mix.env() not in [:test_no_nif] do

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -79,7 +79,7 @@ defmodule AppsignalTest.Utils do
     end)
   end
 
-  def is_reference_or_binary(term) do
+  def reference_or_binary?(term) do
     if System.otp_release() >= "20" do
       is_reference(term)
     else


### PR DESCRIPTION
Suddenly breaks the build, so let's fix it by renaming the function in the way Credo suggests.

[skip review]
[skip changeset]