### PR TITLE
Prevent install from running in test env

### DIFF
--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -22,6 +22,15 @@ defmodule Mix.Appsignal.Helper do
   require Logger
 
   def install do
+    if Enum.member?([:bench, :test, :test_no_nif], Mix.env()) do
+      Mix.shell().info("AppSignal: Skipping agent installation in test environment")
+      :ok
+    else
+      do_install()
+    end
+  end
+
+  def do_install do
     report = initial_report()
 
     case verify_system_architecture(report) do


### PR DESCRIPTION
In Elixir 1.18, `mix test` will attempt to re-run the installation Mix task again. As it's running in test mode, the modules it depends on will have been stubbed out by our test config. But the processes for those modules have not been started yet, so the task crashes.

Guard against this when the task starts and bail out if in test env.

WARNING: This is a draft to work around the issue. I have no idea what unintended effects this has -- can the tests for the helper task even run now? Do not merge this without further testing.