### PR TITLE
Switch off master and main versions to fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,8 +129,8 @@ jobs:
           - 26.x
           - 25.x
         include:
-          - elixir: main
-            otp: master
+          - elixir: latest
+            otp: latest
           - elixir: 1.16.x
             otp: 26.x
           - elixir: 1.15.x

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: latest
-          elixir-version: latest
+          otp-version: 27.x
+          elixir-version: 1.17.x
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Check code formatting
@@ -34,8 +34,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: latest
-          elixir-version: latest
+          otp-version: 27.x
+          elixir-version: 1.17.x
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get dependencies
@@ -49,8 +49,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: latest
-          elixir-version: latest
+          otp-version: 27.x
+          elixir-version: 1.17.x
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get dependencies
@@ -87,8 +87,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: latest
-          elixir-version: latest
+          otp-version: 27.x
+          elixir-version: 1.17.x
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -109,8 +109,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: latest
-          elixir-version: latest
+          otp-version: 27.x
+          elixir-version: 1.17.x
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: master
-          elixir-version: main
+          otp-version: latest
+          elixir-version: latest
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Check code formatting
@@ -34,8 +34,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: master
-          elixir-version: main
+          otp-version: latest
+          elixir-version: latest
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get dependencies
@@ -49,8 +49,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: master
-          elixir-version: main
+          otp-version: latest
+          elixir-version: latest
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get dependencies
@@ -87,8 +87,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: master
-          elixir-version: main
+          otp-version: latest
+          elixir-version: latest
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -109,8 +109,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: master
-          elixir-version: main
+          otp-version: latest
+          elixir-version: latest
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,8 +129,6 @@ jobs:
           - 26.x
           - 25.x
         include:
-          - elixir: latest
-            otp: latest
           - elixir: 1.16.x
             otp: 26.x
           - elixir: 1.15.x


### PR DESCRIPTION
Because of build issues, replace the main/master versions from the CI and run on the latest released versions instead. 

We'd still want to run the CI on unreleased versions, so a pull request is incoming that puts them back. We can then track that to see if the issues resolve.

[skip changeset]