### PR TITLE
Add set_name_if_nil helper

### DIFF
--- a/.changesets/add-set_name_if_nil-for-span-api.md
+++ b/.changesets/add-set_name_if_nil-for-span-api.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: add
+integrations: elixir
+---
+
+Add the `set_name_if_nil` function for Span API to set the span name only if it wasn't set before.

--- a/.changesets/add-set_name_if_nil-for-span-api.md
+++ b/.changesets/add-set_name_if_nil-for-span-api.md
@@ -1,7 +1,0 @@
----
-bump: patch
-type: add
-integrations: elixir
----
-
-Add the `set_name_if_nil` function for Span API to set the span name only if it wasn't set before.

--- a/.changesets/add-span-set_name_if_nil-helper.md
+++ b/.changesets/add-span-set_name_if_nil-helper.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add `Appsignal.Span.set_name_if_nil` helper. This helper can be used to not overwrite previously set span names, and only set the span name if it wasn't set previously. This will used most commonly in AppSignal created integrations with other libraries to allow apps to set custom span names.

--- a/agent.exs
+++ b/agent.exs
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 defmodule Appsignal.Agent do
-  def version, do: "0.35.10"
+  def version, do: "0.35.11"
 
   def mirrors do
     [
@@ -16,55 +16,55 @@ defmodule Appsignal.Agent do
   def triples do
     %{
       "x86_64-darwin" => %{
-        checksum: "8bdf6b162e03c5f63bc06f2d49ae789bb14e111636524ed78262bd543587a971",
+        checksum: "a897f48c0e821fc25eb3e3565ba6d88c6830fcd1e9d68f2d363d3a6aea09a5f8",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "universal-darwin" => %{
-        checksum: "8bdf6b162e03c5f63bc06f2d49ae789bb14e111636524ed78262bd543587a971",
+        checksum: "a897f48c0e821fc25eb3e3565ba6d88c6830fcd1e9d68f2d363d3a6aea09a5f8",
         filename: "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "aarch64-darwin" => %{
-        checksum: "c6453bb54a68cdb0b42864747b328e60a14b5b99921f11757de03db42041bed2",
+        checksum: "ad35cfdb2932c62675c9fa3b7abdd669fdf314133eeb620f4332793ac94d9c54",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm64-darwin" => %{
-        checksum: "c6453bb54a68cdb0b42864747b328e60a14b5b99921f11757de03db42041bed2",
+        checksum: "ad35cfdb2932c62675c9fa3b7abdd669fdf314133eeb620f4332793ac94d9c54",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "arm-darwin" => %{
-        checksum: "c6453bb54a68cdb0b42864747b328e60a14b5b99921f11757de03db42041bed2",
+        checksum: "ad35cfdb2932c62675c9fa3b7abdd669fdf314133eeb620f4332793ac94d9c54",
         filename: "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "aarch64-linux" => %{
-        checksum: "4e90ec4bce1e632316a26fdaf03ccd8773bf7a9615eb7a1739c8c53f3fa5221a",
+        checksum: "32b74d621f202da2eef162f82c4ea4263d8a195b314496207160a997c433bbba",
         filename: "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "i686-linux" => %{
-        checksum: "f5bcb9f732cb5af53a5de2f2c916156bdd6677c0e563ddafd23f09576440dfdc",
+        checksum: "7ee9b4f5cbdab32d9d14150c924e1f536c86e71f5b4c765cbb84bcd00cd12c3c",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86-linux" => %{
-        checksum: "f5bcb9f732cb5af53a5de2f2c916156bdd6677c0e563ddafd23f09576440dfdc",
+        checksum: "7ee9b4f5cbdab32d9d14150c924e1f536c86e71f5b4c765cbb84bcd00cd12c3c",
         filename: "appsignal-i686-linux-all-static.tar.gz"
       },
       "x86_64-linux" => %{
-        checksum: "6faa14f508f7c27b65d912eedb31f7808e1e2fb1dcaa077db2426c321e1f5c65",
+        checksum: "9cc4ef840c0ea65dda40eb5693fe3dd07f76f87d44a281c0a633da27f125bd12",
         filename: "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "x86_64-linux-musl" => %{
-        checksum: "8f54b734e56eae7867b5474c7ad4d79e049fd4063202e1b80989795708354e49",
+        checksum: "23b6962812a12c694d8b0ca02cd132b4759de821ea33f8db1cce62a6ddcfd40a",
         filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "aarch64-linux-musl" => %{
-        checksum: "b3d247d632e3465b2233dd8bb2e977f248f14286ca870e9bd7b855b550ba1c00",
+        checksum: "ca30a855b4a04702872fd8b5e78d39f2e787eb34e4f75dd1e123db70a38a367f",
         filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "x86_64-freebsd" => %{
-        checksum: "1cce550eac963e2edf405e551a613ffd15ae69e4b817b6155b8a5783a9fa9b7f",
+        checksum: "f2729157b59cbe8854c4b0cd82d7c2b060b0691a2cba9991f69c60504db9e3dd",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "amd64-freebsd" => %{
-        checksum: "1cce550eac963e2edf405e551a613ffd15ae69e4b817b6155b8a5783a9fa9b7f",
+        checksum: "f2729157b59cbe8854c4b0cd82d7c2b060b0691a2cba9991f69c60504db9e3dd",
         filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
     }

--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -997,6 +997,26 @@ static ERL_NIF_TERM _set_span_name(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
     return ok_atom;
 }
 
+static ERL_NIF_TERM _set_span_name_if_nil(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    span_ptr *ptr;
+    ErlNifBinary name;
+
+    if (argc != 2) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_get_resource(env, argv[0], appsignal_span_type, (void**) &ptr)) {
+      return enif_make_badarg(env);
+    }
+    if(!enif_inspect_iolist_as_binary(env, argv[1], &name)) {
+        return enif_make_badarg(env);
+    }
+
+    appsignal_set_span_name_if_nil(ptr->span, make_appsignal_string(name));
+
+    return ok_atom;
+}
+
 static ERL_NIF_TERM _set_span_namespace(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     span_ptr *ptr;
@@ -1445,6 +1465,7 @@ static ErlNifFunc nif_funcs[] =
     {"_create_child_span", 1, _create_child_span, 0},
     {"_create_child_span_with_timestamp", 3, _create_child_span_with_timestamp, 0},
     {"_set_span_name", 2, _set_span_name, 0},
+    {"_set_span_name_if_nil", 2, _set_span_name_if_nil, 0},
     {"_set_span_namespace", 2, _set_span_namespace, 0},
     {"_set_span_attribute_string", 3, _set_span_attribute_string, 0},
     {"_set_span_attribute_int", 3, _set_span_attribute_int, 0},

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -204,6 +204,10 @@ defmodule Appsignal.Nif do
     _set_span_name(reference, name)
   end
 
+  def set_span_name_if_nil(reference, name) do
+    _set_span_name_if_nil(reference, name)
+  end
+
   def set_span_namespace(reference, namespace) do
     _set_span_namespace(reference, namespace)
   end
@@ -445,6 +449,10 @@ defmodule Appsignal.Nif do
   end
 
   def _set_span_name(_reference, _name) do
+    :ok
+  end
+
+  def _set_span_name_if_nil(_reference, _name) do
     :ok
   end
 

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -108,6 +108,23 @@ defmodule Appsignal.Span do
 
   def set_name(span, _name), do: span
 
+  @spec set_name_if_nil(t() | nil, String.t()) :: t() | nil
+  @doc """
+  Sets an `Appsignal.Span`'s name if it was not set before.
+
+  ## Example
+      Appsignal.Tracer.root_span()
+      |> Appsignal.Span.set_name_if_nil("PageController#index")
+
+  """
+  def set_name_if_nil(%Span{reference: reference} = span, name)
+      when is_reference(reference) and is_binary(name) do
+    :ok = @nif.set_span_name_if_nil(reference, name)
+    span
+  end
+
+  def set_name_if_nil(span, _name), do: span
+
   @spec set_namespace(t() | nil, String.t()) :: t() | nil
   @doc """
   Sets an `Appsignal.Span`'s namespace.  The namespace is `"http_request"` or

--- a/lib/appsignal/test/span.ex
+++ b/lib/appsignal/test/span.ex
@@ -23,6 +23,11 @@ defmodule Appsignal.Test.Span do
     Span.set_name(span, name)
   end
 
+  def set_name_if_nil(span, name) do
+    add(:set_name_if_nil, {span, name})
+    Span.set_name_if_nil(span, name)
+  end
+
   def set_namespace(span, name) do
     add(:set_namespace, {span, name})
     Span.set_namespace(span, name)

--- a/test/appsignal/span_test.exs
+++ b/test/appsignal/span_test.exs
@@ -174,7 +174,7 @@ defmodule AppsignalSpanTest do
       [return: Span.set_name(span, "test")]
     end
 
-    test "returns a span", %{span: span, return: return} do
+    test "returns a span with the name set", %{span: span, return: return} do
       assert return == span
     end
 
@@ -200,6 +200,49 @@ defmodule AppsignalSpanTest do
 
     test "does not set the name through the Nif" do
       assert Test.Nif.get(:set_span_name) == :error
+    end
+  end
+
+  describe ".set_name_if_nil/2, with span that doesn't have a name yet" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      [return: Span.set_name_if_nil(span, "original name")]
+    end
+
+    test "when no name is set it returns a span with the name set", %{span: span, return: return} do
+      assert return == span
+    end
+
+    @tag :skip_env_test_no_nif
+    test "sets the name through the Nif", %{return: return} do
+      assert %{"name" => "original name"} = Span.to_map(return)
+    end
+
+    test "returns nil when passing a nil-span" do
+      assert Span.set_name(nil, "test") == nil
+    end
+  end
+
+  describe ".set_name_if_nil/2, with span that does have a name already" do
+    setup :create_root_span
+
+    setup %{span: span} do
+      span = Span.set_name_if_nil(span, "original name")
+      [return: Span.set_name_if_nil(span, "updated name")]
+    end
+
+    test "whereturns a span with the name set", %{span: span, return: return} do
+      assert return == span
+    end
+
+    @tag :skip_env_test_no_nif
+    test "doesn't update the name through the Nif", %{return: return} do
+      assert %{"name" => "original name"} = Span.to_map(return)
+    end
+
+    test "returns nil when passing a nil-span" do
+      assert Span.set_name(nil, "test") == nil
     end
   end
 

--- a/test/support/appsignal/test_nif.ex
+++ b/test/support/appsignal/test_nif.ex
@@ -27,6 +27,11 @@ defmodule Appsignal.Test.Nif do
     Nif.set_span_name(reference, name)
   end
 
+  def set_span_name_if_nil(reference, name) do
+    add(:set_span_name_if_nil, {reference, name})
+    Nif.set_span_name_if_nil(reference, name)
+  end
+
   def set_span_namespace(reference, namespace) do
     add(:set_span_namespace, {reference, namespace})
     Nif.set_span_namespace(reference, namespace)


### PR DESCRIPTION
Add helper to not set the name on a span if it's already set. We can use this to only set the span name (and the root span's (action) name), to not overwrite custom (action) names set by the app.

This change requires an update to the extension.
See PR https://github.com/appsignal/appsignal-agent/pull/1158

Part of #869