### PR TITLE
Disable fail fast on CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         elixir:
           - 1.18.x


### PR DESCRIPTION
Let us see the result of all jobs and not exit all running jobs when one fails.

[skip changeset]
[skip review]