### PR TITLE
Fix Dialyzer warnings and remove ignore file

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,6 +1,0 @@
-lib/appsignal/json.ex:31: Unknown function 'Elixir.Jason':encode/1
-lib/appsignal/json.ex:32: Unknown function 'Elixir.Jason':'encode!'/1
-lib/appsignal/json.ex:33: Unknown function 'Elixir.Jason':decode/1
-lib/appsignal/json.ex:34: Unknown function 'Elixir.Jason':'decode!'/1
-lib/mix/tasks/appsignal.install.ex:175: The pattern {'error', _reason@1} can never match the type 'ok'
-lib/mix/tasks/appsignal.install.ex:190

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -183,15 +183,8 @@ defmodule Mix.Tasks.Appsignal.Install do
 
     case File.open(appsignal_config_file_path(), [:write]) do
       {:ok, file} ->
-        case IO.binwrite(file, appsignal_config_file_contents(config)) do
-          :ok ->
-            IO.puts("Success!")
-
-          {:error, reason} ->
-            IO.puts("Failure! #{inspect(reason)}")
-            exit(:shutdown)
-        end
-
+        IO.binwrite(file, appsignal_config_file_contents(config))
+        IO.puts("Success!")
         File.close(file)
 
       {:error, reason} ->

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -183,6 +183,15 @@ defmodule Mix.Tasks.Appsignal.Install do
 
     case File.open(appsignal_config_file_path(), [:write]) do
       {:ok, file} ->
+        case binwrite_with_result(file, appsignal_config_file_contents(config)) do
+          :ok ->
+            IO.puts("Success!")
+
+          {:error, reason} ->
+            IO.puts("Failure! #{inspect(reason)}")
+            exit(:shutdown)
+        end
+
         IO.binwrite(file, appsignal_config_file_contents(config))
         IO.puts("Success!")
         File.close(file)
@@ -191,6 +200,18 @@ defmodule Mix.Tasks.Appsignal.Install do
         IO.puts("Failure! #{inspect(reason)}")
         exit(:shutdown)
     end
+  end
+
+  if Version.match?(System.version(), ">= 1.16.0") do
+    defp binwrite_with_result(path, contents) do
+      try do
+        IO.binwrite(path, contents)
+      catch
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  else
+    defdelegate binwrite_with_result(path, contents), to: IO, as: :binwrite
   end
 
   # Link the config/appsignal.exs config file to the config/config.exs file.

--- a/lib/mix/tasks/appsignal.install.ex
+++ b/lib/mix/tasks/appsignal.install.ex
@@ -192,8 +192,6 @@ defmodule Mix.Tasks.Appsignal.Install do
             exit(:shutdown)
         end
 
-        IO.binwrite(file, appsignal_config_file_contents(config))
-        IO.puts("Success!")
         File.close(file)
 
       {:error, reason} ->

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,6 @@ defmodule Appsignal.Mixfile do
         extras: ["README.md", "CHANGELOG.md"]
       ],
       dialyzer: [
-        ignore_warnings: "dialyzer.ignore-warnings",
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
         plt_add_apps: [:mix]
       ]


### PR DESCRIPTION
Previously, the repository included a Dialyzer ignore file with a couple
of ignored warnings. This patch fixes all warnings and removes the file.

[skip changeset]
