### PR TITLE
Add set_name_if_nil helper

### DIFF
--- a/.changesets/add-span-set_name_if_nil-helper.md
+++ b/.changesets/add-span-set_name_if_nil-helper.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add `Appsignal.Span.set_name_if_nil` helper. This helper can be used to not overwrite previously set span names, and only set the span name if it wasn't set previously. This will used most commonly in AppSignal created integrations with other libraries to allow apps to set custom span names.

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -1,7 +1,7 @@
 defmodule Appsignal.Span do
   alias Appsignal.{Config, Nif, Span}
 
-  defstruct [:reference, :pid]
+  defstruct [:reference, :pid, :name]
 
   require Appsignal.Utils
 
@@ -103,10 +103,31 @@ defmodule Appsignal.Span do
   def set_name(%Span{reference: reference} = span, name)
       when is_reference(reference) and is_binary(name) do
     :ok = @nif.set_span_name(reference, name)
-    span
+    %{span | name: name}
   end
 
   def set_name(span, _name), do: span
+
+  @spec set_name_if_nil(t() | nil, String.t()) :: t() | nil
+  @doc """
+  Sets an `Appsignal.Span`'s name if it was not set before.
+
+  ## Example
+      Appsignal.Tracer.root_span()
+      |> Appsignal.Span.set_name_if_nil("PageController#index")
+
+  """
+  def set_name_if_nil(%Span{reference: reference, name: nil} = span, name)
+      when is_reference(reference) and is_binary(name) do
+    :ok = @nif.set_span_name(reference, name)
+    %{span | name: name}
+  end
+
+  def set_name_if_nil(%Span{reference: reference} = span, name)
+      when is_reference(reference) and is_binary(name),
+      do: span
+
+  def set_name_if_nil(span, _name), do: span
 
   @spec set_namespace(t() | nil, String.t()) :: t() | nil
   @doc """

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -174,13 +174,43 @@ defmodule AppsignalSpanTest do
       [return: Span.set_name(span, "test")]
     end
 
-    test "returns a span", %{span: span, return: return} do
-      assert return == span
+    test "returns a span with the name set", %{span: span, return: return} do
+      assert return == %{span | name: "test"}
     end
 
     @tag :skip_env_test_no_nif
     test "sets the name through the Nif", %{span: span} do
       assert %{"name" => "test"} = Span.to_map(span)
+    end
+
+    test "returns nil when passing a nil-span" do
+      assert Span.set_name(nil, "test") == nil
+    end
+  end
+
+  describe ".set_name_if_nil/2" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      [return: Span.set_name_if_nil(span, "test")]
+    end
+
+    test "when no name is set it returns a span with the name set", %{span: span, return: return} do
+      assert return == %{span | name: "test"}
+    end
+
+    test "when a name is set it returns a span with the original name", %{
+      span: span,
+      return: return
+    } do
+      updated = Span.set_name_if_nil(return, "updated name")
+      assert updated == %{span | name: "test"}
+    end
+
+    @tag :skip_env_test_no_nif
+    test "sets the name through the Nif", %{span: span, return: return} do
+      updated = Span.set_name_if_nil(return, "updated name")
+      assert %{"name" => "test"} = Span.to_map(updated)
     end
 
     test "returns nil when passing a nil-span" do


### PR DESCRIPTION
Add helper to not set the name on a span if it's already set. We can use this to only set the span name (and the root span's (action) name), to not overwrite custom (action) names set by the app.

Add the name field to the span struct to avoid having to update the extension and agent to handle this logic.

Part of #869