### PR TITLE
Do not crash on non-printable errors

### DIFF
--- a/.changesets/fix-crashes-when-failing-to-send-check-ins.md
+++ b/.changesets/fix-crashes-when-failing-to-send-check-ins.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where the check-in scheduler would crash when failing to send a check-in due to a network error.

--- a/lib/appsignal/check_in/scheduler.ex
+++ b/lib/appsignal/check_in/scheduler.ex
@@ -108,7 +108,7 @@ defmodule Appsignal.CheckIn.Scheduler do
         )
 
       {:error, reason} ->
-        @integration_logger.error("Failed to transmit #{description}: #{reason}")
+        @integration_logger.error("Failed to transmit #{description}: #{inspect(reason)}")
     end
 
     {

--- a/lib/mix/tasks/appsignal.diagnose.ex
+++ b/lib/mix/tasks/appsignal.diagnose.ex
@@ -410,7 +410,7 @@ defmodule Mix.Tasks.Appsignal.Diagnose do
 
       {:error, %{reason: reason}} ->
         IO.puts("  Error: Something went wrong while submitting the report to AppSignal.")
-        IO.puts(reason)
+        IO.puts(inspect(reason))
     end
   end
 

--- a/test/appsignal/check_in/scheduler_test.exs
+++ b/test/appsignal/check_in/scheduler_test.exs
@@ -207,7 +207,7 @@ defmodule Appsignal.CheckInSchedulerTest do
                      &1,
                      "Failed to transmit cron check-in `cron-checkin-name` start event"
                    ) &&
-                     String.ends_with?(&1, ": fake error"))
+                     String.contains?(&1, "fake error"))
                )
       end)
     end

--- a/test/mix/tasks/appsignal_diagnose_test.exs
+++ b/test/mix/tasks/appsignal_diagnose_test.exs
@@ -1055,8 +1055,10 @@ defmodule Mix.Tasks.Appsignal.DiagnoseTest do
 
       assert String.contains?(
                output,
-               "Error: Something went wrong while submitting the report to AppSignal.\nfoo"
+               "Error: Something went wrong while submitting the report to AppSignal."
              )
+
+      assert String.contains?(output, "foo")
     end
   end
 


### PR DESCRIPTION
Some error types, such as `Mint.TransportError`, which is returned to us via Finch, do not implement `String.Chars`, and as such cannot be printed directly.

Use `inspect` when printing an error obtained (directly or indirectly) from a `.transmit` `{:error, error}` tuple.