### PR TITLE
Use parentheses when accessing Tesla's `__middleware__/0`

### DIFF
--- a/.changesets/fix-warning-for-tesla.md
+++ b/.changesets/fix-warning-for-tesla.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix parentheses warning for Tesla on Elixir 1.17.x.

--- a/lib/appsignal/tesla.ex
+++ b/lib/appsignal/tesla.ex
@@ -110,7 +110,7 @@ defmodule Appsignal.Tesla do
     module = Map.get(env, :__module__)
 
     if module != nil and function_exported?(module, :__middleware__, 0) do
-      module.__middleware__
+      module.__middleware__()
     end || []
   end
 


### PR DESCRIPTION
Fix the following warning when compiling against Elixir 1.17.x:

```
warning: using map.field notation (without parentheses) to invoke function [...].Client.__middleware__() is deprecated, you must add parentheses instead: remote.function()
  (appsignal 2.13.0) lib/appsignal/tesla.ex:113: Appsignal.Tesla.module_middlewares/1
  (appsignal 2.13.0) lib/appsignal/tesla.ex:106: Appsignal.Tesla.env_middlewares/1
  (appsignal 2.13.0) lib/appsignal/tesla.ex:45: Appsignal.Tesla.do_tesla_request_start/2
  (telemetry 1.3.0) [...]/elixir/deps/telemetry/src/telemetry.erl:167: anonymous fn/4 in :telemetry.execute/3
  (stdlib 6.1.2) lists.erl:2310: :lists.foreach_1/2
  (tesla 1.12.1) lib/tesla/middleware/telemetry.ex:96: Tesla.Middleware.Telemetry.call/3
  (appsignal 2.13.0) lib/appsignal/instrumentation.ex:10: Appsignal.Instrumentation.instrument/1
```