### PR TITLE
Fix flickering assertion on map keys

### DIFF
--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -872,11 +872,12 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
     test "adds paths to report", %{fake_report: fake_report} do
       run()
 
-      assert Map.keys(received_report(fake_report)[:paths]) == [
-               :"appsignal.log",
-               :log_dir_path,
-               :working_dir
-             ]
+      assert MapSet.new(Map.keys(received_report(fake_report)[:paths])) ==
+               MapSet.new([
+                 :"appsignal.log",
+                 :log_dir_path,
+                 :working_dir
+               ])
     end
   end
 


### PR DESCRIPTION
Ran into this earlier while testing #911 locally.

The order of map keys returned by `Map.keys` is not guaranteed. This test fails sometimes when running locally (although somewhat surprisingly it's very rare)