### PR TITLE
Scope working_directory_path by otp_app

### DIFF
--- a/lib/appsignal/config.ex
+++ b/lib/appsignal/config.ex
@@ -91,6 +91,18 @@ defmodule Appsignal.Config do
   defp determine_overrides(config) do
     %{}
     |> Map.merge(skip_session_data_backwards_compatibility(config, config[:skip_session_data]))
+    |> Map.merge(default_working_directory_path(config))
+  end
+
+  defp default_working_directory_path(config) do
+    if empty?(config[:working_directory_path]) && empty?(config[:working_dir_path]) &&
+         present?(config[:otp_app]) do
+      path = Path.join(FileSystem.system_tmp_dir(), "appsignal-#{config[:otp_app]}")
+
+      %{working_directory_path: path}
+    else
+      %{}
+    end
   end
 
   defp skip_session_data_backwards_compatibility(config, nil) do
@@ -404,6 +416,8 @@ defmodule Appsignal.Config do
   defp empty?(""), do: true
   defp empty?([]), do: true
   defp empty?(_), do: false
+
+  defp present?(value), do: !empty?(value)
 
   defp true?("true"), do: true
   defp true?(true), do: true

--- a/test/appsignal/config_test.exs
+++ b/test/appsignal/config_test.exs
@@ -7,6 +7,7 @@ defmodule Appsignal.ConfigTest do
   import AppsignalTest.Utils
   import ExUnit.CaptureIO
   alias Appsignal.{Config, Nif}
+  alias Appsignal.Utils.FileSystem
 
   setup do
     environment = freeze_environment()
@@ -665,6 +666,32 @@ defmodule Appsignal.ConfigTest do
                with_config(%{working_directory_path: "/tmp/appsignal"}, &init_config/0)
     end
 
+    test "working_directory_path defaults to <tmp>/appsignal-<otp_app> when otp_app is set" do
+      tmp = FileSystem.system_tmp_dir()
+      assert %{working_directory_path: path} = with_config(%{otp_app: :my_app}, &init_config/0)
+      assert path == Path.join(tmp, "appsignal-my_app")
+    end
+
+    test "working_directory_path is not defaulted when otp_app is nil" do
+      config = with_config(%{otp_app: nil}, &init_config/0)
+      refute Map.has_key?(config, :working_directory_path)
+    end
+
+    test "explicit working_directory_path takes precedence over otp_app default" do
+      assert %{working_directory_path: "/tmp/custom"} =
+               with_config(
+                 %{otp_app: :my_app, working_directory_path: "/tmp/custom"},
+                 &init_config/0
+               )
+    end
+
+    test "explicit working_dir_path takes precedence over otp_app default" do
+      without_logger(fn ->
+        config = with_config(%{otp_app: :my_app, working_dir_path: "/tmp/custom"}, &init_config/0)
+        refute Map.has_key?(config, :working_directory_path)
+      end)
+    end
+
     test "send_environment_metadata" do
       assert %{send_environment_metadata: false} =
                with_config(%{send_environment_metadata: false}, &init_config/0)
@@ -920,10 +947,18 @@ defmodule Appsignal.ConfigTest do
     end
 
     test "otp_app" do
+      tmp = FileSystem.system_tmp_dir()
+
       assert with_env(
                %{"APPSIGNAL_OTP_APP" => "appsignal_phoenix_example"},
                &init_config/0
-             ) == default_configuration() |> Map.put(:otp_app, :appsignal_phoenix_example)
+             ) ==
+               default_configuration()
+               |> Map.put(:otp_app, :appsignal_phoenix_example)
+               |> Map.put(
+                 :working_directory_path,
+                 Path.join(tmp, "appsignal-appsignal_phoenix_example")
+               )
     end
 
     test "name" do


### PR DESCRIPTION
When multiple Phoenix apps run on the same server, they all default to `/tmp/appsignal` and share one agent socket. The first app to boot "owns" the socket — all subsequent apps connect to it, sending their telemetry under the wrong API key.

This PR scopes `working_directory_path` to `<tmp>/appsignal-<otp_app>` when `otp_app` is set and no explicit path is configured. Apps in the cluster (multiple OS processes, same `otp_app`) still share one agent as intended.

Explicit `working_directory_path` or `working_dir_path` values always take precedence.

Related to #278 and #363.