### PR TITLE
Lock to mint to 1.9.2 on Elixir < 1.15

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -150,6 +150,15 @@ defmodule Appsignal.Mixfile do
         _ -> []
       end
 
+    mint_dependency =
+      case Version.compare(system_version, "1.15.0") do
+        :lt ->
+          [{:mint, "1.9.2"}]
+
+        _ ->
+          []
+      end
+
     plug_version =
       case Version.compare(system_version, "1.10.0") do
         :lt ->
@@ -205,6 +214,6 @@ defmodule Appsignal.Mixfile do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:telemetry, telemetry_version},
       {:httpoison, httpoison_version, optional: true}
-    ] ++ mime_dependency ++ logger_backends_dependency ++ hpax_dependency
+    ] ++ mime_dependency ++ logger_backends_dependency ++ hpax_dependency ++ mint_dependency
   end
 end


### PR DESCRIPTION
Finch's latest version depends on Mint ~>1.8.  Mint versions until v1.9.1
require Elixir version ~>1.12.   Starting with Mint v1.9.2, it requires
Elixir ~>1.15.
The combination of this dependency specification forces us to set a
specific Mint version depending on the Elixir version.  Thus if the Elixir
version is lower than 1.15 we shall use Mint v1.9.2.

[skip changeset]