### PR TITLE
Follow `@defoverridable` protocol in Ecto repo

### DIFF
--- a/.changesets/make--appsignal-ecto-repo--s--default_options-1--function-overridable.md
+++ b/.changesets/make--appsignal-ecto-repo--s--default_options-1--function-overridable.md
@@ -1,0 +1,18 @@
+---
+bump: patch
+type: fix
+---
+
+Make `Appsignal.Ecto.Repo`'s `default_options/1` function overridable. If your Ecto repo uses `Appsignal.Ecto.Repo` and implements its own `default_options/1`, it must call `super` to merge its default options with those of `Appsignal.Ecto.Repo`:
+
+```elixir
+defmodule MyEctoRepo
+  use Appsignal.Ecto.Repo
+
+  def default_options(operation) do
+    super(operation) ++ [
+      # ... your default options here ...
+    ]
+  end
+end
+```

--- a/lib/appsignal/ecto_repo.ex
+++ b/lib/appsignal/ecto_repo.ex
@@ -5,13 +5,15 @@ defmodule Appsignal.Ecto.Repo do
     quote do
       use unquote(@ecto_repo), unquote(opts)
 
-      def default_options(atom) do
-        Appsignal.Ecto.Repo.default_options(atom)
+      def default_options(operation) do
+        super(operation) ++ Appsignal.Ecto.Repo.default_options()
       end
+
+      defoverridable default_options: 1
     end
   end
 
-  def default_options(_atom) do
+  def default_options(_operation \\ nil) do
     [
       telemetry_options: [
         _appsignal_current_span: Appsignal.Tracer.current_span()

--- a/test/appsignal/ecto_repo_test.exs
+++ b/test/appsignal/ecto_repo_test.exs
@@ -4,6 +4,17 @@ defmodule Appsignal.TestEctoRepo do
     adapter: Ecto.Adapters.Postgres
 end
 
+defmodule Appsignal.TestEctoRepoWithOverride do
+  use Appsignal.Ecto.Repo
+
+  def default_options(operation) do
+    super(operation) ++
+      [
+        foo: "bar"
+      ]
+  end
+end
+
 defmodule Appsignal.EctoRepoTest do
   use ExUnit.Case
   alias Appsignal.Ecto.Repo
@@ -21,6 +32,15 @@ defmodule Appsignal.EctoRepoTest do
       otp_app: :plug_example,
       adapter: Ecto.Adapters.Postgres
     ]
+  end
+
+  test "use Appsignal.Ecto.Repo can have overriden default options" do
+    assert Appsignal.TestEctoRepoWithOverride.default_options(:all) == [
+             telemetry_options: [
+               _appsignal_current_span: nil
+             ],
+             foo: "bar"
+           ]
   end
 
   describe "use Appsignal.Ecto.Repo, with a root span" do

--- a/test/support/fake_ecto_repo.ex
+++ b/test/support/fake_ecto_repo.ex
@@ -4,6 +4,11 @@ defmodule FakeEctoRepo do
       def get_received_opts do
         unquote(opts)
       end
+
+      # As implemented in `Ecto.Repo`:
+      # https://github.com/elixir-ecto/ecto/blob/9df9b35044d74322cdd5c263b6d593ba98a19c44/lib/ecto/repo.ex#L260-L261
+      def default_options(_operation), do: []
+      defoverridable default_options: 1
     end
   end
 end


### PR DESCRIPTION
I thought this could be the cause of the issue fixed in #958, but I don't think it is anymore. Still, better to fix this corner case before it pokes someone.

Our `Appsignal.Ecto.Repo`, which is meant to be a swap-in replacement for `Ecto.Repo`, should both call `super` on the original `Ecto.Repo` implementation of `default_options` that it overrides, and allow `super` to be called on it by modules that override `default_options`.
