### PR TITLE
Update Decimal dependency to 3.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -162,7 +162,7 @@ defmodule Appsignal.Mixfile do
     [
       {:castore, "~> 1.0"},
       {:certifi, "~> 2.14"},
-      {:decimal, "~> 3.0"},
+      {:decimal, "3.1.0"},
       {:benchee, "~> 1.0", only: :bench},
       {:finch, "~> 0.19"},
       {:jason, "~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -162,7 +162,7 @@ defmodule Appsignal.Mixfile do
     [
       {:castore, "~> 1.0"},
       {:certifi, "~> 2.14"},
-      {:decimal, "~> 2.0"},
+      {:decimal, "~> 3.0"},
       {:benchee, "~> 1.0", only: :bench},
       {:finch, "~> 0.19"},
       {:jason, "~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -162,7 +162,7 @@ defmodule Appsignal.Mixfile do
     [
       {:castore, "~> 1.0"},
       {:certifi, "~> 2.14"},
-      {:decimal, "3.1.0"},
+      {:decimal, "~> 2.0 or ~> 3.1"},
       {:benchee, "~> 1.0", only: :bench},
       {:finch, "~> 0.19"},
       {:jason, "~> 1.0"},


### PR DESCRIPTION
Pins Decimal to `3.1.0`.

This is a dependency constraint update; I did not find direct Decimal API usage in the codebase.

Verification:
- `mix deps.get`
- `MIX_ENV=test_no_nif mix compile`

I also tried `MIX_ENV=test_no_nif mix test`, but the run is currently blocked by an existing Finch option compatibility error (`:ssl_options` / `:pool`) in the transmitter path before this Decimal change is exercised.

[skip changeset]
