### PR TITLE
Log probe status and errors to the integration log

### DIFF
--- a/.changesets/add-logs-to-probes.md
+++ b/.changesets/add-logs-to-probes.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Add debug and error logs to probes to better track what it's doing. This is helpful when debugging issues with the minutely probes system.

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,6 +5,7 @@ if Mix.env() in [:bench, :test, :test_no_nif] do
   config :appsignal, appsignal_nif: Appsignal.FakeNif
   config :appsignal, appsignal_diagnose_report: Appsignal.Diagnose.FakeReport
   config :appsignal, appsignal: Appsignal.FakeAppsignal
+  config :appsignal, appsignal_integration_logger: Appsignal.FakeIntegrationLogger
   config :appsignal, appsignal_transmitter: Appsignal.FakeTransmitter
   config :appsignal, inet: FakeInet
   config :appsignal, io: FakeIO

--- a/test/appsignal/probes/probes_test.exs
+++ b/test/appsignal/probes/probes_test.exs
@@ -86,12 +86,15 @@ defmodule Appsignal.Probes.ProbesTest do
 
   describe "with a failing probe" do
     setup %{fun: fun} do
-      :ok = Probes.register(:test_probe, fn -> raise "Probe exception!" end, 0)
+      :ok = Probes.register(:broken_probe, fn -> raise "Probe exception!" end, 0)
+      :ok = Probes.register(:not_broken_probe, fun, 1)
       [fun: fun]
     end
 
     test "calls the probe without crashing the probes" do
       run_probes()
+
+      until(fn -> assert Probes.states()[:not_broken_probe] > 1 end)
     end
   end
 end

--- a/test/appsignal/probes/probes_test.exs
+++ b/test/appsignal/probes/probes_test.exs
@@ -36,12 +36,12 @@ defmodule Appsignal.Probes.ProbesTest do
 
   describe "with a non-function probe" do
     setup do
-      {:error, "Probe is not a function"} = Probes.register(:test_probe, :error)
+      {:error, "Probe is not a function"} = Probes.register(:non_func_probe, :error)
       :ok
     end
 
     test "does not register a probe" do
-      refute Map.has_key?(Probes.probes(), :test_probe)
+      refute Map.has_key?(Probes.probes(), :non_func_probe)
     end
   end
 

--- a/test/support/appsignal/fake_integration_logger.ex
+++ b/test/support/appsignal/fake_integration_logger.ex
@@ -1,0 +1,53 @@
+defmodule Appsignal.FakeIntegrationLogger do
+  use TestAgent, %{
+    logs: []
+  }
+
+  def trace(message) do
+    add(:logs, [:trace, message])
+  end
+
+  def debug(message) do
+    add(:logs, [:debug, message])
+  end
+
+  def info(message) do
+    add(:logs, [:info, message])
+  end
+
+  def warn(message) do
+    add(:logs, [:warn, message])
+  end
+
+  def error(message) do
+    add(:logs, [:error, message])
+  end
+
+  def logged?(pid_or_module, type, message) do
+    Enum.any?(get(pid_or_module, :logs), fn element ->
+      match?([^type, ^message], element)
+    end)
+  end
+
+  def get_logs(pid_or_module, type) do
+    Enum.filter(get(pid_or_module, :logs), fn element ->
+      match?([^type, _], element)
+    end)
+  end
+
+  def clear do
+    if alive?() do
+      Agent.update(__MODULE__, fn state ->
+        Map.update!(state, :logs, fn _ -> [] end)
+      end)
+    end
+  end
+
+  defp add(key, event) do
+    if alive?() do
+      Agent.update(__MODULE__, fn state ->
+        Map.update!(state, key, fn current -> [event | current] end)
+      end)
+    end
+  end
+end

--- a/test/support/appsignal/fake_integration_logger.ex
+++ b/test/support/appsignal/fake_integration_logger.ex
@@ -36,18 +36,14 @@ defmodule Appsignal.FakeIntegrationLogger do
   end
 
   def clear do
-    if alive?() do
-      Agent.update(__MODULE__, fn state ->
-        Map.update!(state, :logs, fn _ -> [] end)
-      end)
-    end
+    Agent.cast(__MODULE__, fn state ->
+      Map.update!(state, :logs, fn _ -> [] end)
+    end)
   end
 
   defp add(key, event) do
-    if alive?() do
-      Agent.update(__MODULE__, fn state ->
-        Map.update!(state, key, fn current -> [event | current] end)
-      end)
-    end
+    Agent.cast(__MODULE__, fn state ->
+      Map.update!(state, key, fn current -> [event | current] end)
+    end)
   end
 end


### PR DESCRIPTION
## Assert if failing probe has run or not

This test I can't really tell how it asserts that the probe was not run or that it not crashes the process, as it errors silently.

Add another probe that is run successfully and check if it has run more than once. That means the other probe must have also run and raised an error.

## Make test more stable by using a new probe name

Don't use the same probe name as all the other ones. I ran into a random test failure where it was registered, but I don't think it was the one from this test. It might have been another test case.

## Log probe status and errors to the integration log

Get more insights into the operation of the minutely probes by logging what it's doing (which probes it's running) and if it encounters an error.

These logs follow the same format as the Ruby gem.

Resolves #754 because it now logs when it times out a probe.

## Use cast to communicate with test Agent

For some reason `update` caused the following error sometimes randomly for tests, and changing to `cast` does not result in this random failure behavior.

```
** (exit) exited in: GenServer.call(Appsignal.FakeIntegrationLogger, {:update, #Function<1.87578423/1 in Appsignal.FakeIntegrationLogger.clear/0>}, 5000)
  ** (EXIT) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Map.update!/3
```
