### PR TITLE
Close spans on error

### DIFF
--- a/.changesets/close-spans-on-error.md
+++ b/.changesets/close-spans-on-error.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+type: fix
+---
+
+Close instrumentation spans when an error occurs inside the `Appsignal.instrument` helper's function argument. This prevents spans and traces from not being closed properly.
+
+This will no longer fail to close spans:
+
+```elixir
+Appsignal.instrument("event name", fn -> do
+  raise "Oh no!"
+end)
+```

--- a/lib/appsignal/instrumentation.ex
+++ b/lib/appsignal/instrumentation.ex
@@ -7,8 +7,12 @@ defmodule Appsignal.Instrumentation do
   def instrument(fun) do
     span = @tracer.create_span("background_job", @tracer.current_span)
 
-    result = call_with_optional_argument(fun, span)
-    @tracer.close_span(span)
+    result =
+      try do
+        call_with_optional_argument(fun, span)
+      after
+        @tracer.close_span(span)
+      end
 
     result
   end
@@ -68,9 +72,12 @@ defmodule Appsignal.Instrumentation do
     |> @span.set_name(name)
     |> @span.set_attribute("appsignal:category", name)
 
-    result = fun.()
-
-    @tracer.close_span(span)
+    result =
+      try do
+        call_with_optional_argument(fun, span)
+      after
+        @tracer.close_span(span)
+      end
 
     result
   end


### PR DESCRIPTION
When our `Appsignal.instrument` function encounters an error when the function argument raises an error, the span it created would not be closed.

Wrap the function call in a `try` block, and move the close logic to an `after` block to ensure that the span is always closed.

I don't know if `instrument_root` is actually used anywhere. We don't call it anywhere and we haven't documented it, but I'm updating it just in case to match the `instrument` helper function.

Related internal thread:
https://appsignal.slack.com/archives/C7XHXQ7N0/p1739893354569399?thread_ts=1739870246.417719&cid=C7XHXQ7N0