### PR TITLE
Don't run the installation script on windows

### DIFF
--- a/.changesets/don-t-run-the-insallation-script-on-windows.md
+++ b/.changesets/don-t-run-the-insallation-script-on-windows.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+When running the installation script on Microsoft Windows, some components threw an error. AppSignal doesn't support Windows, so the installation script won't run on Windows anymore. Preventing errors from raising.

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -2,7 +2,22 @@ defmodule Mix.Tasks.Appsignal.Install do
   use Mix.Task
   @shortdoc "Installs AppSignal into the current application"
 
-  def run([]) do
+  def run(args) do
+    case :os.type() do
+      {:win32, _} ->
+        """
+        We've detected that you're running Windows. Unfortunately, AppSignal does not support Windows at this time.
+        """
+        |> IO.puts()
+
+        exit(:shutdown)
+
+      _ ->
+        do_run(args)
+    end
+  end
+
+  defp do_run([]) do
     header()
 
     """
@@ -17,7 +32,7 @@ defmodule Mix.Tasks.Appsignal.Install do
     |> IO.puts()
   end
 
-  def run([push_api_key]) do
+  defp do_run([push_api_key]) do
     config = %{otp_app: otp_app(), active: true, push_api_key: push_api_key, request_headers: []}
     Application.put_env(:appsignal, :config, config)
     Appsignal.Config.initialize()


### PR DESCRIPTION
Windows is not a supported OS. Therefore, the installation script shouldn't run when on this system.

This commit adds a check before the script runs. If the system is Windows based, the installation won't run and a message will be shown.

Closes https://github.com/appsignal/support/issues/308