### PR TITLE
Move SSL and proxy options to pool config

### DIFF
--- a/lib/appsignal.ex
+++ b/lib/appsignal.ex
@@ -54,7 +54,7 @@ defmodule Appsignal do
       {Appsignal.Monitor, []},
       {Appsignal.Probes, []},
       {Appsignal.CheckIn.Scheduler, []},
-      {Finch, name: AppsignalFinch}
+      {Finch, name: AppsignalFinch, pools: %{default: Appsignal.Transmitter.pool_options()}}
     ]
 
     result = Supervisor.start_link(children, strategy: :one_for_one, name: Appsignal.Supervisor)

--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -13,7 +13,7 @@ defmodule Appsignal.Transmitter do
     try do
       method
       |> http_client.build(url, headers, body)
-      |> http_client.request(name, [])
+      |> http_client.request(name)
     after
       Process.exit(pid, :normal)
     end
@@ -24,7 +24,7 @@ defmodule Appsignal.Transmitter do
 
     method
     |> http_client.build(url, headers, body)
-    |> http_client.request(AppsignalFinch, [])
+    |> http_client.request(AppsignalFinch)
   end
 
   @doc false

--- a/lib/appsignal/transmitter.ex
+++ b/lib/appsignal/transmitter.ex
@@ -8,12 +8,12 @@ defmodule Appsignal.Transmitter do
 
     http_client = Application.get_env(:appsignal, :http_client, Finch)
     name = :"AppsignalFinch_#{:erlang.unique_integer([:positive])}"
-    {:ok, pid} = Finch.start_link(name: name)
+    {:ok, pid} = Finch.start_link(name: name, pools: %{default: pool_options(url)})
 
     try do
       method
       |> http_client.build(url, headers, body)
-      |> http_client.request(name, options())
+      |> http_client.request(name, [])
     after
       Process.exit(pid, :normal)
     end
@@ -24,8 +24,23 @@ defmodule Appsignal.Transmitter do
 
     method
     |> http_client.build(url, headers, body)
-    |> http_client.request(AppsignalFinch, options())
+    |> http_client.request(AppsignalFinch, [])
   end
+
+  @doc false
+  def pool_options(url \\ nil) do
+    if https?(url) do
+      case ssl_options() do
+        [] -> []
+        ssl_opts -> [conn_opts: [transport_opts: ssl_opts]]
+      end
+    else
+      []
+    end
+  end
+
+  defp https?(nil), do: true
+  defp https?(url), do: String.starts_with?(url, "https://")
 
   def transmit(url, payload_and_format \\ {nil, nil}, config \\ nil)
 
@@ -73,27 +88,17 @@ defmodule Appsignal.Transmitter do
     |> Enum.map_join("\n", &Jason.encode!/1)
   end
 
-  defp options do
-    ssl_options() ++
-      [
-        pool: :appsignal_transmitter
-      ]
-  end
-
   defp ssl_options do
     ca_file_path = Appsignal.Config.ca_file_path()
 
-    options =
+    result =
       case File.stat(ca_file_path) do
         {:ok, %{access: access}} when access in [:read, :read_write] ->
           {:ok,
            [
-             ssl_options:
-               [
-                 verify: :verify_peer,
-                 cacertfile: ca_file_path
-               ] ++ tls_options() ++ customize_hostname_check_or_verify_fun()
-           ]}
+             verify: :verify_peer,
+             cacertfile: ca_file_path
+           ] ++ tls_options() ++ customize_hostname_check_or_verify_fun()}
 
         {:ok, %{access: access}} ->
           {:error, "File access is #{inspect(access)}"}
@@ -102,7 +107,7 @@ defmodule Appsignal.Transmitter do
           {:error, reason}
       end
 
-    case options do
+    case result do
       {:ok, options} ->
         options
 

--- a/mix.exs
+++ b/mix.exs
@@ -123,6 +123,12 @@ defmodule Appsignal.Mixfile do
         _ -> "~> 1.2.3 or ~> 1.3"
       end
 
+    finch_version =
+      case Version.compare(system_version, "1.15.0") do
+        :lt -> ">= 0.19.0 and < 0.22.0"
+        _ -> "~> 0.19"
+      end
+
     telemetry_version =
       case otp_version < "21" do
         true -> "~> 0.4"
@@ -164,7 +170,7 @@ defmodule Appsignal.Mixfile do
       {:certifi, "~> 2.14"},
       {:decimal, "~> 2.0 or ~> 3.1"},
       {:benchee, "~> 1.0", only: :bench},
-      {:finch, "~> 0.19"},
+      {:finch, finch_version},
       {:jason, "~> 1.0"},
       {:decorator, decorator_version},
       {:plug, plug_version, only: [:test, :test_no_nif]},

--- a/mix_helpers.exs
+++ b/mix_helpers.exs
@@ -173,7 +173,12 @@ defmodule Mix.Appsignal.Helper do
 
       false ->
         Mix.shell().info("Downloading agent release")
-        {:ok, pid} = @finch.start_link(name: AppsignalFinchDownload)
+
+        {:ok, pid} =
+          @finch.start_link(
+            name: AppsignalFinchDownload,
+            pools: %{default: [conn_opts: download_conn_opts()]}
+          )
 
         try do
           case do_download_file!(filename, local_filename, @agent.mirrors()) do
@@ -244,7 +249,7 @@ defmodule Mix.Appsignal.Helper do
   defp do_download_file!(url, local_filename) do
     request =
       @finch.build(:get, url, [], "")
-      |> @finch.request(AppsignalFinchDownload, download_options())
+      |> @finch.request(AppsignalFinchDownload, [])
 
     case request do
       {:ok, %{status: 200, body: body}} ->
@@ -265,7 +270,7 @@ defmodule Mix.Appsignal.Helper do
     Enum.join([mirror, version, filename], "/")
   end
 
-  defp download_options do
+  defp download_conn_opts do
     default_cacert_file_path = priv_path("cacert.pem")
 
     cacert_file =
@@ -283,22 +288,29 @@ defmodule Mix.Appsignal.Helper do
           :certifi.cacertfile()
       end
 
-    options = [
-      ssl_options:
-        [
-          verify: :verify_peer,
-          cacertfile: cacert_file
-        ] ++ tls_options() ++ customize_hostname_check_or_verify_fun()
-    ]
+    transport_opts =
+      [
+        verify: :verify_peer,
+        cacertfile: cacert_file
+      ] ++ tls_options() ++ customize_hostname_check_or_verify_fun()
+
+    conn_opts = [transport_opts: transport_opts]
 
     case check_proxy() do
       nil ->
-        options
+        conn_opts
 
       {var, url} ->
         Mix.shell().info("- using proxy from #{var} (#{url})")
-        options ++ [proxy: url]
+        conn_opts ++ [proxy: parse_proxy(url)]
     end
+  end
+
+  defp parse_proxy(url) do
+    uri = URI.parse(url)
+    scheme = if uri.scheme == "https", do: :https, else: :http
+    port = uri.port || if scheme == :https, do: 443, else: 80
+    {scheme, uri.host, port, []}
   end
 
   defp check_cacert_access(cacert_path) do

--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -24,10 +24,9 @@ defmodule Appsignal.TransmitterTest do
         hostname: "some_hostname"
       }
 
-      [method, url, headers, body, options] = Transmitter.transmit(url, {payload, :json}, config)
+      [method, url, headers, body, _options] = Transmitter.transmit(url, {payload, :json}, config)
 
       assert method == :post
-      assert options == []
 
       # The order in which the query parameters are serialized is not
       # stable across Elixir versions.

--- a/test/appsignal/transmitter_test.exs
+++ b/test/appsignal/transmitter_test.exs
@@ -24,9 +24,10 @@ defmodule Appsignal.TransmitterTest do
         hostname: "some_hostname"
       }
 
-      [method, url, headers, body, _options] = Transmitter.transmit(url, {payload, :json}, config)
+      [method, url, headers, body, options] = Transmitter.transmit(url, {payload, :json}, config)
 
       assert method == :post
+      assert options == []
 
       # The order in which the query parameters are serialized is not
       # stable across Elixir versions.
@@ -79,70 +80,64 @@ defmodule Appsignal.TransmitterTest do
     end
   end
 
-  test "uses the default CA certificate" do
-    [_method, _url, _headers, _body, options] =
-      Transmitter.request(:get, "https://example.com")
+  describe "pool_options/0" do
+    test "uses the default CA certificate" do
+      ssl_options = Transmitter.pool_options() |> get_in([:conn_opts, :transport_opts])
 
-    ssl_options = Keyword.get(options, :ssl_options)
+      assert ssl_options[:verify] == :verify_peer
+      assert ssl_options[:cacertfile] == Config.ca_file_path()
 
-    assert ssl_options[:verify] == :verify_peer
-    assert ssl_options[:cacertfile] == Config.ca_file_path()
+      if System.otp_release() >= "23" do
+        assert ssl_options[:versions] == [:"tlsv1.3", :"tlsv1.2"]
+        refute Keyword.has_key?(ssl_options, :depth)
+        refute Keyword.has_key?(ssl_options, :ciphers)
+        refute Keyword.has_key?(ssl_options, :honor_cipher_order)
+      else
+        refute Keyword.has_key?(ssl_options, :versions)
+        assert ssl_options[:depth] == 4
+        assert ssl_options[:honor_cipher_order] == :undefined
+        assert ssl_options[:ciphers] == :ssl.cipher_suites(:default, :"tlsv1.2")
+      end
 
-    if System.otp_release() >= "23" do
-      assert ssl_options[:versions] == [:"tlsv1.3", :"tlsv1.2"]
-      refute Keyword.has_key?(ssl_options, :depth)
-      refute Keyword.has_key?(ssl_options, :ciphers)
-      refute Keyword.has_key?(ssl_options, :honor_cipher_order)
-    else
-      refute Keyword.has_key?(ssl_options, :versions)
-      assert ssl_options[:depth] == 4
-      assert ssl_options[:honor_cipher_order] == :undefined
-      assert ssl_options[:ciphers] == :ssl.cipher_suites(:default, :"tlsv1.2")
+      if System.otp_release() >= "21" do
+        assert ssl_options[:customize_hostname_check] == [
+                 match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+               ]
+
+        refute Keyword.has_key?(ssl_options, :verify_fun)
+      else
+        assert match?(
+                 {fun, pid} when is_function(fun, 3) and is_pid(pid),
+                 ssl_options[:verify_fun]
+               )
+
+        refute Keyword.has_key?(ssl_options, :customize_hostname_check)
+      end
     end
 
-    if System.otp_release() >= "21" do
-      assert ssl_options[:customize_hostname_check] == [
-               match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-             ]
+    test "uses the configured CA certificate" do
+      path = "priv/cacert.pem"
 
-      refute Keyword.has_key?(ssl_options, :verify_fun)
-    else
-      assert match?(
-               {fun, pid} when is_function(fun, 3) and is_pid(pid),
-               ssl_options[:verify_fun]
-             )
+      with_config(%{ca_file_path: path}, fn ->
+        ssl_options = Transmitter.pool_options() |> get_in([:conn_opts, :transport_opts])
 
-      refute Keyword.has_key?(ssl_options, :customize_hostname_check)
+        assert ssl_options[:cacertfile] == path
+      end)
     end
-  end
 
-  test "uses the configured CA certificate" do
-    path = "priv/cacert.pem"
+    test "logs a warning when the CA certificate file does not exist" do
+      path = "test/fixtures/does_not_exist.pem"
 
-    with_config(%{ca_file_path: path}, fn ->
-      [_method, _url, _headers, _body, options] =
-        Transmitter.request(:get, "https://example.com")
+      with_config(%{ca_file_path: path}, fn ->
+        log =
+          capture_log(fn ->
+            assert Transmitter.pool_options() == []
+          end)
 
-      ssl_options = Keyword.get(options, :ssl_options)
-      assert ssl_options[:cacertfile] == path
-    end)
-  end
-
-  test "logs a warning when the CA certificate file does not exist" do
-    path = "test/fixtures/does_not_exist.pem"
-
-    with_config(%{ca_file_path: path}, fn ->
-      log =
-        capture_log(fn ->
-          [_method, _url, _headers, _body, options] =
-            Transmitter.request(:get, "https://example.com")
-
-          refute Keyword.has_key?(options, :ssl_options)
-        end)
-
-      # credo:disable-for-lines:2 Credo.Check.Readability.MaxLineLength
-      assert log =~
-               ~r/\[warn(ing)?\](\s{1,2})Ignoring non-existing or unreadable ca_file_path \(test\/fixtures\/does_not_exist\.pem\): :enoent/
-    end)
+        # credo:disable-for-lines:2 Credo.Check.Readability.MaxLineLength
+        assert log =~
+                 ~r/\[warn(ing)?\](\s{1,2})Ignoring non-existing or unreadable ca_file_path \(test\/fixtures\/does_not_exist\.pem\): :enoent/
+      end)
+    end
   end
 end

--- a/test/mix/helpers_test.exs
+++ b/test/mix/helpers_test.exs
@@ -211,7 +211,8 @@ defmodule Mix.Appsignal.HelperTest do
     } do
       Mix.Appsignal.Helper.install()
 
-      {_method, requested_url, _headers, _body} = FakeFinchDownload.get(fake_finch, :last_request)
+      {_method, requested_url, _headers, _body, _opts} =
+        FakeFinchDownload.get(fake_finch, :last_request)
 
       assert requested_url ==
                "http://fake-mirror/0.0.1-test/appsignal-x86_64-linux-all-static.tar.gz"
@@ -226,6 +227,28 @@ defmodule Mix.Appsignal.HelperTest do
       assert report[:download][:target] == "linux"
       assert report[:download][:library_type] == "static"
       assert is_binary(report[:download][:time])
+    end
+
+    @tag :skip_env_test_no_nif
+    test "configures connection options on the Finch pool and not on the request", %{
+      fake_finch: fake_finch
+    } do
+      Mix.Appsignal.Helper.install()
+
+      start_opts = FakeFinchDownload.get(fake_finch, :last_start_opts)
+
+      {_method, _url, _headers, _body, request_opts} =
+        FakeFinchDownload.get(fake_finch, :last_request)
+
+      assert request_opts == []
+      assert start_opts[:name] == AppsignalFinchDownload
+      assert %{default: [conn_opts: conn_opts]} = start_opts[:pools]
+
+      transport_opts = conn_opts[:transport_opts]
+
+      assert transport_opts[:verify] == :verify_peer
+      assert is_binary(transport_opts[:cacertfile])
+      refute Keyword.has_key?(conn_opts, :ssl_options)
     end
   end
 

--- a/test/support/fake_finch.ex
+++ b/test/support/fake_finch.ex
@@ -3,7 +3,7 @@ defmodule FakeFinch do
     [method, url, headers, body]
   end
 
-  def request([method, url, headers, body], _, options) do
+  def request([method, url, headers, body], _, options \\ []) do
     [method, url, headers, body, options]
   end
 end

--- a/test/support/fake_mix_helpers.ex
+++ b/test/support/fake_mix_helpers.ex
@@ -33,12 +33,15 @@ defmodule FakeFinchDownload do
   use TestAgent, %{
     response: {:ok, %{status: 200, body: ""}},
     response_queue: [],
-    last_request: nil
+    last_request: nil,
+    last_start_opts: nil
   }
 
   # Spawn a throwaway process so Process.exit(pid, :normal) in the after
   # block of download_package/2 doesn't kill the test process
-  def start_link(name: _name) do
+  def start_link(opts) when is_list(opts) do
+    if alive?(), do: update(__MODULE__, :last_start_opts, opts)
+
     pid = spawn(fn -> :ok end)
     {:ok, pid}
   end
@@ -47,9 +50,9 @@ defmodule FakeFinchDownload do
     {:fake_request, method, url, headers, body}
   end
 
-  def request({:fake_request, method, url, headers, body}, _name, _opts) do
+  def request({:fake_request, method, url, headers, body}, _name, opts) do
     if alive?() do
-      update(__MODULE__, :last_request, {method, url, headers, body})
+      update(__MODULE__, :last_request, {method, url, headers, body, opts})
       next_response()
     else
       {:error, :not_started}

--- a/test/support/fake_mix_helpers.ex
+++ b/test/support/fake_mix_helpers.ex
@@ -50,7 +50,7 @@ defmodule FakeFinchDownload do
     {:fake_request, method, url, headers, body}
   end
 
-  def request({:fake_request, method, url, headers, body}, _name, opts) do
+  def request({:fake_request, method, url, headers, body}, _name, opts \\ []) do
     if alive?() do
       update(__MODULE__, :last_request, {method, url, headers, body, opts})
       next_response()


### PR DESCRIPTION
Based on #1040.

Thanks @nallwhy for the contribution!

### [Move Finch request options to pool config](https://github.com/appsignal/appsignal-elixir/commit/98f20ef322a46015afba80cab78989f4119d625f)

Finch 0.22+ validates keyword list passed to `Finch.request/3`. This
exposes the silently dropped SSL options that were added during during
the migration from Hackney to Finch.

Move SSL and proxy options to pool-level `conn_opts` in
`Finch.start_link`. Scope SSL `transport_opts` to HTTPS URLs only.

### [Remove options list in `Finch.request` calls](https://github.com/appsignal/appsignal-elixir/commit/f69293894e3d32a68ea610da5b994c93c1fb0949)

`Finch.request/3` defaults opts to [], so passing [] is redundant.
Update FakeFinch and FakeFinchDownload to match `Finch.request/3`.

[skip changeset]