### PR TITLE
Allow HTTPoison 3.0 as optional dependency

### DIFF
--- a/.changesets/allow-httpoison-3.md
+++ b/.changesets/allow-httpoison-3.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+type: change
+integrations: all
+---
+
+Allow HTTPoison 3.0 to be used as an optional dependency. Applications
+on HTTPoison 3.0 can now use AppSignal's HTTPoison instrumentation
+without a version conflict.

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,11 @@
+# HTTPoison 3.0's `HTTPoison.Base` macro generates a `stream_next/1` that calls
+# `:hackney.stream_next/1`. hackney 4.0 narrowed that function's typespec, so
+# dialyzer treats the error clause as dead code and flags the generated spec and
+# callback. The code is HTTPoison's, injected into `Appsignal.HTTPoison` through
+# `use`, so we ignore these rather than work around a third-party type change.
+[
+  {"deps/httpoison/lib/httpoison/base.ex", :callback_arg_type_mismatch},
+  {"deps/httpoison/lib/httpoison/base.ex", :callback_type_mismatch},
+  {"deps/httpoison/lib/httpoison/base.ex", :pattern_match_cov},
+  {"lib/appsignal/httpoison.ex", :invalid_contract}
+]

--- a/mix.exs
+++ b/mix.exs
@@ -195,7 +195,7 @@ defmodule Appsignal.Mixfile do
       {:credo, credo_version, only: [:test, :dev], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:telemetry, telemetry_version},
-      {:httpoison, "~> 2.0", optional: true}
+      {:httpoison, "~> 2.0 or ~> 3.0", optional: true}
     ] ++ mime_dependency ++ logger_backends_dependency ++ hpax_dependency
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,8 @@ defmodule Appsignal.Mixfile do
       ],
       dialyzer: [
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
-        plt_add_apps: [:mix]
+        plt_add_apps: [:mix],
+        ignore_warnings: ".dialyzer_ignore.exs"
       ]
     ]
   end
@@ -135,6 +136,14 @@ defmodule Appsignal.Mixfile do
         false -> "~> 0.4 or ~> 1.0"
       end
 
+    # httpoison 3.0 depends on hackney 4.0, which pulls in quic and requires
+    # OTP 26 or later. Cap httpoison at 2.x on older OTP releases.
+    httpoison_version =
+      case otp_version < "26" do
+        true -> "~> 2.0"
+        false -> "~> 2.0 or ~> 3.0"
+      end
+
     mime_dependency =
       case Version.compare(system_version, "1.10.0") do
         :lt -> [{:mime, "~> 1.0", only: [:test, :test_no_nif]}]
@@ -195,7 +204,7 @@ defmodule Appsignal.Mixfile do
       {:credo, credo_version, only: [:test, :dev], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:telemetry, telemetry_version},
-      {:httpoison, "~> 2.0 or ~> 3.0", optional: true}
+      {:httpoison, httpoison_version, optional: true}
     ] ++ mime_dependency ++ logger_backends_dependency ++ hpax_dependency
   end
 end


### PR DESCRIPTION
### [Allow HTTPoison 3.0 as optional dependency](https://github.com/appsignal/appsignal-elixir/commit/f697a54db8780bde36430e074142bbb250c50844)

Widen the optional httpoison requirement to `~> 2.0 or ~> 3.0`. Since
the dependency is optional, its constraint is still binding when a host
app actually uses HTTPoison, so the old `~> 2.0` capped apps at
HTTPoison 2.x and blocked upgrades that pull hackney 4.0 (e.g. via
ex_aws).

The instrumentation only overrides HTTPoison.Base's request/5, whose
signature and __using__/1 macro are unchanged in 3.0; verified the
wrapper compiles and traces real requests against httpoison 3.0.0 /
hackney 4.5.2.

Fixes https://github.com/appsignal/appsignal-elixir/issues/1051.

### [Fix CI builds for HTTPoison 3.0](https://github.com/appsignal/appsignal-elixir/commit/83dba66f5ede7f98e623bf60d37ca8723e2a2058)

Two source-build issues surface once httpoison 3.0 is allowed:

- hackney 4.0 pulls in quic, which requires OTP 26. Gate the
  requirement so our test matrix on OTP 24/25 keeps resolving httpoison
  2.x. This only affects builds from source; the published constraint
  is frozen at publish time from the latest Elixir.

- hackney 4.0 narrowed :hackney.stream_next/1's typespec, so dialyzer
  flags the generated stream_next/1 that HTTPoison.Base injects into
  Appsignal.HTTPoison. Ignore those warnings, since the code is
  HTTPoison's.