### PR TITLE
Set prefix attribute in Oban start handler

### DIFF
--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -70,6 +70,14 @@ defmodule Appsignal.Oban do
     |> @span.set_attribute("worker", to_string(worker))
     |> @span.set_attribute("appsignal:category", "job.oban")
 
+    # The `:conf` metadata key was added in Oban v2.4.0
+    conf = metadata[:conf]
+
+    if conf && conf.prefix do
+      @span.set_attribute(span, "prefix", to_string(conf.prefix))
+    end
+
+
     # The `:job` metadata key was added in Oban v2.3.1.
     job = metadata[:job]
 

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -123,6 +123,22 @@ defmodule Appsignal.ObanTest do
     end
   end
 
+  describe "oban_job_start/4, with a :conf metadata key (v2.4.0)" do
+    setup do
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      execute_job_start(%{
+        conf: sample_conf()
+      })
+
+      [fake_appsignal: fake_appsignal]
+    end
+
+    test "sets conf prefix as a span tag" do
+      assert has_attribute?("conf")
+    end
+  end
+
   describe "oban_job_stop/4" do
     setup do
       fake_appsignal = start_supervised!(FakeAppsignal)
@@ -657,6 +673,12 @@ defmodule Appsignal.ObanTest do
       id: 123,
       queue: :default,
       attempt: 1
+    }
+  end
+
+  defp sample_conf do
+    %{
+      prefix: "test"
     }
   end
 


### PR DESCRIPTION
Just throwing this out there to see if something like this makes sense to add.

I have a multi tenant application that uses an independent Oban instance for each tenant, identified by the `prefix` value in the config. 

In order to include this information in appsignal data, I have needed to manually copy the value into the metadata. By setting it here, it can be automatically included for all jobs.