### PR TITLE
Add `reported_by` tag to error backend errors

### DIFF
--- a/.changesets/add--reported_by--tag-to-errors-reported-by-the-legacy-error-backend.md
+++ b/.changesets/add--reported_by--tag-to-errors-reported-by-the-legacy-error-backend.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add `reported_by` tag to errors reported by the legacy error backend. This makes it easier to understand whether an error is being reported by the error backend.

--- a/lib/appsignal/error/backend.ex
+++ b/lib/appsignal/error/backend.ex
@@ -90,6 +90,7 @@ defmodule Appsignal.Error.Backend do
   defp set_error_data(span, reason, stacktrace) do
     span
     |> @span.add_error(:error, reason, stacktrace)
+    |> @span.set_sample_data("tags", %{"reported_by" => "error_backend"})
     |> @tracer.close_span()
   end
 end

--- a/test/appsignal/error/backend_test.exs
+++ b/test/appsignal/error/backend_test.exs
@@ -225,6 +225,11 @@ defmodule Appsignal.Error.BackendTest do
       assert is_list(stack)
     end
 
+    test "adds a `reported_by` tag to the created span", %{pid: pid} do
+      assert {:ok, [{%Span{pid: ^pid}, "tags", %{"reported_by" => "error_backend"}} | _]} =
+               Test.Span.get(:set_sample_data)
+    end
+
     test "closes the created span", %{pid: pid} do
       assert {:ok, [{%Span{pid: ^pid}} | _]} = Test.Tracer.get(:close_span)
     end


### PR DESCRIPTION
Motivated by [this Intercom conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/admin/5246522/conversation/16410700366093).

We get support tickets about incomplete error reporting, which we assume is due to the use of the error backend. Often customers do not know whether the error was raised from an uninstrumented context, or whether they're using a version of the integration where the error backend is enabled by default.

This should simplify the support workflow for it going forward, by giving us that information in the error sample itself. We can also ask customers to update to the latest version and see if the affected samples have this tag.

This follows the format that we use in [the Ruby integration][ruby].

[ruby]: https://github.com/appsignal/appsignal-ruby/blob/6201f5dbe662e22e682a8a324b7e996e979ef09f/lib/appsignal/integrations/puma.rb#L21