### PR TITLE
Remove redundant cron check-in pairs

### DIFF
--- a/.changesets/remove-redundant-cron-check-in-pairs.md
+++ b/.changesets/remove-redundant-cron-check-in-pairs.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Remove redundant cron check-in pairs. When more than one pair of start and finish cron check-in events is reported for the same identifier in the same period, only one of them will be reported to AppSignal.

--- a/lib/appsignal/check_in/scheduler.ex
+++ b/lib/appsignal/check_in/scheduler.ex
@@ -93,6 +93,7 @@ defmodule Appsignal.CheckIn.Scheduler do
 
   @impl true
   def handle_continue({:transmit, events}, state) do
+    events = Event.deduplicate_cron(events)
     description = Event.describe(events)
 
     config = Appsignal.Config.config()


### PR DESCRIPTION
See https://github.com/appsignal/appsignal-ruby/pull/1407 for context. This commit reimplements that in Elixir.

Before submitting a batch of cron check-in events, check for any pairs of events that are redundant with other pairs of cron check-in events. This would happen, for example, when running a `cron` block for a given identifier many times in quick succession.

A redundant pair of cron check-in events is a pair of start and finish cron check-in events for a given identifier, given that another pair of start and finish check-in events exists for that identifier.