### PR TITLE
Add `ignore_logs` configuration option

### DIFF
--- a/.changesets/implement-ignore-logs.md
+++ b/.changesets/implement-ignore-logs.md
@@ -1,0 +1,14 @@
+---
+bump: "patch"
+integrations: "all"
+type: "add"
+---
+
+Implement the `ignore_logs` configuration option, which can also be configured as the `APPSIGNAL_IGNORE_LOGS` environment variable.
+
+The value of `ignore_logs` is a list (comma-separated, when using the environment variable) of log line messages that should be ignored. For example, the value `"start"` will cause any message containing the word "start" to be ignored. Any log line message containing a value in `ignore_logs` will not be reported to AppSignal.
+
+The values can use a small subset of regular expression syntax (specifically, `^`, `$` and `.*`) to narrow or expand the scope of lines that should be matched.
+
+For example, the value `"^start$"` can be used to ignore any message that is _exactly_ the word "start", but not messages that merely contain it, like "Process failed to start". The value `"Task .* succeeded"` can be used to ignore messages about task success regardless of the specific task name.
+

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "0.34.1"
+  def version, do: "0.35.2"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "351f3dae916d3e84177d8cc35eaeaca5345f4deca9e0925a29353915cc0530d2",
+        checksum: "4a01803fae744971e2da08a325acb88a5f79bf44cbde03456652affb91fa0817",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "351f3dae916d3e84177d8cc35eaeaca5345f4deca9e0925a29353915cc0530d2",
+        checksum: "4a01803fae744971e2da08a325acb88a5f79bf44cbde03456652affb91fa0817",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
+        checksum: "c80fa534a0f34d0056102ed5ec21cb558b714b17dc2a91f62fabdb992acc8a54",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
+        checksum: "c80fa534a0f34d0056102ed5ec21cb558b714b17dc2a91f62fabdb992acc8a54",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
+        checksum: "c80fa534a0f34d0056102ed5ec21cb558b714b17dc2a91f62fabdb992acc8a54",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "dfbab18b7faa24684bf0ab57666b6b493356a3da43ecdba2e992b2d6d513cf31",
+        checksum: "71236975f40316d67c2b0e797814d52a49df8c5941375c0aed81c6870d82f299",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "ce4a819f3eaa4590795497915e4a20b3fe281a0821364b80d26ffd1391af67a8",
+        checksum: "00ab0d029ede31225b2d134cdfab1e2c75e15e96229ef9e89ac14f51b8329988",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "ce4a819f3eaa4590795497915e4a20b3fe281a0821364b80d26ffd1391af67a8",
+        checksum: "00ab0d029ede31225b2d134cdfab1e2c75e15e96229ef9e89ac14f51b8329988",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "e55f9ecb4e4b51e9232918216487712b63a7cfea9710763f61077e8d40d53dbe",
+        checksum: "2e96245f692f47ee8fd12cca92b620baf79845ec920fb19b38612dd1cb051961",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "8963ebc98405648205a6d8aa371bafa49cb33cd104e0c3e6cc1856ba41fe3d8c",
+        checksum: "a99ebcdf993cd740dc556de9fba6e7ce1c802704c290c4d8b842cb4dc971473a",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "34bb72678b896a2a8289a97611a61a297b5a0e6110f5085a683ad93857cdf26c",
+        checksum: "874542de2899dc7ef6d286f1cb719614877651c6cafc9f5ae73d37d1aa0e61da",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "68e882ba3bc87328953d9bfbb676b00d4199756a7090d5cdc265a4b32d857cc5",
+        checksum: "f30c529ed4fffe4f0668bcb59881061b22050813d9d10acf5a4bf03f4547a51b",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "68e882ba3bc87328953d9bfbb676b00d4199756a7090d5cdc265a4b32d857cc5",
+        checksum: "f30c529ed4fffe4f0668bcb59881061b22050813d9d10acf5a4bf03f4547a51b",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -21,6 +21,7 @@ defmodule Appsignal.Config do
     filter_session_data: [],
     ignore_actions: [],
     ignore_errors: [],
+    ignore_logs: [],
     ignore_namespaces: [],
     instrument_absinthe: true,
     instrument_ecto: true,
@@ -321,6 +322,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_HTTP_PROXY" => :http_proxy,
     "APPSIGNAL_IGNORE_ACTIONS" => :ignore_actions,
     "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
+    "APPSIGNAL_IGNORE_LOGS" => :ignore_logs,
     "APPSIGNAL_IGNORE_NAMESPACES" => :ignore_namespaces,
     "APPSIGNAL_INSTRUMENT_ECTO" => :instrument_ecto,
     "APPSIGNAL_INSTRUMENT_FINCH" => :instrument_finch,
@@ -366,7 +368,7 @@ defmodule Appsignal.Config do
   @atom_keys ~w(APPSIGNAL_APP_ENV APPSIGNAL_OTP_APP)
   @string_list_keys ~w(
     APPSIGNAL_FILTER_PARAMETERS APPSIGNAL_ECTO_REPOS
-    APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS
+    APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS APPSIGNAL_IGNORE_LOGS
     APPSIGNAL_IGNORE_NAMESPACES APPSIGNAL_DNS_SERVERS
     APPSIGNAL_FILTER_SESSION_DATA APPSIGNAL_REQUEST_HEADERS
   )
@@ -460,6 +462,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_HTTP_PROXY", to_string(config[:http_proxy]))
     Nif.env_put("_APPSIGNAL_IGNORE_ACTIONS", config[:ignore_actions] |> Enum.join(","))
     Nif.env_put("_APPSIGNAL_IGNORE_ERRORS", config[:ignore_errors] |> Enum.join(","))
+    Nif.env_put("_APPSIGNAL_IGNORE_LOGS", config[:ignore_logs] |> Enum.join(","))
     Nif.env_put("_APPSIGNAL_IGNORE_NAMESPACES", config[:ignore_namespaces] |> Enum.join(","))
 
     Nif.env_put(

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -581,6 +581,12 @@ defmodule Appsignal.ConfigTest do
       assert %{ignore_errors: ^errors} = with_config(%{ignore_errors: errors}, &init_config/0)
     end
 
+    test "ignore_logs" do
+      logs = ["^start$", "^Completed 2.* in .*ms$"]
+
+      assert %{ignore_logs: ^logs} = with_config(%{ignore_logs: logs}, &init_config/0)
+    end
+
     test "ignore_namespaces" do
       namespaces = ~w(admin private_namespace)
 
@@ -884,6 +890,15 @@ defmodule Appsignal.ConfigTest do
              ) ==
                default_configuration()
                |> Map.put(:ignore_errors, ~w(VerySpecificError AnotherError))
+    end
+
+    test "ignore_logs" do
+      assert with_env(
+               %{"APPSIGNAL_IGNORE_LOGS" => "^start$,^Completed 2.* in .*ms$"},
+               &init_config/0
+             ) ==
+               default_configuration()
+               |> Map.put(:ignore_logs, ["^start$", "^Completed 2.* in .*ms$"])
     end
 
     test "ignore_namespaces" do
@@ -1219,6 +1234,7 @@ defmodule Appsignal.ConfigTest do
       assert Nif.env_get("_APPSIGNAL_HTTP_PROXY") == ~c""
       assert Nif.env_get("_APPSIGNAL_IGNORE_ACTIONS") == ~c""
       assert Nif.env_get("_APPSIGNAL_IGNORE_ERRORS") == ~c""
+      assert Nif.env_get("_APPSIGNAL_IGNORE_LOGS") == ~c""
       assert Nif.env_get("_APPSIGNAL_IGNORE_NAMESPACES") == ~c""
       assert Nif.env_get("_APPSIGNAL_LOG_FILE_PATH") == ~c"/tmp/appsignal.log"
       assert Nif.env_get("_APPSIGNAL_WORKING_DIR_PATH") == ~c""
@@ -1265,6 +1281,7 @@ defmodule Appsignal.ConfigTest do
             ExampleApplication.PageController#also_ignored
           ),
           ignore_errors: ~w(VerySpecificError AnotherError),
+          ignore_logs: ["^start$", "^Completed 2.* in .*ms$"],
           ignore_namespaces: ~w(admin private_namespace),
           log: "stdout",
           log_level: "trace",
@@ -1302,6 +1319,7 @@ defmodule Appsignal.ConfigTest do
                    ~c"ExampleApplication.PageController#ignored,ExampleApplication.PageController#also_ignored"
 
           assert Nif.env_get("_APPSIGNAL_IGNORE_ERRORS") == ~c"VerySpecificError,AnotherError"
+          assert Nif.env_get("_APPSIGNAL_IGNORE_LOGS") == ~c"^start$,^Completed 2.* in .*ms$"
           assert Nif.env_get("_APPSIGNAL_IGNORE_NAMESPACES") == ~c"admin,private_namespace"
 
           assert Nif.env_get("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION") ==
@@ -1449,6 +1467,7 @@ defmodule Appsignal.ConfigTest do
       filter_session_data: [],
       ignore_actions: [],
       ignore_errors: [],
+      ignore_logs: [],
       ignore_namespaces: [],
       log: "file",
       logging_endpoint: "https://appsignal-endpoint.net",


### PR DESCRIPTION
Read the `ignore_logs` config option from `config.exs`, or the `APPSIGNAL_IGNORE_LOGS` environment variable, and re-export it for the AppSignal agent as the `_APPSIGNAL_IGNORE_LOGS` environment variable.

[skip changeset] because the corresponding changeset will be added (modified slightly) from the [agent PR][agent]

[agent]: appsignal/appsignal-agent#1127