### PR TITLE
Report Oban configuration prefix as tag

### DIFF
--- a/.changesets/report-oban-configuration-prefix-as-a-tag.md
+++ b/.changesets/report-oban-configuration-prefix-as-a-tag.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Report Oban's configuration [prefix](https://hexdocs.pm/oban/Oban.Migration.html#module-isolation-with-prefixes) value, if present, as a tag in Oban job samples. Thanks to [@tfwright](https://github.com/tfwright) for suggesting and implementing this feature.

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -70,6 +70,13 @@ defmodule Appsignal.Oban do
     |> @span.set_attribute("worker", to_string(worker))
     |> @span.set_attribute("appsignal:category", "job.oban")
 
+    # The `:conf` metadata key was added in Oban v2.4.0.
+    conf = metadata[:conf]
+
+    if conf && Map.get(conf, :prefix) do
+      @span.set_attribute(span, "prefix", Map.get(conf, :prefix))
+    end
+
     # The `:job` metadata key was added in Oban v2.3.1.
     job = metadata[:job]
 

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -123,6 +123,24 @@ defmodule Appsignal.ObanTest do
     end
   end
 
+  describe "oban_job_start/4, with a :conf metadata key (v2.4.0)" do
+    test "sets the prefix as a span tag if present" do
+      execute_job_start(%{
+        conf: sample_conf(prefix: "foo")
+      })
+
+      assert attribute?("prefix", "foo")
+    end
+
+    test "does not set the prefix as a span tag if not present" do
+      execute_job_start(%{
+        conf: sample_conf()
+      })
+
+      assert !has_attribute?("prefix")
+    end
+  end
+
   describe "oban_job_stop/4" do
     setup do
       fake_appsignal = start_supervised!(FakeAppsignal)
@@ -681,5 +699,28 @@ defmodule Appsignal.ObanTest do
         worker: :"Test.Worker"
       }
     }
+  end
+
+  defp sample_conf(opts \\ []) do
+    Appsignal.ObanTest.ObanConfig.new(opts)
+  end
+end
+
+# A struct that emulates the `Oban.Config` struct:
+# https://github.com/oban-bg/oban/blob/8b0aada8b2bdbe7a338c34c87a5f3c079e9800ad/lib/oban/config.ex#L32-L47
+defmodule Appsignal.ObanTest.ObanConfig do
+  @moduledoc false
+
+  defstruct prefix: false
+
+  # A subset of `Oban.Config`'s typing:
+  # https://hexdocs.pm/oban/Oban.Config.html#t:t/0
+  @type t :: %__MODULE__{
+          prefix: false | String.t()
+        }
+
+  @doc false
+  def new(opts) do
+    struct!(__MODULE__, opts)
   end
 end


### PR DESCRIPTION
Following up on #997. See also test setup: https://github.com/appsignal/test-setups/pull/295

Report the `:prefix` key of the Oban configuration as a tag, if present.