### PR TITLE
Turn error backend off by default

### DIFF
--- a/.changesets/turn-error-backend-off-by-default.md
+++ b/.changesets/turn-error-backend-off-by-default.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "change"
+---
+
+Turn error backend off by default

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -195,8 +195,8 @@ defmodule Appsignal.Config do
 
   def error_backend_enabled? do
     case Application.fetch_env(:appsignal, :config) do
-      {:ok, value} -> !!Map.get(value, :enable_error_backend, true)
-      _ -> true
+      {:ok, value} -> !!Map.get(value, :enable_error_backend, false)
+      _ -> false
     end
   end
 

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -179,11 +179,11 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "when unset" do
-      assert with_config(%{}, &Config.error_backend_enabled?/0)
+      refute with_config(%{}, &Config.error_backend_enabled?/0)
     end
 
     test "without an appsignal config" do
-      assert without_config(&Config.error_backend_enabled?/0)
+      refute without_config(&Config.error_backend_enabled?/0)
     end
   end
 


### PR DESCRIPTION
The error backend is a relic of the past, which caught otherwise uncaught errors before we had proper instrumentation through library-specific instrumentation and :telemetry.

Also, the error backend produced confusing results, as the errors it reports are void of context, making them hard to understand at best.

This patch turns the error backend off by default if it's unconfigured, in preparation of removing the backend in a future version.