### PR TITLE
Bump `plug` version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -147,9 +147,15 @@ defmodule Appsignal.Mixfile do
           "~> 1.13.6"
 
         _ ->
-          case Version.compare(system_version, "1.14.0") do
-            :lt -> "~> 1.14 and < 1.19.0"
-            _ -> "~> 1.14"
+          case Version.compare(system_version, "1.12.0") do
+            :lt ->
+              "~> 1.17.0"
+
+            _ ->
+              case Version.compare(system_version, "1.14.0") do
+                :lt -> "~> 1.14 and < 1.19.0"
+                _ -> "~> 1.14"
+              end
           end
       end
 


### PR DESCRIPTION
Update `plug` version constraint to use `plug` `1.17` for Elixir < `1.12`.

[skip changeset]
[skip review]