### PR TITLE
Drop non-500 errors in add_error/3

### DIFF
--- a/.changesets/drop-non-500-plug-errors-in-add_error-3.md
+++ b/.changesets/drop-non-500-plug-errors-in-add_error-3.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Drop non-500 Plug errors in add_error/3

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -288,6 +288,11 @@ defmodule Appsignal.Span do
       end
 
   """
+  def add_error(span, %_{__exception__: true, plug_status: status}, _stacktrace)
+      when status < 500 do
+    span
+  end
+
   def add_error(span, %_{__exception__: true} = exception, stacktrace) do
     {name, message, formatted_stacktrace} = Appsignal.Error.metadata(exception, stacktrace)
     do_add_error(span, name, message, formatted_stacktrace)


### PR DESCRIPTION
Plug sets an attribute named plug_status on each of its raised exceptions, which appsignal-plug uses to filter non-500 errors out. This patch moves that filtering to the add_error/3 function, allowing the integration to properly filter exceptions originating in plug, even if they are not caught by the Plug integration.