### PR TITLE
Update config for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,17 @@
-name: CI
+name: Elixir package CI
 
 on:
-  push: {}
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   schedule:
-    - cron: "0 0 * * 1-5"
+    - cron: 0 0 * * 1-5
 
 jobs:
   lint_git:


### PR DESCRIPTION
Trigger CI builds on new PR creation. This also allows us to run the CI for PRs from forks.

The main and develop branch will also run when pushed.

[skip changeset]
[skip review]