### PR TITLE
Improve Oban result attribute

### DIFF
--- a/.changesets/fix-oban-result-attribute.md
+++ b/.changesets/fix-oban-result-attribute.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: change
+---
+
+Update the `result` attribute reported for Oban jobs. Instead of it including the job's whole return value, it only contains the Oban job control value: `:ok`/`:error`/`:discard`/`:cancel`/`:snooze`.
+The reason for a discard, cancel, error or snooze result will be stored in the new `result_reason` attribute.
+Any `:ok` result reasons and unexpected result values are ignored. This is to avoid storing sensitive data in the attributes and to make it easier to filter by job control value in the interface.

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -261,14 +261,27 @@ defmodule Appsignal.Oban do
     case result_value do
       :ok -> {"ok", nil}
       :discard -> {"discard", nil}
-      {:cancel, reason} -> {"cancel", reason}
-      {:discard, reason} -> {"discard", reason}
+      {:cancel, reason} -> {"cancel", oban_map_reason(reason)}
+      {:discard, reason} -> {"discard", oban_map_reason(reason)}
       {:ok, _} -> {:ok, nil}
-      {:error, reason} -> {"error", reason}
-      {:snooze, reason} -> {"snooze", reason}
+      {:error, reason} -> {"error", oban_map_reason(reason)}
+      {:snooze, reason} -> {"snooze", oban_map_reason(reason)}
       # A job can technically return anything that's not a valid Oban.Worker 'result' type.
       # Account for this here and consider it a success, like Oban does.
       _ -> {"ok", nil}
+    end
+  end
+
+  defp oban_map_reason(value) do
+    case value do
+      v when is_binary(v) ->
+        v
+
+      v when is_integer(v) or is_float(v) or is_boolean(v) or is_atom(v) ->
+        to_string(v)
+
+      _ ->
+        inspect(value)
     end
   end
 end

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -243,7 +243,15 @@ defmodule Appsignal.ObanTest do
         {{:discard, "discard reason"}, "discard", "discard reason"},
         {{:ok, "something"}, "ok", nil},
         {{:error, "error reason"}, "error", "error reason"},
-        {{:snooze, 1_001}, "snooze", 1_001},
+        {{:snooze, 1_001}, "snooze", "1001"},
+
+        # Testing some non-string values and their conversions into strings
+        {{:cancel, :my_reason}, "cancel", "my_reason"},
+        {{:cancel, true}, "cancel", "true"},
+        {{:cancel, false}, "cancel", "false"},
+        {{:cancel, -12.35}, "cancel", "-12.35"},
+        {{:cancel, [abc: :def]}, "cancel", "[abc: :def]"},
+        {{:cancel, 0..255}, "cancel", "0..255"},
         {"other value", "ok", nil}
       ]
       |> Enum.each(fn {return_value, expected_value, expected_reason} ->


### PR DESCRIPTION
First, split out the result value into its expected tuple values. Only store expected value formats, and not any random value the Oban worker's `perform` function can return.
This prevents us storing unintended and potentially sensitive data.

Store the reasons for discard, cancel and snooze result into a new `result_reason` field, so it's easier to search by. The ok reason is ignored, matching the Oban.Worker's result type.

Source:
https://hexdocs.pm/oban/Oban.Worker.html#t:result/0

- [Support conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/conversation/215468907591572?view=List)