### PR TITLE
Remove extra changeset

### DIFF
--- a/.changesets/switch-the-internal-http-client--hackney--with-finch.md
+++ b/.changesets/switch-the-internal-http-client--hackney--with-finch.md
@@ -1,6 +1,0 @@
----
-bump: minor
-type: change
----
-
-Switch the internal HTTP client (hackney) with Finch


### PR DESCRIPTION
Remove a duplicated changeset to avoid repeating information in the changelog.

[skip changeset]