### PR TITLE
Add `nginx_port` configuration option

### DIFF
--- a/.changesets/add--nginx_port--configuration-option.md
+++ b/.changesets/add--nginx_port--configuration-option.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add `nginx_port` configuration option. This configuration option can be used to customize the port on which the AppSignal integration exposes [the NGINX metrics server](https://docs.appsignal.com/metrics/nginx.html).

--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -323,6 +323,7 @@ defmodule Appsignal.Config do
     "APPSIGNAL_LOG_LEVEL" => :log_level,
     "APPSIGNAL_LOG_PATH" => :log_path,
     "APPSIGNAL_LOGGING_ENDPOINT" => :logging_endpoint,
+    "APPSIGNAL_NGINX_PORT" => :nginx_port,
     "APPSIGNAL_OTP_APP" => :otp_app,
     "APPSIGNAL_PUSH_API_ENDPOINT" => :endpoint,
     "APPSIGNAL_PUSH_API_KEY" => :push_api_key,
@@ -344,7 +345,7 @@ defmodule Appsignal.Config do
     APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_KEY APPSIGNAL_PUSH_API_ENDPOINT APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH
     APPSIGNAL_HOSTNAME APPSIGNAL_HOST_ROLE APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG APPSIGNAL_LOG_LEVEL APPSIGNAL_LOG_PATH
     APPSIGNAL_LOGGING_ENDPOINT APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_WORKING_DIRECTORY_PATH APPSIGNAL_CA_FILE_PATH
-    APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION APPSIGNAL_REPORT_OBAN_ERRORS APPSIGNAL_STATSD_PORT
+    APPSIGNAL_DIAGNOSE_ENDPOINT APP_REVISION APPSIGNAL_REPORT_OBAN_ERRORS APPSIGNAL_STATSD_PORT APPSIGNAL_NGINX_PORT
     APPSIGNAL_BIND_ADDRESS
   )
   @bool_keys ~w(
@@ -484,6 +485,7 @@ defmodule Appsignal.Config do
     Nif.env_put("_APPSIGNAL_SEND_PARAMS", to_string(config[:send_params]))
     Nif.env_put("_APPSIGNAL_SEND_SESSION_DATA", to_string(config[:send_session_data]))
     Nif.env_put("_APPSIGNAL_STATSD_PORT", to_string(config[:statsd_port]))
+    Nif.env_put("_APPSIGNAL_NGINX_PORT", to_string(config[:nginx_port]))
     Nif.env_put("_APPSIGNAL_RUNNING_IN_CONTAINER", to_string(config[:running_in_container]))
     Nif.env_put("_APPSIGNAL_TRANSACTION_DEBUG_MODE", to_string(config[:transaction_debug_mode]))
     Nif.env_put("_APPSIGNAL_WORKING_DIRECTORY_PATH", to_string(config[:working_directory_path]))

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -639,6 +639,10 @@ defmodule Appsignal.ConfigTest do
       assert %{statsd_port: "3000"} = with_config(%{statsd_port: "3000"}, &init_config/0)
     end
 
+    test "nginx_port" do
+      assert %{nginx_port: "4321"} = with_config(%{nginx_port: "4321"}, &init_config/0)
+    end
+
     test "transaction_debug_mode" do
       assert %{transaction_debug_mode: true} =
                with_config(%{transaction_debug_mode: true}, &init_config/0)
@@ -1052,6 +1056,13 @@ defmodule Appsignal.ConfigTest do
                &init_config/0
              ) == default_configuration() |> Map.put(:revision, "03bd9e")
     end
+
+    test "nginx_port" do
+      assert with_env(
+               %{"APPSIGNAL_NGINX_PORT" => "4321"},
+               &init_config/0
+             ) == default_configuration() |> Map.put(:nginx_port, "4321")
+    end
   end
 
   describe "config based on system" do
@@ -1216,6 +1227,7 @@ defmodule Appsignal.ConfigTest do
       assert Nif.env_get("_APPSIGNAL_WORKING_DIRECTORY_PATH") == ~c""
       assert Nif.env_get("_APPSIGNAL_RUNNING_IN_CONTAINER") == ~c""
       assert Nif.env_get("_APPSIGNAL_STATSD_PORT") == ~c""
+      assert Nif.env_get("_APPSIGNAL_NGINX_PORT") == ~c""
       assert Nif.env_get("_APP_REVISION") == ~c""
     end
 
@@ -1271,7 +1283,8 @@ defmodule Appsignal.ConfigTest do
           transaction_debug_mode: true,
           filter_parameters: ["password", "confirm_password"],
           filter_session_data: ["key1", "key2"],
-          statsd_port: "3000"
+          statsd_port: "3000",
+          nginx_port: "1234"
         },
         fn ->
           without_logger(&write_to_environment/0)
@@ -1318,6 +1331,7 @@ defmodule Appsignal.ConfigTest do
           assert Nif.env_get("_APPSIGNAL_FILTER_SESSION_DATA") == ~c"key1,key2"
           assert Nif.env_get("_APPSIGNAL_SEND_ENVIRONMENT_METADATA") == ~c"true"
           assert Nif.env_get("_APPSIGNAL_STATSD_PORT") == ~c"3000"
+          assert Nif.env_get("_APPSIGNAL_NGINX_PORT") == ~c"1234"
           assert Nif.env_get("_APP_REVISION") == ~c"03bd9e"
         end
       )


### PR DESCRIPTION
**⚠️ This PR cannot be merged until a release of the agent containing appsignal/appsignal-agent#1275 has been released and its agent file merged into this repository. ⚠️** 

Implement an `nginx_port` configuration option that is passed on to the agent, like the existing `statsd_port` and `opentelemetry_port` configuration options.