### PR TITLE
Fix compilation on Elixir main

### DIFF
--- a/test/appsignal/error/backend_test.exs
+++ b/test/appsignal/error/backend_test.exs
@@ -14,9 +14,7 @@ defmodule Murphy do
 
   def call(pid, fun) do
     ExUnit.CaptureLog.capture_log(fn ->
-      catch_exit do
-        GenServer.call(pid, fun)
-      end
+      catch_exit(GenServer.call(pid, fun))
     end)
   end
 


### PR DESCRIPTION
It looks like the `do end` block no longer works for `catch_exit`.

The only thing it seems to do is catch an exit if one occurs, not assert if it happens. If we remove it the tests fails on the errors we assert on the spans that bubble up from the GenServer.

Directly pass in the GenServer call, like in the docs example:

```elixir
assert catch_exit(exit(1)) == 1
```

https://hexdocs.pm/ex_unit/ExUnit.Assertions.html#catch_exit/1

[skip changeset]