### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,8 +160,6 @@ jobs:
             otp: "24"
           - elixir: "1.12"
             otp: "24"
-          - elixir: "1.11"
-            otp: "24"
 
     steps:
       - name: Set up Erlang and Elixir


### PR DESCRIPTION
Remove Elixir 1.11 from the CI matrix.

[skip changeset]
[skip review]