### PR TITLE
Fix ecto transaction in parallel preload

### DIFF
--- a/.changesets/fix-ecto-transactions-in-parallel-preloads.md
+++ b/.changesets/fix-ecto-transactions-in-parallel-preloads.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where Ecto transactions in parallel preloads would not be instrumented correctly when using `Appsignal.Ecto.Repo`, causing the query in the Ecto transaction to not be instrumented and the sample to be incorrectly closed as an earlier time.

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -68,7 +68,7 @@ defmodule Appsignal.EctoTest do
     end
   end
 
-  describe "handle_event/4 and handle_query/4, with a root span" do
+  describe "handle_event/4 and handle_query/4, with a root span from the tracer" do
     setup do
       start_supervised!(Test.Nif)
       start_supervised!(Test.Tracer)
@@ -188,6 +188,70 @@ defmodule Appsignal.EctoTest do
     test "closes the span with an end time" do
       {:ok, [{_, _, start_time: start_time}]} = Test.Tracer.get(:create_span)
       {:ok, [{%Span{}, end_time: end_time}]} = Test.Tracer.get(:close_span)
+      assert end_time - start_time == 8_829_000
+    end
+  end
+
+  describe "handle_event/4 and handle_commit/4, with a root span from the tracer and a root span passed via telemetry options" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      telemetry_span =
+        fn -> Appsignal.Tracer.create_span("http_request") end
+        |> Task.async()
+        |> Task.await()
+
+      tracer_span = Appsignal.Tracer.create_span("http_request")
+
+      :telemetry.execute(
+        [:appsignal, :test, :repo, :query],
+        %{
+          decode_time: 2_204_000,
+          query_time: 5_386_000,
+          queue_time: 1_239_000,
+          total_time: 8_829_000
+        },
+        %{
+          params: [],
+          query: "commit",
+          repo: Appsignal.Test.Repo,
+          result: :ok,
+          source: "users",
+          type: :ecto_sql_query
+        }
+      )
+
+      %{telemetry_span: telemetry_span, tracer_span: tracer_span}
+    end
+
+    test "creates a span with the tracer span as the parent and a start time", %{
+      tracer_span: parent
+    } do
+      {:ok, [{"http_request", ^parent, start_time: time}]} = Test.Tracer.get(:create_span)
+      assert is_integer(time)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "Commit Appsignal.Test.Repo"}]} = Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert attribute("appsignal:category", "commit.ecto")
+    end
+
+    test "does not set the span's body" do
+      assert Test.Span.get(:set_sql) == :error
+    end
+
+    test "closes the span and the parent tracer span with an end time", %{tracer_span: parent} do
+      {:ok, [{_, _, start_time: start_time}]} = Test.Tracer.get(:create_span)
+
+      {:ok, [{^parent, end_time: end_time}, {%Span{}, end_time: end_time}]} =
+        Test.Tracer.get(:close_span)
+
       assert end_time - start_time == 8_829_000
     end
   end

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -100,7 +100,7 @@ defmodule Appsignal.EctoTest do
     end
 
     test "creates a span with a parent and a start time", %{parent: parent} do
-      {:ok, [{"http_request", parent, start_time: time}]} = Test.Tracer.get(:create_span)
+      {:ok, [{"http_request", ^parent, start_time: time}]} = Test.Tracer.get(:create_span)
       assert is_integer(time)
     end
 
@@ -165,7 +165,7 @@ defmodule Appsignal.EctoTest do
     end
 
     test "creates a span with a parent and a start time", %{parent: parent} do
-      {:ok, [{"http_request", parent, start_time: time}]} = Test.Tracer.get(:create_span)
+      {:ok, [{"http_request", ^parent, start_time: time}]} = Test.Tracer.get(:create_span)
       assert is_integer(time)
     end
 
@@ -223,7 +223,7 @@ defmodule Appsignal.EctoTest do
     end
 
     test "creates a span with a parent and a start time", %{parent: parent} do
-      {:ok, [{"http_request", %Span{}, start_time: time}]} = Test.Tracer.get(:create_span)
+      {:ok, [{"http_request", ^parent, start_time: time}]} = Test.Tracer.get(:create_span)
       assert is_integer(time)
     end
 
@@ -275,7 +275,7 @@ defmodule Appsignal.EctoTest do
     end
 
     test "creates a span with a parent and a start time", %{parent: parent} do
-      {:ok, [{"http_request", %Span{}, start_time: time}]} = Test.Tracer.get(:create_span)
+      {:ok, [{"http_request", ^parent, start_time: time}]} = Test.Tracer.get(:create_span)
       assert is_integer(time)
     end
 
@@ -294,7 +294,7 @@ defmodule Appsignal.EctoTest do
     test "closes the span and its parent with an end time", %{parent: parent} do
       {:ok, [{_, _, start_time: start_time}]} = Test.Tracer.get(:create_span)
 
-      {:ok, [{%Span{}, end_time: end_time}, {parent, end_time: end_time}]} =
+      {:ok, [{^parent, end_time: end_time}, {%Span{}, end_time: end_time}]} =
         Test.Tracer.get(:close_span)
 
       assert end_time - start_time == 8_829_000
@@ -332,7 +332,7 @@ defmodule Appsignal.EctoTest do
     end
 
     test "creates a span with a parent and a start time", %{parent: parent} do
-      {:ok, [{"http_request", parent, start_time: time}]} = Test.Tracer.get(:create_span)
+      {:ok, [{"http_request", ^parent, start_time: time}]} = Test.Tracer.get(:create_span)
       assert is_integer(time)
     end
 
@@ -351,7 +351,7 @@ defmodule Appsignal.EctoTest do
     test "closes the span and its parent with an end time", %{parent: parent} do
       {:ok, [{_, _, start_time: start_time}]} = Test.Tracer.get(:create_span)
 
-      {:ok, [{%Span{}, end_time: end_time}, {parent, end_time: end_time}]} =
+      {:ok, [{^parent, end_time: end_time}, {%Span{}, end_time: end_time}]} =
         Test.Tracer.get(:close_span)
 
       assert end_time - start_time == 8_829_000
@@ -393,7 +393,7 @@ defmodule Appsignal.EctoTest do
     end
 
     test "creates a span with a parent and a start time", %{parent: parent} do
-      {:ok, [{"http_request", parent, start_time: time}]} = Test.Tracer.get(:create_span)
+      {:ok, [{"http_request", ^parent, start_time: time}]} = Test.Tracer.get(:create_span)
       assert is_integer(time)
     end
 


### PR DESCRIPTION
This should fix a customer-reported issue ([Intercom link](https://app.intercom.com/a/inbox/yzor8gyw/inbox/conversation/16410700348838#part_id=comment-16410700348838-21909570055)) where an Ecto transaction performed inside an Ecto parallel preload causes the transaction to be closed early.

It makes sense to me, going from the event timelines reported by the customer, that this is the issue that is taking place: the sample showing the error, where `Appsignal.Ecto.Repo` is used, doesn't show the overarching transaction event or the query within it (because the transaction event is never closed and the query event is orphaned) which are present in the sample where `Ecto.Repo` is used, and it shows a lone commit event, which instead of closing the transaction (its tracer parent, within its process, which was spawned by the parallel preload) would have closed the Oban root span (its telemetry parent, from the root process that initiated the parallel preload)

That said, I have not been able to reproduce it (it is unclear to me how to trigger a transaction within a parallel preload) -- I have asked the customer to try this change, let's wait to hear back before we merge this.

---

### [Actually assert the parent is used](https://github.com/appsignal/appsignal-elixir/commit/40449a4a74ce22f1747cc4c02e1543108fc79475)

Instead of checking that the parent span was used or closed, a new
variable named "parent" was assigned and ignored.

### [Prefer the tracer span to the telemetry span](https://github.com/appsignal/appsignal-elixir/commit/d6333581c2b56d11529c461d14647a860d928d28)

When processing an Ecto event, if both a tracer span and a telemetry
span are present, use the tracer span as the parent.

This should fix an issue where, when an Ecto transaction takes place
inside an Ecto parallel preload, when the transaction's commit or
rollback event attempts to close both its own span and the
overarching transaction span (which would be the tracer parent, within
the parallel preload's sub-process) it instead closes the transaction
span's parent (which would be the telemetry parent, from the process
that spawned the parallel preload) leaving the transaction span
unclosed and potentially cutting the transaction short.