### PR TITLE
Heartbeats

### DIFF
--- a/.changesets/add-heartbeats.md
+++ b/.changesets/add-heartbeats.md
@@ -1,0 +1,25 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add heartbeats support. You can send heartbeats directly from your code, to track the execution of certain processes:
+
+```elixir
+def send_invoices do
+  # ... your code here ...
+  Appsignal.heartbeat("send_invoices")
+end
+```
+
+You can pass a function to `Appsignal.heartbeat`, to report to AppSignal both when the process starts, and when it finishes, allowing you to see the duration of the process:
+
+```elixir
+def send_invoices do
+  Appsignal.heartbeat("send_invoices", fn ->
+    # ... your code here ...
+  end)
+end
+```
+
+If an exception is thrown within the function, the finish event will not be reported to AppSignal, triggering a notification about the missing heartbeat. The exception will bubble outside of the heartbeat function.

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,6 +5,7 @@ if Mix.env() in [:bench, :test, :test_no_nif] do
   config :appsignal, appsignal_nif: Appsignal.FakeNif
   config :appsignal, appsignal_diagnose_report: Appsignal.Diagnose.FakeReport
   config :appsignal, appsignal: Appsignal.FakeAppsignal
+  config :appsignal, appsignal_transmitter: Appsignal.FakeTransmitter
   config :appsignal, inet: FakeInet
   config :appsignal, io: FakeIO
   config :appsignal, file: FakeFile

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -168,6 +168,9 @@ defmodule Appsignal do
   defdelegate send_error(kind, reason, stacktrace), to: Appsignal.Instrumentation
   defdelegate send_error(kind, reason, stacktrace, fun), to: Appsignal.Instrumentation
 
+  defdelegate heartbeat(name), to: Appsignal.Heartbeat
+  defdelegate heartbeat(name, fun), to: Appsignal.Heartbeat
+
   defp log_nif_loading_error do
     arch = parse_architecture(to_string(:erlang.system_info(:system_architecture)))
     {_, target_list} = @os.type()

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -86,6 +86,10 @@ defmodule Appsignal.Config do
     end
   end
 
+  def config do
+    Application.get_env(:appsignal, :config, [])
+  end
+
   defp merge_filter_parameters(map, keys) when is_list(keys) do
     {_, new_map} = Map.get_and_update(map, :filter_parameters, &{&1, &1 ++ keys})
 
@@ -607,17 +611,5 @@ defmodule Appsignal.Config do
       _ -> false
     end)
     |> Enum.into(%{})
-  end
-
-  # When you use Appsignal.Config you get a handy config macro which
-  # can be used to read the application config.
-  defmacro __using__(_) do
-    quote do
-      defmacro config do
-        quote do
-          Application.get_env(:appsignal, :config, [])
-        end
-      end
-    end
   end
 end

--- a/lib/appsignal/diagnose/report.ex
+++ b/lib/appsignal/diagnose/report.ex
@@ -10,19 +10,7 @@ defmodule Appsignal.Diagnose.Report do
 
   @spec send(map(), map()) :: {:ok, String.t()} | {:error, map()}
   def send(config, report) do
-    params =
-      URI.encode_query(%{
-        api_key: config[:push_api_key],
-        name: config[:name],
-        environment: config[:environment],
-        hostname: config[:hostname]
-      })
-
-    url = "#{config[:diagnose_endpoint]}?#{params}"
-    body = Jason.encode!(%{diagnose: report})
-    headers = [{"Content-Type", "application/json; charset=UTF-8"}]
-
-    case Transmitter.request(:post, url, headers, body) do
+    case Transmitter.transmit(config[:diagnose_endpoint], %{diagnose: report}, config) do
       {:ok, 200, _, reference} ->
         {:ok, body} = :hackney.body(reference)
 

--- a/lib/appsignal/heartbeat.ex
+++ b/lib/appsignal/heartbeat.ex
@@ -1,0 +1,95 @@
+defmodule Appsignal.Heartbeat do
+  alias __MODULE__
+  alias Appsignal.Heartbeat.Event
+  require Appsignal.Utils
+
+  @transmitter Appsignal.Utils.compile_env(
+                 :appsignal,
+                 :appsignal_transmitter,
+                 Appsignal.Transmitter
+               )
+  @type t :: %Heartbeat{name: String.t(), id: String.t()}
+
+  defstruct [:name, :id]
+
+  @spec new(String.t()) :: t
+  def new(name) do
+    %Appsignal.Heartbeat{
+      name: name,
+      id: random_id()
+    }
+  end
+
+  defp random_id do
+    Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
+  end
+
+  @spec start(Heartbeat.t()) :: :ok
+  def start(heartbeat) do
+    transmit(Event.new(heartbeat, :start))
+  end
+
+  @spec finish(Heartbeat.t()) :: :ok
+  def finish(heartbeat) do
+    transmit(Event.new(heartbeat, :finish))
+  end
+
+  @spec heartbeat(String.t()) :: :ok
+  def heartbeat(name) do
+    finish(Heartbeat.new(name))
+  end
+
+  @spec heartbeat(String.t(), (-> out)) :: out when out: var
+  def heartbeat(name, fun) do
+    heartbeat = Heartbeat.new(name)
+
+    start(heartbeat)
+    output = fun.()
+    finish(heartbeat)
+
+    output
+  end
+
+  @spec transmit(Event.t()) :: :ok
+  defp transmit(event) do
+    config = Appsignal.Config.config()
+    endpoint = "#{config[:logging_endpoint]}/heartbeats/json"
+
+    case @transmitter.transmit(endpoint, event, config) do
+      {:ok, 200, _, _} ->
+        nil
+
+      {:ok, status_code, _, _} ->
+        Appsignal.IntegrationLogger.warn(
+          "Failed to transmit heartbeat: status code was #{status_code}"
+        )
+
+      {:error, reason} ->
+        Appsignal.IntegrationLogger.warn("Failed to transmit heartbeat: #{reason}")
+    end
+
+    :ok
+  end
+end
+
+defmodule Appsignal.Heartbeat.Event do
+  alias __MODULE__
+  alias Appsignal.Heartbeat
+
+  @derive Jason.Encoder
+
+  @type kind :: :start | :finish
+  @type t :: %Event{name: String.t(), id: String.t(), kind: kind, timestamp: integer}
+
+  defstruct [:name, :id, :kind, :timestamp]
+
+  @spec new(Heartbeat.t(), kind) :: t
+  def new(%Heartbeat{name: name, id: id}, kind) do
+    %Event{
+      name: name,
+      id: id,
+      kind: kind,
+      timestamp: System.system_time(:second)
+    }
+  end
+end

--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -10,6 +10,30 @@ defmodule Appsignal.Transmitter do
     http_client.request(method, url, headers, body, options())
   end
 
+  def transmit(url, payload \\ nil, config \\ nil) do
+    config = config || Appsignal.Config.config()
+
+    params =
+      URI.encode_query(%{
+        api_key: config[:push_api_key],
+        name: config[:name],
+        environment: config[:env],
+        hostname: config[:hostname]
+      })
+
+    url = "#{url}?#{params}"
+    headers = [{"Content-Type", "application/json; charset=UTF-8"}]
+
+    body =
+      if payload do
+        Jason.encode!(payload)
+      else
+        ""
+      end
+
+    request(:post, url, headers, body)
+  end
+
   defp options do
     ca_file_path = Appsignal.Config.ca_file_path()
 

--- a/lib/appsignal/utils/push_api_key_validator.ex
+++ b/lib/appsignal/utils/push_api_key_validator.ex
@@ -3,17 +3,9 @@ defmodule Appsignal.Utils.PushApiKeyValidator do
   alias Appsignal.Transmitter
 
   def validate(config) do
-    params =
-      URI.encode_query(%{
-        "api_key" => config[:push_api_key],
-        "name" => config[:name],
-        "environment" => config[:env],
-        "hostname" => config[:hostname]
-      })
+    url = "#{config[:endpoint]}/1/auth"
 
-    url = "#{config[:endpoint]}/1/auth?#{params}"
-
-    case Transmitter.request(:post, url) do
+    case Transmitter.transmit(url, nil, config) do
       {:ok, 200, _, _} -> :ok
       {:ok, 401, _, _} -> {:error, :invalid}
       {:ok, status_code, _, _} -> {:error, status_code}

--- a/test/appsignal/diagnose/report_test.exs
+++ b/test/appsignal/diagnose/report_test.exs
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose.ReportTest do
     setup_with_config(%{
       api_key: "foo",
       name: "AppSignal test suite app",
-      environment: "prod",
+      env: "prod",
       diagnose_endpoint: "http://localhost:#{diagnose_bypass.port}/diag"
     })
 

--- a/test/appsignal/heartbeat_test.exs
+++ b/test/appsignal/heartbeat_test.exs
@@ -1,0 +1,56 @@
+defmodule Appsignal.HeartbeatTest do
+  use ExUnit.Case
+  alias Appsignal.FakeTransmitter
+  alias Appsignal.Heartbeat
+  alias Appsignal.Heartbeat.Event
+
+  setup do
+    start_supervised!(FakeTransmitter)
+    :ok
+  end
+
+  describe "start/1" do
+    test "transmits a start event for the heartbeat" do
+      heartbeat = Heartbeat.new("heartbeat-name")
+      Heartbeat.start(heartbeat)
+
+      assert [
+               %Event{name: "heartbeat-name", kind: :start}
+             ] = FakeTransmitter.transmitted_payloads()
+    end
+  end
+
+  describe "finish/1" do
+    test "transmits a finish event for the heartbeat" do
+      heartbeat = Heartbeat.new("heartbeat-name")
+      Heartbeat.finish(heartbeat)
+
+      assert [
+               %Event{name: "heartbeat-name", kind: :finish}
+             ] = FakeTransmitter.transmitted_payloads()
+    end
+  end
+
+  describe "heartbeat/2" do
+    test "transmits a start and finish event for the heartbeat" do
+      output = Heartbeat.heartbeat("heartbeat-name", fn -> "output" end)
+
+      assert [
+               %Event{name: "heartbeat-name", kind: :start},
+               %Event{name: "heartbeat-name", kind: :finish}
+             ] = FakeTransmitter.transmitted_payloads()
+
+      assert "output" == output
+    end
+  end
+
+  describe "heartbeat/1" do
+    test "transmits a finish event for the heartbeat" do
+      Heartbeat.heartbeat("heartbeat-name")
+
+      assert [
+               %Event{name: "heartbeat-name", kind: :finish}
+             ] = FakeTransmitter.transmitted_payloads()
+    end
+  end
+end

--- a/test/appsignal/release_upgrade_test.exs
+++ b/test/appsignal/release_upgrade_test.exs
@@ -1,6 +1,6 @@
 defmodule Appsignal.ReleaseUpgradeTest do
   use ExUnit.Case, async: true
-  use Appsignal.Config
+  import Appsignal.Config, only: [config: 0]
   alias Appsignal.Nif
   import AppsignalTest.Utils
 

--- a/test/support/appsignal/fake_transmitter.ex
+++ b/test/support/appsignal/fake_transmitter.ex
@@ -1,0 +1,41 @@
+defmodule Appsignal.FakeTransmitter do
+  use Agent
+
+  def start_link do
+    Agent.start_link(
+      fn ->
+        %{
+          transmitted: [],
+          response: {:ok, 200, :fake, :fake}
+        }
+      end,
+      name: __MODULE__
+    )
+  end
+
+  def child_spec(_opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 500
+    }
+  end
+
+  def transmit(url, payload, config) do
+    Agent.update(__MODULE__, fn state ->
+      Map.update!(state, :transmitted, &[{url, payload, config} | &1])
+    end)
+
+    Agent.get(__MODULE__, & &1[:response])
+  end
+
+  def transmitted do
+    Agent.get(__MODULE__, &Enum.reverse(&1[:transmitted]))
+  end
+
+  def transmitted_payloads do
+    Enum.map(transmitted(), fn {_url, payload, _config} -> payload end)
+  end
+end


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-ruby/issues/1054.

See also test setup: https://github.com/appsignal/test-setups/pull/192

### [Remove `use Appsignal.Config` macro](https://github.com/appsignal/appsignal-elixir/commit/31d6dde23ea1cfd714a516dc72c54c914af8d3d7)

I see no reason why this needs to be a macro. This could just be a
method. So it is a method now.

### [Implement `Transmitter.transmit` method](https://github.com/appsignal/appsignal-elixir/commit/8efa44333129750e4b03dd8212962cd46da1e712)

Implement a `transmit` method, similar to that in the Ruby
integration, that sends a POST request with the API key, environment,
application name and hostname as query parameters.

Use it where requests with these parameters are sent, that is, for
the push API key validation request, and for the diagnose report
request.

Fix a bug where `config[:environment]` (a non-existent configuration
key) was accessed instead of `config[:env]`.

### [Implement heartbeats](https://github.com/appsignal/appsignal-elixir/commit/854b9c9c50d505f107e873996be40bdf38f73ba7)

Implement the heartbeat functionality using the transmitter. The
implementation is functionally identical to the one for the Ruby
integration: https://github.com/appsignal/appsignal-ruby/pull/1057