### PR TITLE
Switch Hackney to Finch

### DIFF
--- a/.changesets/switch-hackney-with-finch.md
+++ b/.changesets/switch-hackney-with-finch.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Switch Hackney to Finch as the bundled HTTP client to operate within the integration

--- a/.changesets/switch-the-internal-http-client--hackney--with-finch.md
+++ b/.changesets/switch-the-internal-http-client--hackney--with-finch.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Switch the internal HTTP client (hackney) with Finch

--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -49,7 +49,7 @@ defmodule Appsignal do
       {Appsignal.Monitor, []},
       {Appsignal.Probes, []},
       {Appsignal.CheckIn.Scheduler, []},
-      :hackney_pool.child_spec(:appsignal_transmitter, [])
+      {Finch, name: AppsignalFinch}
     ]
 
     result = Supervisor.start_link(children, strategy: :one_for_one, name: Appsignal.Supervisor)

--- a/lib/appsignal/check_in/scheduler.ex
+++ b/lib/appsignal/check_in/scheduler.ex
@@ -99,10 +99,10 @@ defmodule Appsignal.CheckIn.Scheduler do
     endpoint = "#{config[:logging_endpoint]}/check_ins/json"
 
     case @transmitter.transmit_and_close(endpoint, {Enum.reverse(events), :ndjson}, config) do
-      {:ok, status_code, _} when status_code in 200..299 ->
+      {:ok, %{status: status_code}, _} when status_code in 200..299 ->
         @integration_logger.trace("Transmitted #{description}")
 
-      {:ok, status_code, _} ->
+      {:ok, %{status: status_code}, _} ->
         @integration_logger.error(
           "Failed to transmit #{description}: status code was #{status_code}"
         )

--- a/lib/appsignal/diagnose/report.ex
+++ b/lib/appsignal/diagnose/report.ex
@@ -10,19 +10,19 @@ defmodule Appsignal.Diagnose.Report do
 
   @spec send(map(), map()) :: {:ok, String.t()} | {:error, map()}
   def send(config, report) do
-    case Transmitter.transmit(config[:diagnose_endpoint], {%{diagnose: report}, :json}, config) do
-      {:ok, 200, _, reference} ->
-        {:ok, body} = :hackney.body(reference)
-        :hackney.close(reference)
-
+    case Transmitter.transmit(
+           config[:diagnose_endpoint],
+           {%{diagnose: report}, :json},
+           config,
+           true
+         ) do
+      {:ok, %{status: 200, body: body}} ->
         case Jason.decode(body) do
           {:ok, response} -> {:ok, response["token"]}
           {:error, _} -> {:error, %{status_code: 200, body: body}}
         end
 
-      {:ok, status_code, _, reference} ->
-        {:ok, body} = :hackney.body(reference)
-        :hackney.close(reference)
+      {:ok, %{status: status_code, body: body}} ->
         {:error, %{status_code: status_code, body: body}}
 
       {:error, reason} ->

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -34,7 +34,9 @@ defmodule Appsignal.Finch do
         %{name: name, request: request},
         _config
       ) do
-    do_finch_request_start(@tracer.current_span(), name, request)
+    if !has_prefix(name, "Elixir.AppsignalFinch") do
+      do_finch_request_start(@tracer.current_span(), name, request)
+    end
   end
 
   def finch_request_start(_event, _measurements, _metadata, _config) do
@@ -64,11 +66,31 @@ defmodule Appsignal.Finch do
     |> @span.set_attribute("appsignal:category", "request.finch")
   end
 
-  def finch_request_stop(_event, _measurements, %{request: _request}, _config) do
-    @tracer.close_span(@tracer.current_span())
+  def finch_request_stop(_event, _measurements, %{name: name, request: _request}, _config) do
+    if !has_prefix(name, "Elixir.AppsignalFinch") do
+      if span = @tracer.current_span() do
+        @tracer.close_span(span)
+      end
+    end
   end
 
   def finch_request_stop(_event, _measurements, _metadata, _config) do
     nil
+  end
+
+  defp has_prefix(name, prefix) when is_atom(name) do
+    atom_string = Atom.to_string(name)
+
+    if String.starts_with?(atom_string, "Elixir.") do
+      module_name = String.replace_prefix(atom_string, "Elixir.", "")
+      String.starts_with?(module_name, prefix)
+    else
+      String.starts_with?(atom_string, prefix)
+    end
+  end
+
+  defp has_prefix(name, prefix) when is_binary(name) do
+    name
+    |> String.starts_with?(prefix)
   end
 end

--- a/lib/appsignal/finch.ex
+++ b/lib/appsignal/finch.ex
@@ -34,7 +34,7 @@ defmodule Appsignal.Finch do
         %{name: name, request: request},
         _config
       ) do
-    if !has_prefix(name, "Elixir.AppsignalFinch") do
+    if !has_prefix(name, "AppsignalFinch") do
       do_finch_request_start(@tracer.current_span(), name, request)
     end
   end
@@ -67,7 +67,7 @@ defmodule Appsignal.Finch do
   end
 
   def finch_request_stop(_event, _measurements, %{name: name, request: _request}, _config) do
-    if !has_prefix(name, "Elixir.AppsignalFinch") do
+    if !has_prefix(name, "AppsignalFinch") do
       if span = @tracer.current_span() do
         @tracer.close_span(span)
       end

--- a/lib/appsignal/utils/push_api_key_validator.ex
+++ b/lib/appsignal/utils/push_api_key_validator.ex
@@ -5,11 +5,11 @@ defmodule Appsignal.Utils.PushApiKeyValidator do
   def validate(config) do
     url = "#{config[:endpoint]}/1/auth"
 
-    case Transmitter.transmit_and_close(url, nil, config) do
+    case Transmitter.transmit_and_close(url, nil, config, true) do
       {:ok, 200, _} -> :ok
       {:ok, 401, _} -> {:error, :invalid}
       {:ok, status_code, _} -> {:error, status_code}
-      {:error, reason} -> {:error, reason}
+      {:error, %{reason: reason}} -> {:error, reason}
     end
   end
 end

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
       end
 
     Application.load(:appsignal)
+    Application.ensure_started(:telemetry)
 
     report = %{process: %{uid: @system.uid()}}
 

--- a/mix.exs
+++ b/mix.exs
@@ -103,12 +103,6 @@ defmodule Appsignal.Mixfile do
     system_version = System.version()
     otp_version = System.otp_release()
 
-    hackney_version =
-      case otp_version >= "21" do
-        true -> "~> 1.6 and <= 1.21.0"
-        false -> "1.18.1"
-      end
-
     decorator_version =
       case Version.compare(system_version, "1.5.0") do
         :lt -> "~> 1.2.3"
@@ -140,9 +134,11 @@ defmodule Appsignal.Mixfile do
       end
 
     [
+      {:castore, "~> 1.0"},
+      {:certifi, "~> 2.14"},
       {:decimal, "~> 2.0"},
       {:benchee, "~> 1.0", only: :bench},
-      {:hackney, hackney_version},
+      {:finch, "~> 0.19"},
       {:jason, "~> 1.0"},
       {:decorator, decorator_version},
       {:plug, plug_version, only: [:test, :test_no_nif]},

--- a/test/appsignal/diagnose/report_test.exs
+++ b/test/appsignal/diagnose/report_test.exs
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose.ReportTest do
     end
 
     test "sends the diagnostics report to AppSignal and returns an error" do
-      assert send() == {:error, %{body: "woops", status_code: 500}}
+      assert send() == {:error, %{status_code: 500, body: "woops"}}
     end
   end
 

--- a/test/appsignal/finch_test.exs
+++ b/test/appsignal/finch_test.exs
@@ -142,7 +142,7 @@ defmodule Appsignal.FinchTest do
       :telemetry.execute(
         [:finch, :request, :stop],
         %{},
-        %{request: %{}}
+        %{name: "", request: %{}}
       )
     end
 
@@ -175,7 +175,7 @@ defmodule Appsignal.FinchTest do
       :telemetry.execute(
         [:finch, :request, :exception],
         %{},
-        %{request: %{}}
+        %{name: "", request: %{}}
       )
     end
 

--- a/test/appsignal/finch_test.exs
+++ b/test/appsignal/finch_test.exs
@@ -114,6 +114,76 @@ defmodule Appsignal.FinchTest do
     end
   end
 
+  describe "finch_request_start/4, with an AppsignalFinch event" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      Appsignal.Tracer.create_span("http_request")
+
+      :telemetry.execute(
+        [:finch, :request, :start],
+        %{},
+        %{
+          name: AppsignalFinch,
+          request: %{
+            method: "GET",
+            scheme: :https,
+            path: "/",
+            query: "foo=bar",
+            host: "example.com",
+            port: 443
+          }
+        }
+      )
+    end
+
+    test "does not create a span" do
+      assert Test.Tracer.get(:create_span) == :error
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:finch, :request, :start])
+    end
+  end
+
+  describe "finch_request_stop/4, with an AppsignalFinch event" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+
+      Appsignal.Tracer.create_span("http_request")
+
+      :telemetry.execute(
+        [:finch, :request, :stop],
+        %{},
+        %{
+          name: AppsignalFinch,
+          request: %{
+            method: "GET",
+            scheme: :https,
+            path: "/",
+            query: "foo=bar",
+            host: "example.com",
+            port: 443
+          }
+        }
+      )
+    end
+
+    test "does not close a span" do
+      assert Test.Tracer.get(:close_span) == :error
+    end
+
+    test "does not detach the handler" do
+      assert attached?([:finch, :request, :stop])
+    end
+  end
+
   describe "finch_request_start/4, and finch_request_stop/4 with a root span" do
     setup do
       start_supervised!(Test.Nif)

--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -5,7 +5,7 @@ defmodule Appsignal.TransmitterTest do
   import ExUnit.CaptureLog
 
   setup do
-    Application.put_env(:appsignal, :http_client, FakeHackney)
+    Application.put_env(:appsignal, :http_client, FakeFinch)
 
     on_exit(fn ->
       Application.delete_env(:appsignal, :http_client)

--- a/test/support/appsignal/fake_transmitter.ex
+++ b/test/support/appsignal/fake_transmitter.ex
@@ -34,7 +34,7 @@ defmodule Appsignal.FakeTransmitter do
   def transmit_and_close(url, payload, config) do
     case transmit(url, payload, config) do
       {:ok, status, headers, _reference} ->
-        {:ok, status, headers}
+        {:ok, %{status: status}, headers}
 
       {:error, reason} ->
         {:error, reason}

--- a/test/support/fake_finch.ex
+++ b/test/support/fake_finch.ex
@@ -1,0 +1,9 @@
+defmodule FakeFinch do
+  def build(method, url, headers, body) do
+    [method, url, headers, body]
+  end
+
+  def request([method, url, headers, body], _, options) do
+    [method, url, headers, body, options]
+  end
+end

--- a/test/support/fake_hackney.ex
+++ b/test/support/fake_hackney.ex
@@ -1,5 +1,0 @@
-defmodule FakeHackney do
-  def request(method, url, headers, body, options) do
-    [method, url, headers, body, options]
-  end
-end


### PR DESCRIPTION
**Transition the HTTP client usage from Hackney to Finch to optimize
requests performance.**

Two versions of transmissions are required now, as Finch needs to be run
under the supervision tree. One version is a standalone transmission
that starts and kills the process as soon as the requests is made, and
the other one uses the pool that's created when the integration starts.

Fixes #978
Fixes #981