### PR TITLE
Load dependencies for `compile.appsignal` task

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,6 +3,8 @@
 defmodule Mix.Tasks.Compile.Appsignal do
   use Mix.Task
 
+  @requirements "loadpaths"
+
   def run(_args) do
     {_, _} = Code.eval_file("mix_helpers.exs")
     Mix.Appsignal.Helper.install()


### PR DESCRIPTION
The `compile.appsignal` task requires dependencies like Jason and Hackney to function. Use `@requirements "loadpaths"` so that the dependencies are loaded when running `mix compile.appsignal`.