### PR TITLE
Fix Phoenix filter_parameters partial keys support

### DIFF
--- a/.changesets/fix-phoenix-filter_parameters-partial-key-matches-support.md
+++ b/.changesets/fix-phoenix-filter_parameters-partial-key-matches-support.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the Phoenix `filter_parameters` config option support for partial key matches. When configuring `config :phoenix, filter_parameters` with `["key"]` or `{:discard, ["key"]}`, it now also matches partial keys like `"my_key"`, just like Phoenix's logger does.

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -63,10 +63,6 @@ defmodule Appsignal.Config do
     sources = Map.put(sources, :override, determine_overrides(config))
     config = Map.merge(config, sources[:override])
 
-    config =
-      config
-      |> merge_filter_parameters(Application.get_env(:phoenix, :filter_parameters, []))
-
     if !empty?(config[:working_dir_path]) do
       warning(fn ->
         "'working_dir_path' is deprecated, please use " <>
@@ -89,16 +85,6 @@ defmodule Appsignal.Config do
 
   def config do
     Application.get_env(:appsignal, :config, [])
-  end
-
-  defp merge_filter_parameters(map, keys) when is_list(keys) do
-    {_, new_map} = Map.get_and_update(map, :filter_parameters, &{&1, &1 ++ keys})
-
-    new_map
-  end
-
-  defp merge_filter_parameters(map, _keys) do
-    map
   end
 
   defp determine_overrides(config) do

--- a/lib/appsignal/utils/map_filter.ex
+++ b/lib/appsignal/utils/map_filter.ex
@@ -2,16 +2,49 @@ defmodule Appsignal.Utils.MapFilter do
   @moduledoc false
   require Logger
 
-  def filter(data) do
-    filter(data, Application.get_env(:phoenix, :filter_parameters, []))
+  # Phoenix parameter filtering copied from to ensure we support the same filtering options:
+  # https://github.com/phoenixframework/phoenix/blob/dfb0c00d2077e10f8df6cc6e334e04924c4c2bcd/lib/phoenix/logger.ex#L157-L199
+
+  def filter(values, params \\ Application.get_env(:phoenix, :filter_parameters, []))
+  def filter(values, {:discard, params}), do: discard_values(values, params)
+  def filter(values, {:keep, params}), do: keep_values(values, params)
+  def filter(values, params), do: discard_values(values, params)
+
+  defp discard_values(%{__struct__: mod} = struct, _params) when is_atom(mod) do
+    struct
   end
 
-  defp filter(data, {:keep, keys}) do
-    Enum.into(data, %{}, fn {key, value} ->
-      new_value = if key in keys, do: value, else: "[FILTERED]"
-      {key, new_value}
+  defp discard_values(%{} = map, params) do
+    Enum.into(map, %{}, fn {k, v} ->
+      if is_binary(k) and String.contains?(k, params) do
+        {k, "[FILTERED]"}
+      else
+        {k, discard_values(v, params)}
+      end
     end)
   end
 
-  defp filter(data, _), do: data
+  defp discard_values([_ | _] = list, params) do
+    Enum.map(list, &discard_values(&1, params))
+  end
+
+  defp discard_values(other, _params), do: other
+
+  defp keep_values(%{__struct__: mod}, _params) when is_atom(mod), do: "[FILTERED]"
+
+  defp keep_values(%{} = map, params) do
+    Enum.into(map, %{}, fn {k, v} ->
+      if is_binary(k) and k in params do
+        {k, discard_values(v, [])}
+      else
+        {k, keep_values(v, params)}
+      end
+    end)
+  end
+
+  defp keep_values([_ | _] = list, params) do
+    Enum.map(list, &keep_values(&1, params))
+  end
+
+  defp keep_values(_other, _params), do: "[FILTERED]"
 end

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -518,31 +518,6 @@ defmodule Appsignal.ConfigTest do
                with_config(%{filter_session_data: ~w(accept connection)}, &init_config/0)
     end
 
-    test "filter_parameters loaded from Phoenix' filter_parameters configuration option" do
-      Application.put_env(:phoenix, :filter_parameters, ~w(token))
-
-      assert %{filter_parameters: ~w(token)} = init_config()
-
-      Application.delete_env(:phoenix, :filter_parameters)
-    end
-
-    test "ignores Phoenix' filter_parameters :keep-lists" do
-      Application.put_env(:phoenix, :filter_parameters, {:keep, [:token]})
-
-      assert %{filter_parameters: []} = init_config()
-
-      Application.delete_env(:phoenix, :filter_parameters)
-    end
-
-    test "filter_parameters merges appsignal and phoenix ignored keys" do
-      Application.put_env(:phoenix, :filter_parameters, ~w(token))
-
-      assert %{filter_parameters: ~w(password secret token)} =
-               with_config(%{filter_parameters: ~w(password secret)}, &init_config/0)
-
-      Application.delete_env(:phoenix, :filter_parameters)
-    end
-
     test "frontend_error_catching_path" do
       assert %{frontend_error_catching_path: "/appsignal_error_catcher"} =
                with_config(

--- a/test/appsignal/utils/map_filter_test.exs
+++ b/test/appsignal/utils/map_filter_test.exs
@@ -28,6 +28,13 @@ defmodule Appsignal.Utils.MapFilterTest do
                %{"foo" => "bar", "password" => "[FILTERED]"}
     end
 
+    test "with :discard option" do
+      values = %{"foo" => "bar", "password" => "should_not_show"}
+
+      assert MapFilter.filter(values, {:discard, ["password"]}) ==
+               %{"foo" => "bar", "password" => "[FILTERED]"}
+    end
+
     test "discards keys with partial key match" do
       values = %{"password" => "should_not_show", "my_password" => "should_not_show"}
 

--- a/test/appsignal/utils/map_filter_test.exs
+++ b/test/appsignal/utils/map_filter_test.exs
@@ -8,19 +8,97 @@ defmodule Appsignal.Utils.MapFilterTest do
     end
   end
 
-  describe "filter/1, with a blocklist" do
-    test "returns the map as-is, and leaves filtering to the agent" do
-      Application.put_env(:phoenix, :filter_parameters, ~w(name))
-      assert %{id: 4, name: "David"} = MapFilter.filter(%{id: 4, name: "David"})
+  describe "filter/1" do
+    test "reads filter config from Phoenix config by default" do
+      Application.put_env(:phoenix, :filter_parameters, ["password"])
+      values = %{"foo" => "bar", "password" => "should_not_show"}
+
+      assert MapFilter.filter(values) ==
+               %{"foo" => "bar", "password" => "[FILTERED]"}
+
       Application.delete_env(:phoenix, :filter_parameters)
     end
   end
 
-  describe "filter/1, with a keeplist" do
-    test "returns the map as-is, and leaves filtering to the agent" do
-      Application.put_env(:phoenix, :filter_parameters, {:keep, [:name]})
-      assert %{id: "[FILTERED]", name: "David"} = MapFilter.filter(%{id: 4, name: "David"})
-      Application.delete_env(:phoenix, :filter_parameters)
+  describe "filter/2 with discard strategy" do
+    test "in top level map" do
+      values = %{"foo" => "bar", "password" => "should_not_show"}
+
+      assert MapFilter.filter(values, ["password"]) ==
+               %{"foo" => "bar", "password" => "[FILTERED]"}
+    end
+
+    test "discards keys with partial key match" do
+      values = %{"password" => "should_not_show", "my_password" => "should_not_show"}
+
+      assert MapFilter.filter(values, ["password"]) ==
+               %{"password" => "[FILTERED]", "my_password" => "[FILTERED]"}
+    end
+
+    test "when a map has secret key" do
+      values = %{"foo" => "bar", "map" => %{"password" => "should_not_show"}}
+
+      assert MapFilter.filter(values, ["password"]) ==
+               %{"foo" => "bar", "map" => %{"password" => "[FILTERED]"}}
+    end
+
+    test "when a list has a map with secret" do
+      values = %{"foo" => "bar", "list" => [%{"password" => "should_not_show"}]}
+
+      assert MapFilter.filter(values, ["password"]) ==
+               %{"foo" => "bar", "list" => [%{"password" => "[FILTERED]"}]}
+    end
+
+    test "does not filter structs" do
+      values = %{"foo" => "bar", "file" => %Plug.Upload{}}
+
+      assert MapFilter.filter(values, ["password"]) ==
+               %{"foo" => "bar", "file" => %Plug.Upload{}}
+
+      values = %{"foo" => "bar", "file" => %{__struct__: "s"}}
+
+      assert MapFilter.filter(values, ["password"]) ==
+               %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
+    end
+
+    test "does not fail on atomic keys" do
+      values = %{:foo => "bar", "password" => "should_not_show"}
+
+      assert MapFilter.filter(values, ["password"]) ==
+               %{:foo => "bar", "password" => "[FILTERED]"}
+    end
+  end
+
+  describe "filter/2 with keep strategy" do
+    test "discards values not specified in params" do
+      values = %{"foo" => "bar", "password" => "abc123", "file" => %Plug.Upload{}}
+
+      assert MapFilter.filter(values, {:keep, []}) ==
+               %{"foo" => "[FILTERED]", "password" => "[FILTERED]", "file" => "[FILTERED]"}
+    end
+
+    test "keeps values that are specified in params" do
+      values = %{"foo" => "bar", "password" => "abc123", "file" => %Plug.Upload{}}
+
+      assert MapFilter.filter(values, {:keep, ["foo", "file"]}) ==
+               %{"foo" => "bar", "password" => "[FILTERED]", "file" => %Plug.Upload{}}
+    end
+
+    test "keeps all values under keys that are kept" do
+      values = %{"foo" => %{"bar" => 1, "baz" => 2}}
+
+      assert MapFilter.filter(values, {:keep, ["foo"]}) ==
+               %{"foo" => %{"bar" => 1, "baz" => 2}}
+    end
+
+    test "only filters leaf values" do
+      values = %{"foo" => %{"bar" => 1, "baz" => 2}, "ids" => [1, 2]}
+
+      assert MapFilter.filter(values, {:keep, []}) ==
+               %{
+                 "foo" => %{"bar" => "[FILTERED]", "baz" => "[FILTERED]"},
+                 "ids" => ["[FILTERED]", "[FILTERED]"]
+               }
     end
   end
 end


### PR DESCRIPTION
The Phoenix Logger filters out partial keys matches. Our implementation for Phoenix's filter_parameters did not follow this implementation. This change adds support for filtering out partial key matches when using the discard filtering strategy.

Phoenix implementation:
https://github.com/phoenixframework/phoenix/blob/dfb0c00d2077e10f8df6cc6e334e04924c4c2bcd/lib/phoenix/logger.ex#L157-L199

Fixes #936