### PR TITLE
Add regression test for function_clause errors

### DIFF
--- a/test/appsignal/error_test.exs
+++ b/test/appsignal/error_test.exs
@@ -78,6 +78,34 @@ defmodule Appsignal.ErrorTest do
     end
   end
 
+  describe "metadata/3, with a function_clause" do
+    setup do
+      try do
+        _ = Keyword.get(:a, :b)
+      catch
+        kind, reason -> %{metadata: Appsignal.Error.metadata(kind, reason, __STACKTRACE__)}
+      end
+    end
+
+    test "extracts the error's name", %{metadata: metadata} do
+      assert {"FunctionClauseError", _message, _stack} = metadata
+    end
+
+    test "extracts the error's message", %{metadata: metadata} do
+      {_name, error_message, _stack} = metadata
+
+      assert error_message ==
+               "** (FunctionClauseError) no function clause matching in Keyword.get/3"
+    end
+
+    test "format's the error's stack trace", %{metadata: metadata} do
+      {_name, _message, stack} = metadata
+      assert is_list(stack)
+      assert length(stack) > 0
+      assert Enum.all?(stack, &is_binary(&1))
+    end
+  end
+
   describe "metadata/3, with an exit" do
     setup do
       try do


### PR DESCRIPTION
Function clause errors include the blame, which exposes the arguments in the function call. This patch adds a test to make sure those don't leak to AppSignal, and won't in the future.