### PR TITLE
Optional user definable custom function on_create_span/2

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,6 @@ if Mix.env() in [:bench, :test, :test_no_nif] do
   config :appsignal, appsignal_span: Appsignal.Test.Span
   config :appsignal, appsignal_tracer: Appsignal.Test.Tracer
   config :appsignal, appsignal_tracer_nif: Appsignal.Test.Nif
-  config :appsignal, custom_on_create_fun: &Appsignal.Support.Tracer.custom_on_create_fun/2
   config :appsignal, deletion_delay: 100
 
   config :appsignal, :config,

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,10 +11,11 @@ if Mix.env() in [:bench, :test, :test_no_nif] do
   config :appsignal, os_internal: FakeOS
   config :appsignal, ecto_repo: FakeEctoRepo
 
-  config :appsignal, appsignal_tracer_nif: Appsignal.Test.Nif
-  config :appsignal, appsignal_tracer: Appsignal.Test.Tracer
-  config :appsignal, appsignal_span: Appsignal.Test.Span
   config :appsignal, appsignal_monitor: Appsignal.Test.Monitor
+  config :appsignal, appsignal_span: Appsignal.Test.Span
+  config :appsignal, appsignal_tracer: Appsignal.Test.Tracer
+  config :appsignal, appsignal_tracer_nif: Appsignal.Test.Nif
+  config :appsignal, custom_on_create_fun: &Appsignal.Support.Tracer.custom_on_create_fun/2
   config :appsignal, deletion_delay: 100
 
   config :appsignal, :config,

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -54,7 +54,7 @@ defmodule Appsignal.Tracer do
       namespace
       |> Span.create_root(pid, options[:start_time])
       |> register()
-      |> on_create_span(nil)
+      |> on_create_span()
     end
   end
 
@@ -65,7 +65,7 @@ defmodule Appsignal.Tracer do
       parent
       |> Span.create_child(pid, options[:start_time])
       |> register()
-      |> on_create_span(parent)
+      |> on_create_span()
     end
   end
 
@@ -262,12 +262,12 @@ defmodule Appsignal.Tracer do
     end
   end
 
-  @spec on_create_span(Span.t() | nil, Span.t() | nil) :: Span.t() | nil
-  defp on_create_span(span, parent) do
+  @spec on_create_span(Span.t() | nil) :: Span.t() | nil
+  defp on_create_span(span) do
     custom_on_create_fun =
-      Application.get_env(:appsignal, :custom_on_create_fun, &__MODULE__.custom_on_create_fun/2)
+      Application.get_env(:appsignal, :custom_on_create_fun, &__MODULE__.custom_on_create_fun/1)
 
-    span = custom_on_create_fun.(span, parent)
+    custom_on_create_fun.(span)
     span
   end
 
@@ -279,7 +279,7 @@ defmodule Appsignal.Tracer do
   Example in your own application:
   ```ex
   defmodule MyApp.Appsignal do
-    def custom_on_create_fun(span, parent) do
+    def custom_on_create_fun(span) do
       Appsignal.Span.set_sample_data(span, "custom_data", %{"foo": "bar"})
     end
   end
@@ -287,12 +287,12 @@ defmodule Appsignal.Tracer do
 
   This can be added to the config with:
   ```ex
-  config :appsignal, custom_on_create_fun: &MyApp.Appsignal.custom_on_create_fun/2
+  config :appsignal, custom_on_create_fun: &MyApp.Appsignal.custom_on_create_fun/1
   ```
   """
 
-  @spec custom_on_create_fun(Span.t() | nil, Span.t() | nil) :: Span.t() | nil
-  def custom_on_create_fun(span, _parent) do
-    span
+  @spec custom_on_create_fun(Span.t() | nil) :: any()
+  def custom_on_create_fun(_span) do
+    nil
   end
 end

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -4,11 +4,6 @@ defmodule Appsignal.Tracer do
   require Appsignal.Utils
 
   @monitor Appsignal.Utils.compile_env(:appsignal, :appsignal_monitor, Appsignal.Monitor)
-  @custom_on_create_fun Appsignal.Utils.compile_env(
-                          :appsignal,
-                          :custom_on_create_fun,
-                          &Appsignal.Tracer.custom_on_create_fun/2
-                        )
 
   @table :"$appsignal_registry"
 
@@ -269,7 +264,10 @@ defmodule Appsignal.Tracer do
 
   @spec on_create_span(Span.t() | nil, Span.t() | nil) :: Span.t() | nil
   defp on_create_span(span, parent) do
-    @custom_on_create_fun.(span, parent)
+    custom_on_create_fun =
+      Application.get_env(:appsignal, :custom_on_create_fun, &__MODULE__.custom_on_create_fun/2)
+
+    span = custom_on_create_fun.(span, parent)
     span
   end
 

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -489,6 +489,7 @@ defmodule Appsignal.TracerTest do
       end)
     end
 
+    @tag :skip_env_test_no_nif
     test "custom data is set with custom_on_create_fun_span" do
       Application.put_env(
         :appsignal,
@@ -502,6 +503,7 @@ defmodule Appsignal.TracerTest do
                |> Span.to_map()
     end
 
+    @tag :skip_env_test_no_nif
     test "custom data is set with custom_on_create_fun_parent updates the parent span" do
       parent = "http_request" |> Tracer.create_span()
 

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -485,7 +485,7 @@ defmodule Appsignal.TracerTest do
   describe "on_create_span/2" do
     setup do
       on_exit(fn ->
-        Application.put_env(:appsignal, :custom_on_create_fun, &Tracer.custom_on_create_fun/2)
+        Application.put_env(:appsignal, :custom_on_create_fun, &Tracer.custom_on_create_fun/1)
       end)
     end
 
@@ -493,7 +493,7 @@ defmodule Appsignal.TracerTest do
       Application.put_env(
         :appsignal,
         :custom_on_create_fun,
-        &__MODULE__.custom_on_create_fun_span/2
+        &__MODULE__.custom_on_create_fun_span/1
       )
 
       assert %{"sample_data" => %{"custom_data" => "{\"foo\":\"bar\"}"}} =
@@ -510,7 +510,7 @@ defmodule Appsignal.TracerTest do
       Application.put_env(
         :appsignal,
         :custom_on_create_fun,
-        &__MODULE__.custom_on_create_fun_parent/2
+        &__MODULE__.custom_on_create_fun_parent/1
       )
 
       "http_request" |> Tracer.create_span(parent)
@@ -560,12 +560,12 @@ defmodule Appsignal.TracerTest do
     end)
   end
 
-  def custom_on_create_fun_span(span, _parent) do
+  def custom_on_create_fun_span(span) do
     Appsignal.Span.set_sample_data(span, "custom_data", %{foo: "bar"})
   end
 
-  def custom_on_create_fun_parent(span, parent) do
-    Appsignal.Span.set_sample_data(parent, "custom_data", %{foo: "bar"})
-    span
+  def custom_on_create_fun_parent(span) do
+    root = Tracer.root_span(span.pid)
+    Appsignal.Span.set_sample_data(root, "custom_data", %{foo: "bar"})
   end
 end

--- a/test/appsignal/tracer_test.exs
+++ b/test/appsignal/tracer_test.exs
@@ -482,6 +482,15 @@ defmodule Appsignal.TracerTest do
     end
   end
 
+  describe "on_create_span/2" do
+    test "custom data is set with Appsignal.Support.Tracer defined in config" do
+      assert %{"sample_data" => %{"custom_data" => "{\"foo\":\"bar\"}"}} =
+               "http_request"
+               |> Tracer.create_span()
+               |> Span.to_map()
+    end
+  end
+
   defp create_root_span(_context) do
     [span: Tracer.create_span("http_request")]
   end

--- a/test/support/tracer.ex
+++ b/test/support/tracer.ex
@@ -1,0 +1,6 @@
+defmodule Appsignal.Support.Tracer do
+  @spec custom_on_create_fun(nil | Appsignal.Span.t(), any()) :: nil | Appsignal.Span.t()
+  def custom_on_create_fun(span, _parent) do
+    Appsignal.Span.set_sample_data(span, "custom_data", %{foo: "bar"})
+  end
+end

--- a/test/support/tracer.ex
+++ b/test/support/tracer.ex
@@ -1,6 +1,0 @@
-defmodule Appsignal.Support.Tracer do
-  @spec custom_on_create_fun(nil | Appsignal.Span.t(), any()) :: nil | Appsignal.Span.t()
-  def custom_on_create_fun(span, _parent) do
-    Appsignal.Span.set_sample_data(span, "custom_data", %{foo: "bar"})
-  end
-end


### PR DESCRIPTION
With this function users can add their own function that will be executed right after create_span is called. This allows users to inject data into spans with traces of other tracing providers.

Example
```ex
  defmodule MyApp.Appsignal do
    def custom_on_create_fun(span) do
      Appsignal.Span.set_sample_data(span, "custom_data", %{"foo": "bar"})
    end
  end
```
Then it can be added to the config with
```ex
  config :appsignal, custom_on_create_fun: &MyApp.Appsignal.custom_on_create_fun/1
```

After opening the PR  [Optional fun argument for attach](https://github.com/appsignal/appsignal-elixir-phoenix/pull/80) in here @unflxw mentioned adding the option to this library and executing it on the `create_span/3`.