### PR TITLE
Fix Ecto parallel preloads

### DIFF
--- a/.changesets/add-appsignal-ecto-repo-to-fix-parallel-preloads.md
+++ b/.changesets/add-appsignal-ecto-repo-to-fix-parallel-preloads.md
@@ -3,7 +3,7 @@ bump: "patch"
 type: "add"
 ---
 
-Add `Appsignal.Ecto.Repo` to fix parallel preloads.
+Add `Appsignal.Ecto.Repo` to support parallel preloads.
 
 For AppSignal to be able to instrument parallel preloads, the current instrumentation context needs to be passed from the Elixir process that spawns the preload to the short-lived processes that run each of the parallel queries.
 

--- a/.changesets/add-appsignal-ecto-repo-to-fix-parallel-preloads.md
+++ b/.changesets/add-appsignal-ecto-repo-to-fix-parallel-preloads.md
@@ -1,0 +1,19 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add `Appsignal.Ecto.Repo` to fix parallel preloads.
+
+For AppSignal to be able to instrument parallel preloads, the current instrumentation context needs to be passed from the Elixir process that spawns the preload to the short-lived processes that run each of the parallel queries.
+
+By replacing `use Ecto.Repo` with `use Appsignal.Ecto.Repo`, the appropriate telemetry context will be passed so that AppSignal can correctly instrument these queries:
+
+```elixir
+defmodule MyApp.Repo do
+  # replace `use Ecto.Repo` with `use Appsignal.Ecto.Repo`
+  use Appsignal.Ecto.Repo,
+    otp_app: :my_app,
+    adapter: Ecto.Adapters.Postgres
+end
+```

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,6 +9,7 @@ if Mix.env() in [:bench, :test, :test_no_nif] do
   config :appsignal, io: FakeIO
   config :appsignal, file: FakeFile
   config :appsignal, os_internal: FakeOS
+  config :appsignal, ecto_repo: FakeEctoRepo
 
   config :appsignal, appsignal_tracer_nif: Appsignal.Test.Nif
   config :appsignal, appsignal_tracer: Appsignal.Test.Tracer

--- a/lib/appsignal/ecto_repo.ex
+++ b/lib/appsignal/ecto_repo.ex
@@ -1,0 +1,22 @@
+defmodule Appsignal.Ecto.Repo do
+  require Appsignal.Utils
+  @ecto_repo Appsignal.Utils.compile_env(:appsignal, :ecto_repo, Ecto.Repo)
+
+  defmacro __using__(opts) do
+    quote do
+      use unquote(@ecto_repo), unquote(opts)
+
+      def default_options(atom) do
+        Appsignal.Ecto.Repo.default_options(atom)
+      end
+    end
+  end
+
+  def default_options(_atom) do
+    [
+      telemetry_options: [
+        _appsignal_current_span: Appsignal.Tracer.current_span()
+      ]
+    ]
+  end
+end

--- a/test/appsignal/ecto_repo_test.exs
+++ b/test/appsignal/ecto_repo_test.exs
@@ -1,0 +1,73 @@
+defmodule Appsignal.TestEctoRepo do
+  use Appsignal.Ecto.Repo,
+    otp_app: :plug_example,
+    adapter: Ecto.Adapters.Postgres
+end
+
+defmodule Appsignal.EctoRepoTest do
+  use ExUnit.Case
+  alias Appsignal.Ecto.Repo
+  alias Appsignal.Test
+
+  setup do
+    start_supervised!(Test.Nif)
+    start_supervised!(Test.Monitor)
+
+    :ok
+  end
+
+  test "use Appsignal.Ecto.Repo passes through options to Ecto.Repo" do
+    Appsignal.TestEctoRepo.get_received_opts() == [
+      otp_app: :plug_example,
+      adapter: Ecto.Adapters.Postgres
+    ]
+  end
+
+  describe "use Appsignal.Ecto.Repo, with a root span" do
+    setup do
+      %{span: Appsignal.Tracer.create_span("http_request")}
+    end
+
+    test "it returns the current span in telemetry options", %{span: span} do
+      assert Appsignal.TestEctoRepo.default_options(:all) == [
+               telemetry_options: [
+                 _appsignal_current_span: span
+               ]
+             ]
+    end
+  end
+
+  describe "use Appsignal.Ecto.Repo, without a root span" do
+    test "it returns nil as the current span in telemetry options" do
+      assert Appsignal.TestEctoRepo.default_options(:all) == [
+               telemetry_options: [
+                 _appsignal_current_span: nil
+               ]
+             ]
+    end
+  end
+
+  describe "default_options/1, with a root span" do
+    setup do
+      %{span: Appsignal.Tracer.create_span("http_request")}
+    end
+
+    test "it returns the current span in telemetry options", %{span: span} do
+      assert Appsignal.Ecto.Repo.default_options(:all) == [
+               telemetry_options: [
+                 _appsignal_current_span: span
+               ]
+             ]
+    end
+  end
+
+  describe "default_options/1, without a root span" do
+    test "it returns nil as the current span in telemetry options" do
+      assert Appsignal.Ecto.Repo.default_options(:all) == [
+               telemetry_options: [
+                 _appsignal_current_span: nil
+               ]
+             ]
+    end
+  end
+end

--- a/test/support/fake_ecto_repo.ex
+++ b/test/support/fake_ecto_repo.ex
@@ -1,0 +1,9 @@
+defmodule FakeEctoRepo do
+  defmacro __using__(opts) do
+    quote do
+      def get_received_opts do
+        unquote(opts)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #603. See also https://github.com/appsignal/appsignal-docs/pull/1715. Use https://github.com/appsignal/test-setups/pull/184 to test it.

Add the `Appsignal.Ecto.Repo` module to fix the Ecto parallel preload issue, making it easy to apply the workaround that was already found by [Elixir Forums][solution] users.

After this change, customers can replace `use Ecto.Repo` in their Ecto repositories with `use Appsignal.Ecto.Repo`. This will configure Ecto so that it passes through the current span at invocation time as the telemetry options for the query, fixing the issue where parallel preload queries were lost because they took place in parallel processes where there was no current span.

For customers who wish to customise their Ecto repo default options, which would override the `default_options/1` function implemented by `Appsignal.Ecto.Repo`, a workaround is provided by also exposing this function as `Appsignal.Ecto.Repo.default_options`, so customers can call it manually and merge its output with their own default options.

[solution]: https://elixirforum.com/t/help-understanding-ecto-telemetry-events-according-to-appsignal/35957/3