### PR TITLE
Sample data fixes for lists and keyword lists

### DIFF
--- a/.changesets/fix-data-encoding-for-keyword-lists.md
+++ b/.changesets/fix-data-encoding-for-keyword-lists.md
@@ -1,0 +1,14 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Add support for keywords lists in sample data on spans. These would previously be shown an empty list.
+
+```elixir
+Appsignal.Span.set_sample_data(
+  Appsignal.Tracer.root_span,
+  "custom_data",
+  %{"keyword_list": [foo: "some value", "bar": "other value"]}
+)
+```

--- a/.changesets/support-lists-as-root-sample-data.md
+++ b/.changesets/support-lists-as-root-sample-data.md
@@ -1,0 +1,17 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add support for lists in the sample data as root values on spans, as shown below. Previously we only supported lists as nested objects in maps.
+
+```elixir
+Appsignal.Span.set_sample_data(
+  Appsignal.Tracer.root_span,
+  "custom_data",
+  [
+    "value 1",
+    "value 2"
+  ]
+)
+```

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -242,7 +242,7 @@ defmodule Appsignal.Span do
   end
 
   defp do_set_sample_data(%Span{reference: reference} = span, key, value, setter)
-       when is_binary(key) and is_map(value) do
+       when is_binary(key) and (is_map(value) or is_list(value)) do
     data = Appsignal.Utils.DataEncoder.encode(value)
 
     :ok = setter.(reference, key, data)

--- a/lib/appsignal/utils/data_encoder.ex
+++ b/lib/appsignal/utils/data_encoder.ex
@@ -19,7 +19,26 @@ defmodule Appsignal.Utils.DataEncoder do
 
   def encode(data) when is_list(data) do
     {:ok, resource} = Nif.data_list_new()
-    Enum.each(data, fn item -> encode(resource, item) end)
+
+    Enum.each(data, fn item ->
+      if is_map(item) or is_tuple(item) do
+        Nif.data_set_data(resource, encode(item))
+      else
+        if is_list(item) do
+          if proper_list?(item) do
+            Nif.data_set_data(resource, encode(item))
+          else
+            Nif.data_set_string(
+              resource,
+              "improper_list:#{inspect(item)}"
+            )
+          end
+        else
+          encode(resource, item)
+        end
+      end
+    end)
+
     resource
   end
 

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -504,6 +504,36 @@ defmodule AppsignalSpanTest do
     end
   end
 
+  describe ".set_sample_data/3, with a list" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      Span.set_sample_data(span, "custom_data", ["abc", "def"])
+
+      :ok
+    end
+
+    @tag :skip_env_test_no_nif
+    test "sets the list as sample data", %{span: span} do
+      assert %{"sample_data" => %{"custom_data" => "[\"abc\",\"def\"]"}} = Span.to_map(span)
+    end
+  end
+
+  describe ".set_sample_data/3, with a keyword list" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      Span.set_sample_data(span, "custom_data", abc: "def")
+
+      :ok
+    end
+
+    @tag :skip_env_test_no_nif
+    test "sets the keyword list as sample data", %{span: span} do
+      assert %{"sample_data" => %{"custom_data" => "[[\"abc\",\"def\"]]"}} = Span.to_map(span)
+    end
+  end
+
   describe ".set_sample_data/3, when passing invalid data" do
     setup :create_root_span
 
@@ -652,6 +682,36 @@ defmodule AppsignalSpanTest do
     @tag :skip_env_test_no_nif
     test "does not set the sample data", %{span: span} do
       assert Span.to_map(span)["sample_data"] == %{}
+    end
+  end
+
+  describe ".set_sample_data_if_nil/3, with a list" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      Span.set_sample_data_if_nil(span, "custom_data", ["abc", "def"])
+
+      :ok
+    end
+
+    @tag :skip_env_test_no_nif
+    test "sets the list as sample data", %{span: span} do
+      assert %{"sample_data" => %{"custom_data" => "[\"abc\",\"def\"]"}} = Span.to_map(span)
+    end
+  end
+
+  describe ".set_sample_data_if_nil/3, with a keyword list" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      Span.set_sample_data_if_nil(span, "custom_data", abc: "def")
+
+      :ok
+    end
+
+    @tag :skip_env_test_no_nif
+    test "sets the keyword list as sample data", %{span: span} do
+      assert %{"sample_data" => %{"custom_data" => "[[\"abc\",\"def\"]]"}} = Span.to_map(span)
     end
   end
 

--- a/test/appsignal/utils/data_encoder_test.exs
+++ b/test/appsignal/utils/data_encoder_test.exs
@@ -117,6 +117,20 @@ defmodule Appsignal.Utils.DataEncoderTest do
              Nif.data_to_json(resource)
   end
 
+  test "encode a keyword list of keyword lists" do
+    resource = DataEncoder.encode(foo: [bar: :bar], baz: [quux: :quux])
+
+    assert {:ok, ~c"[[\"foo\",[[\"bar\",\"bar\"]]],[\"baz\",[[\"quux\",\"quux\"]]]]"} ==
+             Nif.data_to_json(resource)
+  end
+
+  test "encode a map with a keyword list as a value" do
+    resource = DataEncoder.encode(%{foo: [bar: :baz]})
+
+    assert {:ok, ~c"{\"foo\":[[\"bar\",\"baz\"]]}"} ==
+             Nif.data_to_json(resource)
+  end
+
   test "encode a list with a keywords with maps as values" do
     resource = DataEncoder.encode(field: {"can't be blank", [validation: :required]})
 

--- a/test/appsignal/utils/data_encoder_test.exs
+++ b/test/appsignal/utils/data_encoder_test.exs
@@ -110,6 +110,20 @@ defmodule Appsignal.Utils.DataEncoderTest do
     assert {:ok, ~c"[\"bar\"]"} == Nif.data_to_json(resource)
   end
 
+  test "encode a list with a keywords" do
+    resource = DataEncoder.encode(foo: "some value", bar: "other value")
+
+    assert {:ok, ~c"[[\"foo\",\"some value\"],[\"bar\",\"other value\"]]"} ==
+             Nif.data_to_json(resource)
+  end
+
+  test "encode a list with a keywords with maps as values" do
+    resource = DataEncoder.encode(field: {"can't be blank", [validation: :required]})
+
+    assert {:ok, ~c"[[\"field\",[\"can't be blank\",[[\"validation\",\"required\"]]]]]"} ==
+             Nif.data_to_json(resource)
+  end
+
   test "encode a list with an integer item" do
     resource = DataEncoder.encode([9_223_372_036_854_775_807])
     assert {:ok, ~c"[9223372036854775807]"} == Nif.data_to_json(resource)


### PR DESCRIPTION
## Support encoding keyword lists

Add a test case for a previously failing scenario encoding keyword lists.

Implement encoding for this by checking if a list is a keyword list, then casting each item from a Tuple to a List, so the item is not interpreted as a thing we can set on a Map.

If it encounters a keyword list's Tuple, it assumed the parent would be a Map, and try to set it on the non-existent map. Then the Rust Extension's data encoder would silently drop the value.

## Support lists as sample data root arguments

We documented that we support lists as sample data root values, but in practice we did not.

This fix allows for setting lists as custom sample data (and other types of sample data) as shown in the changeset.

---

- [Intercom conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/admin/540709/conversation/16410700282572?view=List)
