### PR TITLE
Lock credo to 1.7.6 on Elixir < 1.13

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -132,6 +132,12 @@ defmodule Appsignal.Mixfile do
         _ -> "~> 1.14"
       end
 
+    credo_version =
+      case Version.compare(system_version, "1.13.0") do
+        :lt -> "1.7.6"
+        _ -> "~> 1.7"
+      end
+
     [
       {:decimal, "~> 2.0"},
       {:benchee, "~> 1.0", only: :bench},
@@ -142,7 +148,7 @@ defmodule Appsignal.Mixfile do
       {:plug_cowboy, "~> 1.0", only: [:test, :test_no_nif]},
       {:bypass, "~> 0.6.0", only: [:test, :test_no_nif]},
       {:ex_doc, "~> 0.12", only: :dev, runtime: false},
-      {:credo, "~> 1.6", only: [:test, :dev], runtime: false},
+      {:credo, credo_version, only: [:test, :dev], runtime: false},
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:telemetry, telemetry_version}
     ] ++ mime_dependency


### PR DESCRIPTION
Credo 1.7.7 dropped support for Elixir versions below 1.13. This patch locks the credo version to 1.7.6 on any Elixir version before 1.13.

[skip changeset]