### PR TITLE
Drop Elixir versions before 1.11

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -15,7 +15,6 @@ defmodule Appsignal do
   use Application
   alias Appsignal.Config
   require Logger
-  import Appsignal.Utils, only: [info: 1, warning: 1]
 
   @doc false
   def start(_type, _args) do
@@ -87,7 +86,7 @@ defmodule Appsignal do
   def initialize do
     case {Config.initialize(), Config.configured_as_active?()} do
       {_, false} ->
-        info("AppSignal disabled.")
+        Logger.info("AppSignal disabled.")
 
       {:ok, true} ->
         Appsignal.IntegrationLogger.debug("AppSignal starting.")
@@ -101,7 +100,7 @@ defmodule Appsignal do
         end
 
       {{:error, :invalid_config}, true} ->
-        warning(
+        Logger.warning(
           "Warning: No valid AppSignal configuration found, continuing with " <>
             "AppSignal metrics disabled."
         )

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -8,9 +8,7 @@ defmodule Appsignal do
   helper functions for sending metrics to AppSignal.
   """
 
-  require Mix.Appsignal.Utils
-
-  @os Mix.Appsignal.Utils.compile_env(:appsignal, :os_internal, :os)
+  @os Application.compile_env(:appsignal, :os_internal, :os)
 
   use Application
   alias Appsignal.Config

--- a/lib/appsignal/absinthe.ex
+++ b/lib/appsignal/absinthe.ex
@@ -1,9 +1,8 @@
 defmodule Appsignal.Absinthe do
-  require Appsignal.Utils
   require Logger
 
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @moduledoc false
 

--- a/lib/appsignal/absinthe.ex
+++ b/lib/appsignal/absinthe.ex
@@ -1,12 +1,11 @@
 defmodule Appsignal.Absinthe do
   require Appsignal.Utils
+  require Logger
 
   @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @moduledoc false
-
-  import Appsignal.Utils, only: [warning: 1]
 
   def attach do
     handlers = %{
@@ -34,7 +33,9 @@ defmodule Appsignal.Absinthe do
           :ok
 
         {_, {:error, _} = error} ->
-          warning("Appsignal.Absinthe not attached to #{inspect(event)}: #{inspect(error)}")
+          Logger.warning(
+            "Appsignal.Absinthe not attached to #{inspect(event)}: #{inspect(error)}"
+          )
 
           error
       end

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -2,7 +2,8 @@ defmodule Appsignal.Config do
   @moduledoc false
   alias Appsignal.Nif
   alias Appsignal.Utils.FileSystem
-  import Appsignal.Utils, only: [warning: 1]
+
+  require Logger
 
   @default_config %{
     active: false,
@@ -64,7 +65,7 @@ defmodule Appsignal.Config do
     config = Map.merge(config, sources[:override])
 
     if !empty?(config[:working_dir_path]) do
-      warning(fn ->
+      Logger.warning(fn ->
         "'working_dir_path' is deprecated, please use " <>
           "'working_directory_path' instead and specify the " <>
           "full path to the working directory"
@@ -234,7 +235,7 @@ defmodule Appsignal.Config do
             "all"
 
           unknown ->
-            warning(
+            Logger.warning(
               "Unknown value #{inspect(unknown)} for report_oban_errors config " <>
                 ~s(option. Valid values are "discard", "none", "all". ) <>
                 ~s(Defaulting to "all".)

--- a/lib/appsignal/demo.ex
+++ b/lib/appsignal/demo.ex
@@ -7,9 +7,7 @@ defmodule Appsignal.Demo do
   @moduledoc false
   import Appsignal.Instrumentation, only: [instrument: 2, instrument: 3]
 
-  require Appsignal.Utils
-
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   def send_performance_sample do
     instrument("DemoController#hello", "call.phoenix", fn span ->

--- a/lib/appsignal/diagnose/agent.ex
+++ b/lib/appsignal/diagnose/agent.ex
@@ -1,9 +1,7 @@
 defmodule Appsignal.Diagnose.Agent do
   @moduledoc false
 
-  require Appsignal.Utils
-
-  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+  @nif Application.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   def report do
     if @nif.loaded?() do

--- a/lib/appsignal/diagnose/host.ex
+++ b/lib/appsignal/diagnose/host.ex
@@ -1,10 +1,8 @@
 defmodule Appsignal.Diagnose.Host do
   @moduledoc false
 
-  require Appsignal.Utils
-
-  @system Appsignal.Utils.compile_env(:appsignal, :appsignal_system, Appsignal.System)
-  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+  @system Application.compile_env(:appsignal, :appsignal_system, Appsignal.System)
+  @nif Application.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   def info do
     {_, os} = :os.type()

--- a/lib/appsignal/diagnose/library.ex
+++ b/lib/appsignal/diagnose/library.ex
@@ -1,11 +1,9 @@
 defmodule Appsignal.Diagnose.Library do
   @moduledoc false
 
-  require Appsignal.Utils
-
   @appsignal_version Mix.Project.config()[:version]
   @agent_version Appsignal.Agent.version()
-  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
+  @nif Application.compile_env(:appsignal, :appsignal_nif, Appsignal.Nif)
 
   def info do
     %{

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -1,9 +1,10 @@
 defmodule Appsignal.Ecto do
   require Appsignal.Utils
+  require Logger
 
   @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
-  import Appsignal.Utils, only: [module_name: 1, warning: 1]
+  import Appsignal.Utils, only: [module_name: 1]
 
   @doc """
   Attaches `Appsignal.Ecto` to the Ecto telemetry channel configured in the
@@ -34,7 +35,7 @@ defmodule Appsignal.Ecto do
         :ok
 
       {:error, _} = error ->
-        warning("Appsignal.Ecto not attached to #{inspect(event)}: #{inspect(error)}")
+        Logger.warning("Appsignal.Ecto not attached to #{inspect(event)}: #{inspect(error)}")
 
         error
     end

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -1,9 +1,8 @@
 defmodule Appsignal.Ecto do
-  require Appsignal.Utils
   require Logger
 
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   import Appsignal.Utils, only: [module_name: 1]
 
   @doc """

--- a/lib/appsignal/ecto_repo.ex
+++ b/lib/appsignal/ecto_repo.ex
@@ -1,6 +1,5 @@
 defmodule Appsignal.Ecto.Repo do
-  require Appsignal.Utils
-  @ecto_repo Appsignal.Utils.compile_env(:appsignal, :ecto_repo, Ecto.Repo)
+  @ecto_repo Application.compile_env(:appsignal, :ecto_repo, Ecto.Repo)
 
   defmacro __using__(opts) do
     quote do

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -1,11 +1,10 @@
 defmodule Appsignal.Error.Backend do
   @moduledoc false
 
-  require Appsignal.Utils
   require Logger
 
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @behaviour :gen_event
 

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -2,20 +2,19 @@ defmodule Appsignal.Error.Backend do
   @moduledoc false
 
   require Appsignal.Utils
+  require Logger
 
   @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @behaviour :gen_event
 
-  import Appsignal.Utils, only: [warning: 1]
-
   def init(opts), do: {:ok, opts}
 
   def attach do
     case Logger.add_backend(Appsignal.Error.Backend) do
       {:error, error} ->
-        warning("Appsignal.Error.Backend not attached to Logger: #{error}")
+        Logger.warning("Appsignal.Error.Backend not attached to Logger: #{error}")
         :error
 
       _ ->

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -1,12 +1,11 @@
 defmodule Appsignal.Finch do
   require Appsignal.Utils
+  require Logger
 
   @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @moduledoc false
-
-  import Appsignal.Utils, only: [warning: 1]
 
   def attach do
     handlers = %{
@@ -23,7 +22,7 @@ defmodule Appsignal.Finch do
           :ok
 
         {:error, _} = error ->
-          warning("Appsignal.Finch not attached to #{inspect(event)}: #{inspect(error)}")
+          Logger.warning("Appsignal.Finch not attached to #{inspect(event)}: #{inspect(error)}")
 
           error
       end

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -1,9 +1,8 @@
 defmodule Appsignal.Finch do
-  require Appsignal.Utils
   require Logger
 
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @moduledoc false
 

--- a/lib/appsignal/heartbeat.ex
+++ b/lib/appsignal/heartbeat.ex
@@ -1,9 +1,8 @@
 defmodule Appsignal.Heartbeat do
   alias __MODULE__
   alias Appsignal.Heartbeat.Event
-  require Appsignal.Utils
 
-  @transmitter Appsignal.Utils.compile_env(
+  @transmitter Application.compile_env(
                  :appsignal,
                  :appsignal_transmitter,
                  Appsignal.Transmitter

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -1,8 +1,6 @@
 defmodule Appsignal.Instrumentation do
-  require Appsignal.Utils
-
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @spec instrument(function()) :: any()
   @doc false

--- a/lib/appsignal/instrumentation/decorators.ex
+++ b/lib/appsignal/instrumentation/decorators.ex
@@ -1,9 +1,7 @@
 defmodule Appsignal.Instrumentation.Decorators do
   @moduledoc false
 
-  require Appsignal.Utils
-
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   use Decorator.Define,
     instrument: 0,

--- a/lib/appsignal/integration_logger.ex
+++ b/lib/appsignal/integration_logger.ex
@@ -1,8 +1,6 @@
 defmodule Appsignal.IntegrationLogger do
-  require Appsignal.Utils
-
-  @io Appsignal.Utils.compile_env(:appsignal, :io, IO)
-  @file_module Appsignal.Utils.compile_env(:appsignal, :file, File)
+  @io Application.compile_env(:appsignal, :io, IO)
+  @file_module Application.compile_env(:appsignal, :file, File)
 
   @log_levels [:trace, :debug, :info, :warn, :error]
 

--- a/lib/appsignal/logger.ex
+++ b/lib/appsignal/logger.ex
@@ -1,7 +1,5 @@
 defmodule Appsignal.Logger do
-  require Appsignal.Utils
-
-  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
+  @nif Application.compile_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
 
   @type log_level ::
           :debug | :info | :notice | :warning | :error | :critical | :alert | :emergency

--- a/lib/appsignal/monitor.ex
+++ b/lib/appsignal/monitor.ex
@@ -1,10 +1,8 @@
 defmodule Appsignal.Monitor do
   @moduledoc false
 
-  require Appsignal.Utils
-
-  @deletion_delay Appsignal.Utils.compile_env(:appsignal, :deletion_delay, 5_000)
-  @sync_interval Appsignal.Utils.compile_env(:appsignal, :sync_interval, 60_000)
+  @deletion_delay Application.compile_env(:appsignal, :deletion_delay, 5_000)
+  @sync_interval Application.compile_env(:appsignal, :sync_interval, 60_000)
 
   use GenServer
   alias Appsignal.Tracer

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -1,13 +1,12 @@
 defmodule Appsignal.Oban do
   require Appsignal.Utils
+  require Logger
 
   @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   @appsignal Appsignal.Utils.compile_env(:appsignal, :appsignal, Appsignal)
 
   @moduledoc false
-
-  import Appsignal.Utils, only: [warning: 1]
 
   def attach do
     exception_handler =
@@ -42,7 +41,7 @@ defmodule Appsignal.Oban do
           :ok
 
         {_, {:error, _} = error} ->
-          warning("Appsignal.Oban not attached to #{inspect(event)}: #{inspect(error)}")
+          Logger.warning("Appsignal.Oban not attached to #{inspect(event)}: #{inspect(error)}")
 
           error
       end

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -1,10 +1,9 @@
 defmodule Appsignal.Oban do
-  require Appsignal.Utils
   require Logger
 
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
-  @appsignal Appsignal.Utils.compile_env(:appsignal, :appsignal, Appsignal)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @appsignal Application.compile_env(:appsignal, :appsignal, Appsignal)
 
   @moduledoc false
 

--- a/lib/appsignal/probes/erlang_probe.ex
+++ b/lib/appsignal/probes/erlang_probe.ex
@@ -1,6 +1,5 @@
 defmodule Appsignal.Probes.ErlangProbe do
   @moduledoc false
-  require Appsignal.Utils
 
   def call(sample \\ nil) do
     next_sample = sample_schedulers()

--- a/lib/appsignal/probes/probes.ex
+++ b/lib/appsignal/probes/probes.ex
@@ -2,9 +2,8 @@ defmodule Appsignal.Probes do
   @moduledoc false
   use GenServer
   require Logger
-  require Appsignal.Utils
 
-  @integration_logger Appsignal.Utils.compile_env(
+  @integration_logger Application.compile_env(
                         :appsignal,
                         :appsignal_integration_logger,
                         Appsignal.IntegrationLogger

--- a/lib/appsignal/span.ex
+++ b/lib/appsignal/span.ex
@@ -3,9 +3,7 @@ defmodule Appsignal.Span do
 
   defstruct [:reference, :pid]
 
-  require Appsignal.Utils
-
-  @nif Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
+  @nif Application.compile_env(:appsignal, :appsignal_tracer_nif, Appsignal.Nif)
 
   @type t() :: %__MODULE__{
           reference: reference(),

--- a/lib/appsignal/tesla.ex
+++ b/lib/appsignal/tesla.ex
@@ -1,9 +1,8 @@
 defmodule Appsignal.Tesla do
-  require Appsignal.Utils
   require Logger
 
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @moduledoc false
 

--- a/lib/appsignal/tesla.ex
+++ b/lib/appsignal/tesla.ex
@@ -1,12 +1,11 @@
 defmodule Appsignal.Tesla do
   require Appsignal.Utils
+  require Logger
 
   @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @moduledoc false
-
-  import Appsignal.Utils, only: [warning: 1]
 
   def attach do
     handlers = %{
@@ -23,7 +22,7 @@ defmodule Appsignal.Tesla do
           :ok
 
         {:error, _} = error ->
-          warning("Appsignal.Tesla not attached to #{inspect(event)}: #{inspect(error)}")
+          Logger.warning("Appsignal.Tesla not attached to #{inspect(event)}: #{inspect(error)}")
 
           error
       end

--- a/lib/appsignal/tracer.ex
+++ b/lib/appsignal/tracer.ex
@@ -1,9 +1,7 @@
 defmodule Appsignal.Tracer do
   alias Appsignal.Span
 
-  require Appsignal.Utils
-
-  @monitor Appsignal.Utils.compile_env(:appsignal, :appsignal_monitor, Appsignal.Monitor)
+  @monitor Application.compile_env(:appsignal, :appsignal_monitor, Appsignal.Monitor)
 
   @table :"$appsignal_registry"
 

--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -1,7 +1,7 @@
 defmodule Appsignal.Transmitter do
   @moduledoc false
 
-  import Appsignal.Utils, only: [warning: 1]
+  require Logger
 
   def request(method, url, headers \\ [], body \\ "") do
     http_client = Application.get_env(:appsignal, :http_client, :hackney)
@@ -62,7 +62,7 @@ defmodule Appsignal.Transmitter do
 
       {:error, message} ->
         unless ca_file_path == packaged_ca_file_path() do
-          warning(
+          Logger.warning(
             "Ignoring non-existing or unreadable ca_file_path (#{ca_file_path}): #{inspect(message)}"
           )
         end

--- a/lib/appsignal/utils.ex
+++ b/lib/appsignal/utils.ex
@@ -19,6 +19,18 @@ defmodule Appsignal.Utils do
 
   def module_name(module), do: module |> to_string() |> module_name()
 
+  @deprecated "Use Logger.info/1 instead."
+  def info(message) do
+    require Logger
+    Logger.info(message)
+  end
+
+  @deprecated "Use Logger.warning/1 instead."
+  def warning(message) do
+    require Logger
+    Logger.warning(message)
+  end
+
   defmacro compile_env(app, key, default \\ nil) do
     if Version.match?(System.version(), ">= 1.10.0") do
       quote do

--- a/lib/appsignal/utils.ex
+++ b/lib/appsignal/utils.ex
@@ -19,19 +19,16 @@ defmodule Appsignal.Utils do
 
   def module_name(module), do: module |> to_string() |> module_name()
 
-  @deprecated "Use Logger.info/1 instead."
   def info(message) do
     require Logger
     Logger.info(message)
   end
 
-  @deprecated "Use Logger.warning/1 instead."
   def warning(message) do
     require Logger
     Logger.warning(message)
   end
 
-  @deprecated "Use Application.compile_env/3 instead."
   defmacro compile_env(app, key, default \\ nil) do
     quote do
       Application.compile_env(unquote(app), unquote(key), unquote(default))

--- a/lib/appsignal/utils.ex
+++ b/lib/appsignal/utils.ex
@@ -30,16 +30,4 @@ defmodule Appsignal.Utils do
     require Logger
     Logger.warning(message)
   end
-
-  defmacro compile_env(app, key, default \\ nil) do
-    if Version.match?(System.version(), ">= 1.10.0") do
-      quote do
-        Application.compile_env(unquote(app), unquote(key), unquote(default))
-      end
-    else
-      quote do
-        Application.get_env(unquote(app), unquote(key), unquote(default))
-      end
-    end
-  end
 end

--- a/lib/appsignal/utils.ex
+++ b/lib/appsignal/utils.ex
@@ -30,4 +30,11 @@ defmodule Appsignal.Utils do
     require Logger
     Logger.warning(message)
   end
+
+  @deprecated "Use Application.compile_env/3 instead."
+  defmacro compile_env(app, key, default \\ nil) do
+    quote do
+      Application.compile_env(unquote(app), unquote(key), unquote(default))
+    end
+  end
 end

--- a/lib/appsignal/utils.ex
+++ b/lib/appsignal/utils.ex
@@ -1,8 +1,6 @@
 defmodule Appsignal.Utils do
   @moduledoc false
 
-  require Logger
-
   @doc """
   Converts module name atoms to strings.
 
@@ -20,14 +18,6 @@ defmodule Appsignal.Utils do
   def module_name(module) when is_binary(module), do: module
 
   def module_name(module), do: module |> to_string() |> module_name()
-
-  defdelegate info(message), to: Logger
-
-  if Version.compare(System.version(), "1.11.0") == :lt do
-    defdelegate warning(message), to: Logger, as: :warn
-  else
-    defdelegate warning(message), to: Logger
-  end
 
   defmacro compile_env(app, key, default \\ nil) do
     if Version.match?(System.version(), ">= 1.10.0") do

--- a/lib/appsignal/utils/hostname.ex
+++ b/lib/appsignal/utils/hostname.ex
@@ -1,9 +1,7 @@
 defmodule Appsignal.Utils.Hostname do
   @moduledoc false
 
-  require Appsignal.Utils
-
-  @inet Appsignal.Utils.compile_env(:appsignal, :inet, :inet)
+  @inet Application.compile_env(:appsignal, :inet, :inet)
 
   def hostname do
     case Application.fetch_env(:appsignal, :config) do

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -3,10 +3,8 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
   alias Appsignal.Config
   alias Appsignal.Diagnose
 
-  require Appsignal.Utils
-
-  @system Appsignal.Utils.compile_env(:appsignal, :appsignal_system, Appsignal.System)
-  @report Appsignal.Utils.compile_env(
+  @system Application.compile_env(:appsignal, :appsignal_system, Appsignal.System)
+  @report Application.compile_env(
             :appsignal,
             :appsignal_diagnose_report,
             Appsignal.Diagnose.Report

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -2,30 +2,14 @@ unless Code.ensure_loaded?(Appsignal.Agent) do
   {_, _} = Code.eval_file("agent.exs")
 end
 
-defmodule Mix.Appsignal.Utils do
-  defmacro compile_env(app, key, default \\ nil) do
-    if Version.match?(System.version(), ">= 1.10.0") do
-      quote do
-        Application.compile_env(unquote(app), unquote(key), unquote(default))
-      end
-    else
-      quote do
-        Application.get_env(unquote(app), unquote(key), unquote(default))
-      end
-    end
-  end
-end
-
 defmodule Mix.Appsignal.Helper do
   @moduledoc """
   Helper functions for downloading and compiling the AppSignal agent library.
   """
 
-  require Mix.Appsignal.Utils
-
-  @erlang Mix.Appsignal.Utils.compile_env(:appsignal, :erlang, :erlang)
-  @os Mix.Appsignal.Utils.compile_env(:appsignal, :os, :os)
-  @system Mix.Appsignal.Utils.compile_env(:appsignal, :mix_system, System)
+  @erlang Application.compile_env(:appsignal, :erlang, :erlang)
+  @os Application.compile_env(:appsignal, :os, :os)
+  @system Application.compile_env(:appsignal, :mix_system, System)
 
   @proxy_env_vars [
     "APPSIGNAL_HTTP_PROXY",


### PR DESCRIPTION
AppSignal  for Elixir supports the Elixir and OTP versions listed on the [compatibility page](https://hexdocs.pm/elixir/main/compatibility-and-deprecations.html). Currently, that's Elixir 1.13 and up, and therefore OTP 25 and up.

However, we don't tend to remove old versions from CI until they start giving us issues. When switching the CI to GitHub actions, we found that we could no longer install OTP versions lower than 24, as they're incompatible with the Ubuntu version we're running. Instead of trying to compile from source, we decided to drop Elixir 1.9.x and 1.10.x. Currently, the CI runs Elixir 1.11 and up, and OTP 24 and up.

By dropping these versions, we were able to remove some code we added for compatibility with versions before Elixir 1.11:

1. `Appsignal.Utils.warning/1` was added to bridge the gap between `Logger.warn/1` and `Logger.warning/1`, after the rename in 1.11. Since we don't support versions before 1.11 anymore, we don't need the helper function and we can just call `Logger.warning/1` directly.

2. `Appsignal.Utils.compile_env/3` is a similar case, in which `Application.compile_env/3` was introduced in Elixir 1.10. The helper dropped down to  `Application.get_env/3` on older versions. We can now call `Application.compile_env/3` directly.

Both of these functions were also used in AppSignal for Phoenix and AppSignal for Plug. Pull requests are opened for both (https://github.com/appsignal/appsignal-elixir-phoenix/pull/94 and https://github.com/appsignal/appsignal-elixir-plug/pull/47). 

Because this pull request includes fallbacks, we don't need to release these in a specific order. In unlikely cases where a user updates AppSignal for Elixir without updating Appsignal for Phoenix, the integration will remain working, but it will throw deprecation warnings.
