### PR TITLE
Fix Finch usage in check-in scheduler

### DIFF
--- a/.changesets/fix-check-in-scheduler.md
+++ b/.changesets/fix-check-in-scheduler.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where the check-in scheduler crashes upon use.

--- a/lib/appsignal/check_in/scheduler.ex
+++ b/lib/appsignal/check_in/scheduler.ex
@@ -98,11 +98,11 @@ defmodule Appsignal.CheckIn.Scheduler do
     config = Appsignal.Config.config()
     endpoint = "#{config[:logging_endpoint]}/check_ins/json"
 
-    case @transmitter.transmit_and_close(endpoint, {Enum.reverse(events), :ndjson}, config) do
-      {:ok, %{status: status_code}, _} when status_code in 200..299 ->
+    case @transmitter.transmit(endpoint, {Enum.reverse(events), :ndjson}, config) do
+      {:ok, %{status: status_code}} when status_code in 200..299 ->
         @integration_logger.trace("Transmitted #{description}")
 
-      {:ok, %{status: status_code}, _} ->
+      {:ok, %{status: status_code}} ->
         @integration_logger.error(
           "Failed to transmit #{description}: status code was #{status_code}"
         )

--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -43,8 +43,6 @@ defmodule Appsignal.Transmitter do
     do_transmit(url, {payload, format}, config, standalone)
   end
 
-  # If you're not interested in the body, only in the status code
-  # and headers, use `transmit_and_close/4` instead.
   def do_transmit(url, {payload, format}, config, standalone) do
     config = config || Appsignal.Config.config()
 
@@ -63,21 +61,6 @@ defmodule Appsignal.Transmitter do
 
     request_fun = if standalone, do: &request_standalone/4, else: &request/4
     request_fun.(:post, url, headers, body)
-  end
-
-  def transmit_and_close(
-        url,
-        payload_and_format \\ {nil, nil},
-        config \\ nil,
-        standalone \\ false
-      ) do
-    case transmit(url, payload_and_format, config, standalone) do
-      {:ok, %{status: status, headers: headers}} ->
-        {:ok, status, headers}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
   end
 
   defp encode_body(nil, _), do: ""

--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -4,6 +4,8 @@ defmodule Appsignal.Transmitter do
   require Logger
 
   def request_standalone(method, url, headers \\ [], body \\ "") do
+    :application.ensure_all_started(:telemetry)
+
     http_client = Application.get_env(:appsignal, :http_client, Finch)
     name = :"AppsignalFinch_#{:erlang.unique_integer([:positive])}"
     {:ok, pid} = Finch.start_link(name: name)

--- a/lib/appsignal/utils/push_api_key_validator.ex
+++ b/lib/appsignal/utils/push_api_key_validator.ex
@@ -5,11 +5,15 @@ defmodule Appsignal.Utils.PushApiKeyValidator do
   def validate(config) do
     url = "#{config[:endpoint]}/1/auth"
 
-    case Transmitter.transmit_and_close(url, nil, config, true) do
-      {:ok, 200, _} -> :ok
-      {:ok, 401, _} -> {:error, :invalid}
-      {:ok, status_code, _} -> {:error, status_code}
+    case Transmitter.transmit(url, nil, config, true) do
+      {:ok, %{status: 200}} -> :ok
+      {:ok, %{status: 401}} -> {:error, :invalid}
+      {:ok, %{status: status_code}} -> {:error, status_code}
+      # If the error is a `Mint.TransportError`, extract the reason
+      # atom from the struct.
       {:error, %{reason: reason}} -> {:error, reason}
+      # Otherwise, return the error as is.
+      {:error, e} -> {:error, e}
     end
   end
 end

--- a/test/appsignal/check_in/scheduler_test.exs
+++ b/test/appsignal/check_in/scheduler_test.exs
@@ -167,7 +167,9 @@ defmodule Appsignal.CheckInSchedulerTest do
     end
 
     test "it logs an error when it receives a non-2xx response" do
-      FakeTransmitter.set_response({:ok, 500, :fake, :fake})
+      FakeTransmitter.set_response(
+        {:ok, %{status: 500, body: :fake, headers: :fake, trailers: :fake}}
+      )
 
       cron = Cron.new("cron-checkin-name")
 

--- a/test/support/appsignal/fake_transmitter.ex
+++ b/test/support/appsignal/fake_transmitter.ex
@@ -6,7 +6,7 @@ defmodule Appsignal.FakeTransmitter do
       fn ->
         %{
           transmitted: [],
-          response: fn -> {:ok, 200, :fake, :fake} end
+          response: fn -> {:ok, %{status: 200, body: :fake, headers: :fake, trailers: :fake}} end
         }
       end,
       name: __MODULE__
@@ -29,16 +29,6 @@ defmodule Appsignal.FakeTransmitter do
     end)
 
     Agent.get(__MODULE__, & &1[:response]).()
-  end
-
-  def transmit_and_close(url, payload, config) do
-    case transmit(url, payload, config) do
-      {:ok, status, headers, _reference} ->
-        {:ok, %{status: status}, headers}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
   end
 
   def transmitted do


### PR DESCRIPTION
Fixes #988. See #983 for context.

---

Remove `Transmitter.transmit_and_close` method. This method existed due to some scenarios where a Hackney connection would be kept open for its body to be read, saturating the Hackney pool.

As such, we previously changed how the transmitter worked, so that either you call `.transmit`, and you're responsible for reading the body and closing the request, or you call `.transmit_and_close`, which takes care of closing the request for you, but does not provide access to the body.

Finch does not seem to have such issues, and as such there is no need for this convenience method.

In the push API key validator, don't assume that the error returned by Finch (which is passed through by `Transmitter.transmit`) is a `Mint.TransportError` with a `:reason` key. Prevent potential pattern-matching errors by accepting differently-shaped errors as well.

In the fake transmitter, which is used by the scheduler tests, make the response returned by the fake transmission be Finch-shaped, not Hackney-shaped. Fix the implementation accordingly.