### PR TITLE
Add Elixir main to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,8 @@ jobs:
           - 26.x
           - 25.x
         include:
+          - elixir: main
+            otp: 27.x
           - elixir: latest
             otp: 27.x
           - elixir: 1.16.x


### PR DESCRIPTION
Removed in #954, this patch restores the Elixir main and Erlang master versions on CI.

[skip changeset]