### PR TITLE
Ignore binwrite error response handling warning

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -3,3 +3,4 @@ lib/appsignal/json.ex:32: Unknown function 'Elixir.Jason':'encode!'/1
 lib/appsignal/json.ex:33: Unknown function 'Elixir.Jason':decode/1
 lib/appsignal/json.ex:34: Unknown function 'Elixir.Jason':'decode!'/1
 lib/mix/tasks/appsignal.install.ex:175: The pattern {'error', _reason@1} can never match the type 'ok'
+lib/mix/tasks/appsignal.install.ex:190


### PR DESCRIPTION
IO's module `binwrite/2` function no longer returns an error touple when
failing. Instead, it raises an Erlang error. This commit makes dialyzer
ignore that warning so it behaves appropriately in newer and older
versions.

[skip changeset]

Ref: https://github.com/elixir-lang/elixir/blob/v1.17.1/lib/elixir/lib/io.ex#L280-L284