### PR TITLE
Add mix appsignal.check_install task

### DIFF
--- a/.changesets/add-mix-task-to-check-the-extension-install.md
+++ b/.changesets/add-mix-task-to-check-the-extension-install.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Add a mix task to check the extension install.
+
+Run `mix appsignal.check_install` to see if the NIF and agent were successfully installed. If not, it will return with exit code 1. Use this in your CI or build step to check if AppSignal was installed correctly before deploying or starting your application.

--- a/lib/appsignal/utils/tasks.ex
+++ b/lib/appsignal/utils/tasks.ex
@@ -9,4 +9,9 @@ defmodule :appsignal_tasks do
     Mix.Tasks.Appsignal.Demo.run(nil)
     :init.stop()
   end
+
+  def check_install do
+    Mix.Tasks.Appsignal.CheckInstall.run(nil)
+    :init.stop()
+  end
 end

--- a/lib/mix/tasks/appsignal.check_install.ex
+++ b/lib/mix/tasks/appsignal.check_install.ex
@@ -1,0 +1,17 @@
+defmodule Mix.Tasks.Appsignal.CheckInstall do
+  use Mix.Task
+
+  def run(_) do
+    Application.ensure_all_started(:appsignal)
+
+    if Appsignal.Nif.loaded?() do
+      IO.puts("The AppSignal NIF was successfully installed and loaded.")
+    else
+      IO.puts(
+        "AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/elixir/command-line/diagnose.html"
+      )
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/test/mix/tasks/appsignal_check_install_test.exs
+++ b/test/mix/tasks/appsignal_check_install_test.exs
@@ -1,0 +1,28 @@
+defmodule Mix.Tasks.Appsignal.CheckInstallTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  defp run do
+    Mix.Tasks.Appsignal.CheckInstall.run([])
+  end
+
+  describe "when successfully installed" do
+    @tag :skip_env_test_no_nif
+    test "prints no error" do
+      output = capture_io(fn -> run() end)
+      assert String.contains?(output, "The AppSignal NIF was successfully installed and loaded.")
+    end
+  end
+
+  describe "when not installed" do
+    @tag :skip_env_test
+    test "prints an error" do
+      output =
+        capture_io(fn ->
+          assert catch_exit(run()) == {:shutdown, 1}
+        end)
+
+      assert String.contains?(output, "AppSignal failed to load the extension.")
+    end
+  end
+end


### PR DESCRIPTION
In a support conversation we discussed how adding a mix task that can check if AppSignal's NIF and agent were successfully installed.

We don't fail the installation if these couldn't be installed because we don't want to breaks applications and prevent them from starting, potentially bringing down whole applications. We rather not report data to AppSignal in this scenario.

For people who do want this behavior, they can run this task before they start their application or as part of their CI.

https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/all/conversation/16410700412377#part_id=comment-16410700412377-21909590891