### PR TITLE
Group Absinthe GraphQL requests by operation name

### DIFF
--- a/.changesets/report-graphql-operation-name-as-absinthe-action-name.md
+++ b/.changesets/report-graphql-operation-name-as-absinthe-action-name.md
@@ -1,0 +1,12 @@
+---
+bump: minor
+type: change
+---
+
+Group GraphQL queries by operation names if available. It will no longer group all errors and performance measurements under the same action name. If no operation name is set, it will use the default action name of the HTTP request route, like `POST /graphql`.
+
+If you do not wish to use the operation name, or customize the action name for the GraphQL query request, use the `Appsignal.Span.set_name` in a plug middleware that is called before or after the HTTP request is made:
+
+```elixir
+Appsignal.Span.set_name(Appsignal.Tracer.root_span(), "MyActionName")
+```

--- a/lib/appsignal/absinthe.ex
+++ b/lib/appsignal/absinthe.ex
@@ -41,11 +41,19 @@ defmodule Appsignal.Absinthe do
     end
   end
 
-  def absinthe_execute_operation_start(_event, _measurements, _metadata, _config) do
-    "http_request"
+  def absinthe_execute_operation_start(_event, _measurements, metadata, _config) do
+    operation_name = metadata[:options][:operation_name]
+
+    "graphql"
     |> @tracer.create_span(@tracer.current_span())
-    |> @span.set_name("graphql")
+    |> @span.set_name(operation_name || "graphql")
     |> @span.set_attribute("appsignal:category", "call.graphql")
+
+    if operation_name do
+      @tracer.root_span()
+      |> @span.set_name_if_nil(operation_name)
+      |> @span.set_namespace("graphql")
+    end
   end
 
   def absinthe_execute_operation_stop(_event, _measurements, _metadata, _config) do


### PR DESCRIPTION
Group GraphQL requests handled by Absinthe by the GraphQL operation name. Operation names are optional in GraphQL queries, so only set it if it's present.

This uses the new `Span.set_name_if_nil` helper to only set this name if it isn't set by another instrumentation hook or customized by the app.

Fixes https://github.com/appsignal/support/issues/283

---

This also requires a change to the Phoenix integration to use `set_name_if_nil`: https://github.com/appsignal/appsignal-elixir-phoenix/pull/88