### PR TITLE
Add changesets for recent version bumps

### DIFF
--- a/.changesets/decimal-version-bump.md
+++ b/.changesets/decimal-version-bump.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: security
+---
+
+[CVE-2026-32686](https://cna.erlef.org/cves/CVE-2026-32686.html) describes an unauthenticated remote Denial of Service vulnerability in `decmimal` before `3.0.0`.  Loosen `decimal` requirement to allow `~> 3.0` and fix compatibility with `ecto`.

--- a/.changesets/move-ssl-config-to-finch-pool-config.md
+++ b/.changesets/move-ssl-config-to-finch-pool-config.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix compatibility with Finch 0.22+. This change moves SSL and proxy options to pool-level `conn_opts` in `Finch.start_link`.


### PR DESCRIPTION
Add changesets explaining version bumps for `decimal` and `finch`.

[skip review] since these are just changesets