### PR TITLE
Remove Transaction Nif code

### DIFF
--- a/c_src/appsignal_extension.c
+++ b/c_src/appsignal_extension.c
@@ -10,7 +10,6 @@
 #include <unistd.h>
 #include <appsignal.h>
 
-static ErlNifResourceType *appsignal_transaction_type = NULL;
 static ErlNifResourceType *appsignal_data_type = NULL;
 static ErlNifResourceType *appsignal_span_type = NULL;
 
@@ -20,10 +19,6 @@ ERL_NIF_TERM sample_atom;
 ERL_NIF_TERM no_sample_atom;
 ERL_NIF_TERM true_atom;
 ERL_NIF_TERM false_atom;
-
-typedef struct {
-  appsignal_transaction_t *transaction;
-} transaction_ptr;
 
 typedef struct {
   appsignal_data_t *data;
@@ -136,369 +131,6 @@ static ERL_NIF_TERM _stop(ErlNifEnv* env, int UNUSED(arc), const ERL_NIF_TERM UN
 
 static ERL_NIF_TERM _diagnose(ErlNifEnv* env, int UNUSED(arc), const ERL_NIF_TERM UNUSED(argv[])) {
   return make_elixir_string(env, appsignal_diagnose());
-}
-
-static ERL_NIF_TERM _start_transaction(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    ErlNifBinary transaction_id, namespace;
-    transaction_ptr *ptr;
-    ERL_NIF_TERM transaction_ref;
-
-    if (argc != 2) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[0], &transaction_id)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &namespace)) {
-        return enif_make_badarg(env);
-    }
-
-    ptr = enif_alloc_resource(appsignal_transaction_type, sizeof(transaction_ptr));
-    if(!ptr)
-      return make_error_tuple(env, "no_memory");
-
-    ptr->transaction = appsignal_start_transaction(
-        make_appsignal_string(transaction_id),
-        make_appsignal_string(namespace),
-        0
-    );
-
-    transaction_ref = enif_make_resource(env, ptr);
-    enif_release_resource(ptr);
-
-    return make_ok_tuple(env, transaction_ref);
-}
-
-static ERL_NIF_TERM _start_event(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-
-    if (argc != 1) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-
-    appsignal_start_event(ptr->transaction, 0);
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _finish_event(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    ErlNifBinary name, title, body;
-    int bodyFormat;
-
-    if (argc != 5) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &name)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[2], &title)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[3], &body)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_get_int(env, argv[4], &bodyFormat)) {
-        return enif_make_badarg(env);
-    }
-
-    appsignal_finish_event(
-        ptr->transaction,
-        make_appsignal_string(name),
-        make_appsignal_string(title),
-        make_appsignal_string(body),
-        bodyFormat,
-        0
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _finish_event_data(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    ErlNifBinary name, title;
-    int bodyFormat;
-    data_ptr *body;
-
-    if (argc != 5) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &name)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[2], &title)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[3], appsignal_data_type, (void**) &body)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_int(env, argv[4], &bodyFormat)) {
-      return enif_make_badarg(env);
-    }
-
-    appsignal_finish_event_data(
-        ptr->transaction,
-        make_appsignal_string(name),
-        make_appsignal_string(title),
-        body->data,
-        bodyFormat,
-        0
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _record_event(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    ErlNifBinary name, title, body;
-    long duration;
-    int bodyFormat;
-
-    if (argc != 6) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &name)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[2], &title)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[3], &body)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_get_int(env, argv[4], &bodyFormat)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_get_long(env, argv[5], &duration)) {
-        return enif_make_badarg(env);
-    }
-
-    appsignal_record_event(
-        ptr->transaction,
-        make_appsignal_string(name),
-        make_appsignal_string(title),
-        make_appsignal_string(body),
-        bodyFormat,
-        duration,
-        0
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _set_error(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    ErlNifBinary error, message;
-    data_ptr *data_ptr;
-
-    if (argc != 4) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &error)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[2], &message)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[3], appsignal_data_type, (void**) &data_ptr)) {
-      return enif_make_badarg(env);
-    }
-
-    appsignal_set_transaction_error(
-        ptr->transaction,
-        make_appsignal_string(error),
-        make_appsignal_string(message),
-        data_ptr->data
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _set_sample_data(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    ErlNifBinary key;
-    data_ptr *data_ptr;
-
-    if (argc != 3) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &key)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[2], appsignal_data_type, (void**) &data_ptr)) {
-      return enif_make_badarg(env);
-    }
-
-    appsignal_set_transaction_sample_data(
-        ptr->transaction,
-        make_appsignal_string(key),
-        data_ptr->data
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _set_action(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    ErlNifBinary action;
-
-    if (argc != 2) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &action)) {
-        return enif_make_badarg(env);
-    }
-
-    appsignal_set_transaction_action(
-        ptr->transaction,
-        make_appsignal_string(action)
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _set_namespace(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    ErlNifBinary namespace;
-
-    if (argc != 2) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &namespace)) {
-        return enif_make_badarg(env);
-    }
-
-    appsignal_set_transaction_namespace(
-        ptr->transaction,
-        make_appsignal_string(namespace)
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _set_queue_start(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    long start;
-
-    if (argc != 2) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_long(env, argv[1], &start)) {
-        return enif_make_badarg(env);
-    }
-
-    appsignal_set_transaction_queue_start(
-        ptr->transaction,
-        start
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _set_meta_data(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    ErlNifBinary key, value;
-
-    if (argc != 3) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[1], &key)) {
-        return enif_make_badarg(env);
-    }
-    if(!enif_inspect_iolist_as_binary(env, argv[2], &value)) {
-        return enif_make_badarg(env);
-    }
-
-    appsignal_set_transaction_metadata(
-        ptr->transaction,
-        make_appsignal_string(key),
-        make_appsignal_string(value)
-    );
-
-    return ok_atom;
-}
-
-static ERL_NIF_TERM _finish(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-    int sample;
-
-    if (argc != 1) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-
-    sample = appsignal_finish_transaction(ptr->transaction, 0);
-
-    if (sample == 1) {
-      return sample_atom;
-    } else {
-      return no_sample_atom;
-    }
-}
-
-static ERL_NIF_TERM _complete(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    transaction_ptr *ptr;
-
-    if (argc != 1) {
-      return enif_make_badarg(env);
-    }
-    if(!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-      return enif_make_badarg(env);
-    }
-
-    appsignal_complete_transaction(ptr->transaction);
-
-    return ok_atom;
-}
-
-static void destruct_appsignal_transaction(ErlNifEnv *UNUSED(env), void *arg) {
-  transaction_ptr *ptr = (transaction_ptr *)arg;
-  appsignal_free_transaction(ptr->transaction);
 }
 
 static void destruct_appsignal_data(ErlNifEnv *UNUSED(env), void *arg) {
@@ -843,21 +475,6 @@ static ERL_NIF_TERM _data_to_json(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
 
   json = appsignal_data_to_json(ptr->data);
   return make_ok_tuple(env, enif_make_string(env, json.buf, ERL_NIF_LATIN1));
-}
-
-static ERL_NIF_TERM _transaction_to_json(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-  transaction_ptr *ptr;
-  appsignal_string_t json;
-
-  if (argc != 1) {
-    return enif_make_badarg(env);
-  }
-  if (!enif_get_resource(env, argv[0], appsignal_transaction_type, (void**) &ptr)) {
-    return enif_make_badarg(env);
-  }
-
-  json = appsignal_transaction_to_json(ptr->transaction);
-  return make_ok_tuple(env, make_elixir_string(env, json));
 }
 #endif
 
@@ -1357,18 +974,8 @@ static ERL_NIF_TERM _log(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
 
 static int on_load(ErlNifEnv* env, void** UNUSED(priv), ERL_NIF_TERM UNUSED(info))
 {
-    ErlNifResourceType *transaction_resource_type;
     ErlNifResourceType *data_resource_type;
     ErlNifResourceType *span_resource_type;
-
-    transaction_resource_type = enif_open_resource_type(
-        env,
-        "appsignal_nif",
-        "appsignal_transaction_type",
-        destruct_appsignal_transaction,
-        ERL_NIF_RT_CREATE,
-        NULL
-    );
 
     data_resource_type = enif_open_resource_type(
         env,
@@ -1388,10 +995,9 @@ static int on_load(ErlNifEnv* env, void** UNUSED(priv), ERL_NIF_TERM UNUSED(info
         NULL
     );
 
-    if (!transaction_resource_type || !data_resource_type) {
+    if (!data_resource_type) {
       return -1;
     }
-    appsignal_transaction_type = transaction_resource_type;
     appsignal_data_type = data_resource_type;
     appsignal_span_type = span_resource_type;
 
@@ -1424,19 +1030,6 @@ static ErlNifFunc nif_funcs[] =
     {"_start", 0, _start, 0},
     {"_stop", 0, _stop, 0},
     {"_diagnose", 0, _diagnose, 0},
-    {"_start_transaction", 2, _start_transaction, 0},
-    {"_start_event", 1, _start_event, 0},
-    {"_finish_event", 5, _finish_event, 0},
-    {"_finish_event_data", 5, _finish_event_data, 0},
-    {"_record_event", 6, _record_event, 0},
-    {"_set_error", 4, _set_error, 0},
-    {"_set_sample_data", 3, _set_sample_data, 0},
-    {"_set_action", 2, _set_action, 0},
-    {"_set_namespace", 2, _set_namespace, 0},
-    {"_set_queue_start", 2, _set_queue_start, 0},
-    {"_set_meta_data", 3, _set_meta_data, 0},
-    {"_finish", 1, _finish, 0},
-    {"_complete", 1, _complete, 0},
     {"_set_gauge", 3, _set_gauge, 0},
     {"_increment_counter", 3, _increment_counter, 0},
     {"_add_distribution_value", 3, _add_distribution_value, 0},
@@ -1456,7 +1049,6 @@ static ErlNifFunc nif_funcs[] =
     {"_data_list_new", 0, _data_list_new, 0},
     {"_running_in_container", 0, _running_in_container, 0},
 #ifdef TEST
-    {"_transaction_to_json", 1, _transaction_to_json, 0},
     {"_data_to_json", 1, _data_to_json, 0},
 #endif
     {"_loaded", 0, _loaded, 0},

--- a/lib/appsignal/nif.ex
+++ b/lib/appsignal/nif.ex
@@ -56,58 +56,6 @@ defmodule Appsignal.Nif do
     _diagnose()
   end
 
-  def start_transaction(transaction_id, namespace) do
-    _start_transaction(transaction_id, namespace)
-  end
-
-  def start_event(transaction_resource) do
-    _start_event(transaction_resource)
-  end
-
-  def finish_event(transaction_resource, name, title, body, body_format) do
-    _finish_event(transaction_resource, name, title, body, body_format)
-  end
-
-  def finish_event_data(transaction_resource, name, title, body, body_format) do
-    _finish_event_data(transaction_resource, name, title, body, body_format)
-  end
-
-  def record_event(transaction_resource, name, title, body, body_format, duration) do
-    _record_event(transaction_resource, name, title, body, body_format, duration)
-  end
-
-  def set_error(transaction_resource, error, message, backtrace) do
-    _set_error(transaction_resource, error, message, backtrace)
-  end
-
-  def set_sample_data(transaction_resource, key, payload) do
-    _set_sample_data(transaction_resource, key, payload)
-  end
-
-  def set_action(transaction_resource, action) do
-    _set_action(transaction_resource, action)
-  end
-
-  def set_namespace(transaction_resource, namespace) do
-    _set_namespace(transaction_resource, namespace)
-  end
-
-  def set_queue_start(transaction_resource, start) do
-    _set_queue_start(transaction_resource, start)
-  end
-
-  def set_meta_data(transaction_resource, key, value) do
-    _set_meta_data(transaction_resource, key, value)
-  end
-
-  def finish(transaction_resource) do
-    _finish(transaction_resource)
-  end
-
-  def complete(transaction_resource) do
-    _complete(transaction_resource)
-  end
-
   def set_gauge(key, value, tags) do
     _set_gauge(key, value, tags)
   end
@@ -264,10 +212,6 @@ defmodule Appsignal.Nif do
     def data_to_json(reference) do
       _data_to_json(reference)
     end
-
-    def transaction_to_json(resource) do
-      _transaction_to_json(resource)
-    end
   end
 
   def _env_put(_key, _value) do
@@ -296,64 +240,6 @@ defmodule Appsignal.Nif do
 
   def _diagnose do
     :error
-  end
-
-  def _start_transaction(_id, _namespace) do
-    if System.otp_release() >= "20" do
-      {:ok, make_ref()}
-    else
-      {:ok, <<>>}
-    end
-  end
-
-  def _start_event(_transaction_resource) do
-    :ok
-  end
-
-  def _finish_event(_transaction_resource, _name, _title, _body, _body_format) do
-    :ok
-  end
-
-  def _finish_event_data(_transaction_resource, _name, _title, _body, _body_format) do
-    :ok
-  end
-
-  def _record_event(_transaction_resource, _name, _title, _body, _body_format, _duration) do
-    :ok
-  end
-
-  def _set_error(_transaction_resource, _error, _message, _backtrace) do
-    :ok
-  end
-
-  def _set_sample_data(_transaction_resource, _key, _payload) do
-    :ok
-  end
-
-  def _set_action(_transaction_resource, _action) do
-    :ok
-  end
-
-  def _set_namespace(_transaction_resource, _action) do
-    :ok
-  end
-
-  def _set_queue_start(_transaction_resource, _start) do
-    :ok
-  end
-
-  def _set_meta_data(_transaction_resource, _key, _value) do
-    :ok
-  end
-
-  def _finish(_transaction_resource) do
-    # Using `String.to_atom("no_sample") instead of `:no_sample` to trick
-    # Dialyzer into thinking this value isn't hardcoded.
-    String.to_atom("no_sample")
-  end
-
-  def _complete(_transaction_resource) do
-    :ok
   end
 
   def _set_gauge(_key, _value, _tags) do
@@ -511,10 +397,6 @@ defmodule Appsignal.Nif do
   if Mix.env() in [:test, :test_no_nif] do
     def _data_to_json(resource) do
       resource
-    end
-
-    def _transaction_to_json(resource) do
-      {:ok, resource}
     end
   end
 end

--- a/test/appsignal/nif_test.exs
+++ b/test/appsignal/nif_test.exs
@@ -5,7 +5,6 @@ end
 defmodule Appsignal.NifTest do
   alias Appsignal.Nif
   use ExUnit.Case, async: true
-  import AppsignalTest.Utils, only: [reference_or_binary?: 1]
 
   test "whether the agent starts" do
     assert :ok = Nif.start()
@@ -13,12 +12,6 @@ defmodule Appsignal.NifTest do
 
   test "whether the agent stops" do
     assert :ok = Nif.stop()
-  end
-
-  @tag :skip_env_test_no_nif
-  test "starting transaction returns a reference to the transaction resource" do
-    assert {:ok, reference} = Nif.start_transaction("transaction id", "http_request")
-    assert reference_or_binary?(reference)
   end
 
   if Mix.env() not in [:test_no_nif] do


### PR DESCRIPTION
This package uses the Span API. The Transaction API isn't used anymore. Remove the C-extension and Nif code that still call it. Our deprecated Transaction API in Elixir is no-op and doesn't call these Nif functions so we can safely remove them.

[skip changeset]