### PR TITLE
Emit Ecto timings as metrics

### DIFF
--- a/.changesets/emit-ecto-query-distribution-metrics.md
+++ b/.changesets/emit-ecto-query-distribution-metrics.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+type: add
+---
+
+Emit distribution metrics from the Ecto integration.
+
+Each Ecto query telemetry event now also reports its timing values as `ecto_query_time`, `ecto_queue_time`, `ecto_decode_time`, `ecto_idle_time` and `ecto_total_time` distribution metrics.
+
+All five metrics are tagged by `repo` and `hostname`. The `ecto_query_time`, `ecto_decode_time` and `ecto_total_time` metrics are additionally tagged by `repo` and `source` (the Ecto table).
+
+This surfaces pool waits, decode time, idle connection time and per-table latency as standalone metrics in addition to the existing query span.

--- a/.changesets/preserve-sub-millisecond-precision-in-distribution-metrics.md
+++ b/.changesets/preserve-sub-millisecond-precision-in-distribution-metrics.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: fix
+---
+
+Preserve sub-millisecond precision when reporting timing distribution metrics.
+
+The Ecto (`ecto_query_time`, `ecto_queue_time`, `ecto_decode_time`, `ecto_idle_time`, `ecto_total_time`) and Oban (`oban_job_duration`, `oban_job_queue_time`) distribution metrics now report fractional milliseconds, instead of being truncated to whole milliseconds. Sub-millisecond measurements were previously rounded down to zero.

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -4,7 +4,7 @@ defmodule Appsignal.Ecto do
   @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   @appsignal Application.compile_env(:appsignal, :appsignal, Appsignal)
-  import Appsignal.Utils, only: [module_name: 1]
+  import Appsignal.Utils, only: [module_name: 1, native_to_milliseconds: 1]
 
   # For each measurement Ecto emits, the tag combinations we want to fan out to.
   # `:hostname` -> tagged by repo + hostname (BEAM-side dimension).
@@ -95,7 +95,7 @@ defmodule Appsignal.Ecto do
       value = Map.get(measurements, key)
 
       if is_integer(value) do
-        ms = System.convert_time_unit(value, :native, :millisecond)
+        ms = native_to_milliseconds(value)
         metric = "ecto_#{key}"
 
         if :hostname in modes do

--- a/lib/appsignal/ecto.ex
+++ b/lib/appsignal/ecto.ex
@@ -3,7 +3,20 @@ defmodule Appsignal.Ecto do
 
   @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @appsignal Application.compile_env(:appsignal, :appsignal, Appsignal)
   import Appsignal.Utils, only: [module_name: 1]
+
+  # For each measurement Ecto emits, the tag combinations we want to fan out to.
+  # `:hostname` -> tagged by repo + hostname (BEAM-side dimension).
+  # `:source` -> tagged by repo + source (table-side dimension), only relevant
+  # for measurements that vary with the query shape.
+  @measurement_tag_modes [
+    query_time: [:hostname, :source],
+    queue_time: [:hostname],
+    decode_time: [:hostname, :source],
+    idle_time: [:hostname],
+    total_time: [:hostname, :source]
+  ]
 
   @doc """
   Attaches `Appsignal.Ecto` to the Ecto telemetry channel configured in the
@@ -63,14 +76,44 @@ defmodule Appsignal.Ecto do
   @doc false
   def handle_event(
         _event,
-        %{total_time: total_time},
+        %{total_time: total_time} = measurements,
         %{repo: repo, query: query} = metadata,
         _config
       ) do
+    add_measurement_distributions(repo, measurements, metadata)
     do_handle_event(current_span(metadata), total_time, repo, query)
   end
 
   def handle_event(_event, _measurements, _metadata, _config), do: :ok
+
+  defp add_measurement_distributions(repo, measurements, metadata) do
+    repo_name = module_name(repo)
+    hostname_tags = %{repo: repo_name, hostname: Appsignal.Utils.Hostname.hostname()}
+    source_tags = source_tags(repo_name, metadata)
+
+    Enum.each(@measurement_tag_modes, fn {key, modes} ->
+      value = Map.get(measurements, key)
+
+      if is_integer(value) do
+        ms = System.convert_time_unit(value, :native, :millisecond)
+        metric = "ecto_#{key}"
+
+        if :hostname in modes do
+          @appsignal.add_distribution_value(metric, ms, hostname_tags)
+        end
+
+        if :source in modes and source_tags do
+          @appsignal.add_distribution_value(metric, ms, source_tags)
+        end
+      end
+    end)
+  end
+
+  defp source_tags(repo_name, %{source: source}) when is_binary(source) do
+    %{repo: repo_name, source: source}
+  end
+
+  defp source_tags(_repo_name, _metadata), do: nil
 
   defp current_span(metadata) do
     # If a current span is already set in this process, use that instead

--- a/lib/appsignal/oban.ex
+++ b/lib/appsignal/oban.ex
@@ -5,6 +5,8 @@ defmodule Appsignal.Oban do
   @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   @appsignal Application.compile_env(:appsignal, :appsignal, Appsignal)
 
+  import Appsignal.Utils, only: [native_to_milliseconds: 1]
+
   @moduledoc false
 
   def attach do
@@ -232,14 +234,14 @@ defmodule Appsignal.Oban do
     Enum.each(tag_combinations, fn tags ->
       @appsignal.add_distribution_value(
         "oban_job_duration",
-        System.convert_time_unit(duration, :native, :millisecond),
+        native_to_milliseconds(duration),
         tags
       )
     end)
   end
 
   defp add_job_queue_time_value(job, queue) do
-    delay = DateTime.diff(job.attempted_at, job.scheduled_at, :millisecond)
+    delay = DateTime.diff(job.attempted_at, job.scheduled_at, :microsecond) / 1000
 
     @appsignal.add_distribution_value("oban_job_queue_time", delay, %{
       queue: to_string(queue)

--- a/lib/appsignal/utils.ex
+++ b/lib/appsignal/utils.ex
@@ -19,6 +19,22 @@ defmodule Appsignal.Utils do
 
   def module_name(module), do: module |> to_string() |> module_name()
 
+  @doc """
+  Converts a native-unit duration to fractional milliseconds, preserving
+  sub-millisecond precision. Use this when reporting timings as distribution
+  metric values.
+
+  ## Examples
+
+      iex> Appsignal.Utils.native_to_milliseconds(System.convert_time_unit(1500, :microsecond, :native))
+      1.5
+
+  """
+  @spec native_to_milliseconds(integer()) :: float()
+  def native_to_milliseconds(native) when is_integer(native) do
+    System.convert_time_unit(native, :native, :microsecond) / 1000
+  end
+
   def info(message) do
     require Logger
     Logger.info(message)

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -82,7 +82,7 @@ defmodule Appsignal.EctoTest do
           decode_time: 2_204_000,
           query_time: 5_386_000,
           queue_time: 1_239_000,
-          idle_time: 12_000_000,
+          idle_time: 12_017_000,
           total_time: 8_829_000
         },
         %{
@@ -100,58 +100,48 @@ defmodule Appsignal.EctoTest do
     end
 
     test "adds query_time with both hostname and source tags", %{fake_appsignal: f} do
-      expected = System.convert_time_unit(5_386_000, :native, :millisecond)
-
       assert [
-               %{value: ^expected, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
+               %{value: 5.386, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
                %{
-                 value: ^expected,
+                 value: 5.386,
                  tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
                }
              ] = FakeAppsignal.get_distribution_values(f, "ecto_query_time")
     end
 
     test "adds decode_time with both hostname and source tags", %{fake_appsignal: f} do
-      expected = System.convert_time_unit(2_204_000, :native, :millisecond)
-
       assert [
-               %{value: ^expected, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
+               %{value: 2.204, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
                %{
-                 value: ^expected,
+                 value: 2.204,
                  tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
                }
              ] = FakeAppsignal.get_distribution_values(f, "ecto_decode_time")
     end
 
     test "adds total_time with both hostname and source tags", %{fake_appsignal: f} do
-      expected = System.convert_time_unit(8_829_000, :native, :millisecond)
-
       assert [
-               %{value: ^expected, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
+               %{value: 8.829, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
                %{
-                 value: ^expected,
+                 value: 8.829,
                  tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
                }
              ] = FakeAppsignal.get_distribution_values(f, "ecto_total_time")
     end
 
     test "adds queue_time with hostname tags only", %{fake_appsignal: f} do
-      expected = System.convert_time_unit(1_239_000, :native, :millisecond)
-
       assert [
                %{
-                 value: ^expected,
+                 value: 1.239,
                  tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
                }
              ] = FakeAppsignal.get_distribution_values(f, "ecto_queue_time")
     end
 
     test "adds idle_time with hostname tags only", %{fake_appsignal: f} do
-      expected = System.convert_time_unit(12_000_000, :native, :millisecond)
-
       assert [
                %{
-                 value: ^expected,
+                 value: 12.017,
                  tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
                }
              ] = FakeAppsignal.get_distribution_values(f, "ecto_idle_time")
@@ -172,7 +162,7 @@ defmodule Appsignal.EctoTest do
           decode_time: 2_204_000,
           query_time: 5_386_000,
           queue_time: 1_239_000,
-          idle_time: 12_000_000,
+          idle_time: 12_017_000,
           total_time: 8_829_000
         },
         %{

--- a/test/appsignal/ecto_test.exs
+++ b/test/appsignal/ecto_test.exs
@@ -1,6 +1,6 @@
 defmodule Appsignal.EctoTest do
   use ExUnit.Case
-  alias Appsignal.{Ecto, Span, Test}
+  alias Appsignal.{Ecto, FakeAppsignal, Span, Test}
   import AppsignalTest.Utils, only: [with_config: 2]
 
   test "is attached to the repo query event automatically" do
@@ -65,6 +65,232 @@ defmodule Appsignal.EctoTest do
 
     test "does not create a span" do
       assert Test.Tracer.get(:create_span) == :error
+    end
+  end
+
+  describe "handle_event/4, emitted metrics with a source" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      :telemetry.execute(
+        [:appsignal, :test, :repo, :query],
+        %{
+          decode_time: 2_204_000,
+          query_time: 5_386_000,
+          queue_time: 1_239_000,
+          idle_time: 12_000_000,
+          total_time: 8_829_000
+        },
+        %{
+          params: [],
+          query:
+            "SELECT u0.\"id\", u0.\"name\", u0.\"inserted_at\", u0.\"updated_at\" FROM \"users\" AS u0",
+          repo: Appsignal.Test.Repo,
+          result: :ok,
+          source: "users",
+          type: :ecto_sql_query
+        }
+      )
+
+      [fake_appsignal: fake_appsignal]
+    end
+
+    test "adds query_time with both hostname and source tags", %{fake_appsignal: f} do
+      expected = System.convert_time_unit(5_386_000, :native, :millisecond)
+
+      assert [
+               %{value: ^expected, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
+               %{
+                 value: ^expected,
+                 tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
+               }
+             ] = FakeAppsignal.get_distribution_values(f, "ecto_query_time")
+    end
+
+    test "adds decode_time with both hostname and source tags", %{fake_appsignal: f} do
+      expected = System.convert_time_unit(2_204_000, :native, :millisecond)
+
+      assert [
+               %{value: ^expected, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
+               %{
+                 value: ^expected,
+                 tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
+               }
+             ] = FakeAppsignal.get_distribution_values(f, "ecto_decode_time")
+    end
+
+    test "adds total_time with both hostname and source tags", %{fake_appsignal: f} do
+      expected = System.convert_time_unit(8_829_000, :native, :millisecond)
+
+      assert [
+               %{value: ^expected, tags: %{repo: "Appsignal.Test.Repo", source: "users"}},
+               %{
+                 value: ^expected,
+                 tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
+               }
+             ] = FakeAppsignal.get_distribution_values(f, "ecto_total_time")
+    end
+
+    test "adds queue_time with hostname tags only", %{fake_appsignal: f} do
+      expected = System.convert_time_unit(1_239_000, :native, :millisecond)
+
+      assert [
+               %{
+                 value: ^expected,
+                 tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
+               }
+             ] = FakeAppsignal.get_distribution_values(f, "ecto_queue_time")
+    end
+
+    test "adds idle_time with hostname tags only", %{fake_appsignal: f} do
+      expected = System.convert_time_unit(12_000_000, :native, :millisecond)
+
+      assert [
+               %{
+                 value: ^expected,
+                 tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}
+               }
+             ] = FakeAppsignal.get_distribution_values(f, "ecto_idle_time")
+    end
+  end
+
+  describe "handle_event/4, when the source is nil" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      :telemetry.execute(
+        [:appsignal, :test, :repo, :query],
+        %{
+          decode_time: 2_204_000,
+          query_time: 5_386_000,
+          queue_time: 1_239_000,
+          idle_time: 12_000_000,
+          total_time: 8_829_000
+        },
+        %{
+          params: [],
+          query: "begin",
+          repo: Appsignal.Test.Repo,
+          result: :ok,
+          source: nil,
+          type: :ecto_sql_query
+        }
+      )
+
+      [fake_appsignal: fake_appsignal]
+    end
+
+    test "skips source-tagged distributions", %{fake_appsignal: f} do
+      for metric <- ~w(ecto_query_time ecto_decode_time ecto_total_time) do
+        values = FakeAppsignal.get_distribution_values(f, metric)
+        assert length(values) == 1
+        assert hd(values).tags |> Map.has_key?(:source) |> Kernel.!()
+      end
+    end
+
+    test "still emits hostname-tagged distributions", %{fake_appsignal: f} do
+      for metric <- ~w(ecto_query_time ecto_queue_time ecto_decode_time
+                       ecto_idle_time ecto_total_time) do
+        assert [
+                 %{tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}}
+               ] = FakeAppsignal.get_distribution_values(f, metric)
+      end
+    end
+  end
+
+  describe "handle_event/4, when the source key is missing from metadata" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      :telemetry.execute(
+        [:appsignal, :test, :repo, :query],
+        %{
+          query_time: 5_386_000,
+          total_time: 5_386_000
+        },
+        %{
+          query: "SELECT 1",
+          repo: Appsignal.Test.Repo,
+          result: :ok,
+          type: :ecto_sql_query
+        }
+      )
+
+      [fake_appsignal: fake_appsignal]
+    end
+
+    test "does not crash and still emits hostname-tagged distributions", %{fake_appsignal: f} do
+      assert [
+               %{tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}}
+             ] = FakeAppsignal.get_distribution_values(f, "ecto_query_time")
+
+      assert [
+               %{tags: %{repo: "Appsignal.Test.Repo", hostname: "Bobs-MBP.example.com"}}
+             ] = FakeAppsignal.get_distribution_values(f, "ecto_total_time")
+    end
+
+    test "does not emit metrics whose measurements are missing", %{fake_appsignal: f} do
+      for metric <- ~w(ecto_queue_time ecto_decode_time ecto_idle_time) do
+        assert FakeAppsignal.get_distribution_values(f, metric) == []
+      end
+    end
+  end
+
+  describe "handle_event/4, when individual measurements are nil or missing" do
+    setup do
+      start_supervised!(Test.Nif)
+      start_supervised!(Test.Tracer)
+      start_supervised!(Test.Span)
+      start_supervised!(Test.Monitor)
+      fake_appsignal = start_supervised!(FakeAppsignal)
+
+      :telemetry.execute(
+        [:appsignal, :test, :repo, :query],
+        %{
+          # decode_time missing entirely
+          query_time: 5_386_000,
+          queue_time: 1_239_000,
+          idle_time: nil,
+          total_time: 8_829_000
+        },
+        %{
+          params: [],
+          query:
+            "SELECT u0.\"id\", u0.\"name\", u0.\"inserted_at\", u0.\"updated_at\" FROM \"users\" AS u0",
+          repo: Appsignal.Test.Repo,
+          result: :ok,
+          source: "users",
+          type: :ecto_sql_query
+        }
+      )
+
+      [fake_appsignal: fake_appsignal]
+    end
+
+    test "skips the nil measurement", %{fake_appsignal: f} do
+      assert FakeAppsignal.get_distribution_values(f, "ecto_idle_time") == []
+    end
+
+    test "skips the missing measurement", %{fake_appsignal: f} do
+      assert FakeAppsignal.get_distribution_values(f, "ecto_decode_time") == []
+    end
+
+    test "still emits the present measurements", %{fake_appsignal: f} do
+      assert [_, _] = FakeAppsignal.get_distribution_values(f, "ecto_query_time")
+      assert [_] = FakeAppsignal.get_distribution_values(f, "ecto_queue_time")
+      assert [_, _] = FakeAppsignal.get_distribution_values(f, "ecto_total_time")
     end
   end
 

--- a/test/appsignal/oban_test.exs
+++ b/test/appsignal/oban_test.exs
@@ -118,7 +118,7 @@ defmodule Appsignal.ObanTest do
 
     test "adds job queue time distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: _, value: 3000, tags: %{queue: "default"}}
+               %{key: _, value: 3456.789, tags: %{queue: "default"}}
              ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_queue_time")
     end
   end
@@ -176,13 +176,13 @@ defmodule Appsignal.ObanTest do
 
     test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{key: _, value: 123.456, tags: %{worker: "Test.Worker"}},
                %{
                  key: _,
-                 value: 123,
+                 value: 123.456,
                  tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
                },
-               %{key: _, value: 123, tags: %{state: "success", worker: "Test.Worker"}}
+               %{key: _, value: 123.456, tags: %{state: "success", worker: "Test.Worker"}}
              ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
 
@@ -223,13 +223,13 @@ defmodule Appsignal.ObanTest do
 
     test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{key: _, value: 123.456, tags: %{worker: "Test.Worker"}},
                %{
                  key: _,
-                 value: 123,
+                 value: 123.456,
                  tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
                },
-               %{key: _, value: 123, tags: %{state: "snoozed", worker: "Test.Worker"}}
+               %{key: _, value: 123.456, tags: %{state: "snoozed", worker: "Test.Worker"}}
              ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
   end
@@ -317,13 +317,13 @@ defmodule Appsignal.ObanTest do
 
     test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{key: _, value: 123.456, tags: %{worker: "Test.Worker"}},
                %{
                  key: _,
-                 value: 123,
+                 value: 123.456,
                  tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
                },
-               %{key: _, value: 123, tags: %{state: "failure", worker: "Test.Worker"}}
+               %{key: _, value: 123.456, tags: %{state: "failure", worker: "Test.Worker"}}
              ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
 
@@ -401,13 +401,13 @@ defmodule Appsignal.ObanTest do
 
     test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{key: _, value: 123.456, tags: %{worker: "Test.Worker"}},
                %{
                  key: _,
-                 value: 123,
+                 value: 123.456,
                  tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
                },
-               %{key: _, value: 123, tags: %{state: "failure", worker: "Test.Worker"}}
+               %{key: _, value: 123.456, tags: %{state: "failure", worker: "Test.Worker"}}
              ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
 
@@ -450,13 +450,13 @@ defmodule Appsignal.ObanTest do
 
     test "adds job duration distribution value", %{fake_appsignal: fake_appsignal} do
       assert [
-               %{key: _, value: 123, tags: %{worker: "Test.Worker"}},
+               %{key: _, value: 123.456, tags: %{worker: "Test.Worker"}},
                %{
                  key: _,
-                 value: 123,
+                 value: 123.456,
                  tags: %{hostname: "Bobs-MBP.example.com", worker: "Test.Worker"}
                },
-               %{key: _, value: 123, tags: %{state: "discard", worker: "Test.Worker"}}
+               %{key: _, value: 123.456, tags: %{state: "discard", worker: "Test.Worker"}}
              ] = FakeAppsignal.get_distribution_values(fake_appsignal, "oban_job_duration")
     end
   end
@@ -737,7 +737,7 @@ defmodule Appsignal.ObanTest do
   defp execute_job_stop(additional_metadata \\ %{}) do
     :telemetry.execute(
       [:oban, :job, :stop],
-      %{duration: 123 * 1_000_000},
+      %{duration: 123_456_000},
       Map.merge(sample_metadata(), additional_metadata)
     )
   end
@@ -756,7 +756,7 @@ defmodule Appsignal.ObanTest do
 
         :telemetry.execute(
           [:oban, :job, :exception],
-          %{duration: 123 * 1_000_000},
+          %{duration: 123_456_000},
           Map.merge(metadata, additional_metadata)
         )
     end
@@ -785,8 +785,8 @@ defmodule Appsignal.ObanTest do
   defp sample_job do
     %{
       priority: 0,
-      scheduled_at: DateTime.from_unix!(1_234_000_000),
-      attempted_at: DateTime.from_unix!(1_234_000_003),
+      scheduled_at: DateTime.from_unix!(1_234_000_000_000_000, :microsecond),
+      attempted_at: DateTime.from_unix!(1_234_000_003_456_789, :microsecond),
       meta: %{
         number: 123,
         string: "foo",


### PR DESCRIPTION
Fixes https://github.com/appsignal/support/issues/378.

Each `[:repo, :query]` telemetry event already carries `query_time`, `queue_time`, `decode_time`, `idle_time` and `total_time`, but the existing handler only used `total_time` to back-date a span. Forward all five as distribution values (in ms) so the Database dashboard can surface pool waits, decode time, idle connection time and per- table latency separately from the query span.

All five metrics are tagged with `{repo, hostname}`. The query-shape dependent ones — `ecto_query_time`, `ecto_decode_time` and `ecto_total_time` — are additionally tagged with `{repo, source}`. Missing or nil measurements and a missing `source` are skipped, so non-SQL adapters and edge cases (e.g. `idle_time` on a fresh connection) don't blow up.