### PR TITLE
Add Elixir 1.18 to the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         elixir:
-          - 1.17.x
+          - 1.18.x
         otp:
           - 27.x
           - 26.x
@@ -140,6 +140,8 @@ jobs:
           - elixir: main
             otp: 27.x
           - elixir: latest
+            otp: 27.x
+          - elixir: 1.17.x
             otp: 27.x
           - elixir: 1.16.x
             otp: 26.x


### PR DESCRIPTION
And move 1.17 to the includes, testing only against the latest OTP version.

[skip changeset]