### PR TITLE
Check the dependencies published to Hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -114,24 +114,44 @@ defmodule Appsignal.Mixfile do
   defp test?(:bench), do: true
   defp test?(_), do: false
 
-  defp deps do
-    system_version = System.version()
-    otp_version = System.otp_release()
+  # Hex freezes the dependency requirements in this file into the package
+  # metadata when the package is published. Applications that install this
+  # package resolve their dependencies against those frozen requirements.
+  # Some of the requirements below are narrowed on older Elixir and OTP
+  # releases, so that this package keeps building on every version in our CI
+  # matrix. Publishing from one of those releases would impose the narrower
+  # requirements on every application that installs the package. To catch
+  # that, the requirements are computed from a map of versions. That makes it
+  # possible to compare the requirements this machine produces with the ones
+  # the newest Elixir and OTP releases produce.
+  @publish_versions %{elixir: "999.0.0", otp: 999}
 
+  defp deps do
+    versions = %{
+      elixir: System.version(),
+      otp: String.to_integer(System.otp_release())
+    }
+
+    deps = deps(versions)
+    verify_publishable!(deps)
+    deps
+  end
+
+  defp deps(versions) do
     decorator_version =
-      case Version.compare(system_version, "1.5.0") do
+      case Version.compare(versions.elixir, "1.5.0") do
         :lt -> "~> 1.2.3"
         _ -> "~> 1.2.3 or ~> 1.3"
       end
 
     finch_version =
-      case Version.compare(system_version, "1.15.0") do
+      case Version.compare(versions.elixir, "1.15.0") do
         :lt -> ">= 0.19.0 and < 0.22.0"
         _ -> "~> 0.19"
       end
 
     telemetry_version =
-      case otp_version < "21" do
+      case versions.otp < 21 do
         true -> "~> 0.4"
         false -> "~> 0.4 or ~> 1.0"
       end
@@ -139,19 +159,19 @@ defmodule Appsignal.Mixfile do
     # httpoison 3.0 depends on hackney 4.0, which pulls in quic and requires
     # OTP 26 or later. Cap httpoison at 2.x on older OTP releases.
     httpoison_version =
-      case otp_version < "26" do
+      case versions.otp < 26 do
         true -> "~> 2.0"
         false -> "~> 2.0 or ~> 3.0"
       end
 
     mime_dependency =
-      case Version.compare(system_version, "1.10.0") do
+      case Version.compare(versions.elixir, "1.10.0") do
         :lt -> [{:mime, "~> 1.0", only: [:test, :test_no_nif]}]
         _ -> []
       end
 
     mint_dependency =
-      case Version.compare(system_version, "1.15.0") do
+      case Version.compare(versions.elixir, "1.15.0") do
         :lt ->
           [{:mint, "1.9.2"}]
 
@@ -160,18 +180,18 @@ defmodule Appsignal.Mixfile do
       end
 
     plug_version =
-      case Version.compare(system_version, "1.10.0") do
+      case Version.compare(versions.elixir, "1.10.0") do
         :lt ->
           "~> 1.13.6"
 
         _ ->
-          case Version.compare(system_version, "1.14.0") do
+          case Version.compare(versions.elixir, "1.14.0") do
             :lt ->
               "~> 1.14 and < 1.19.0"
 
             _ ->
               # plug 1.20.0 requires Elixir ~> 1.15, so cap it on 1.14.
-              case Version.compare(system_version, "1.15.0") do
+              case Version.compare(versions.elixir, "1.15.0") do
                 :lt -> "~> 1.14 and < 1.20.0"
                 _ -> "~> 1.14"
               end
@@ -179,13 +199,13 @@ defmodule Appsignal.Mixfile do
       end
 
     credo_version =
-      case Version.compare(system_version, "1.13.0") do
+      case Version.compare(versions.elixir, "1.13.0") do
         :lt -> "1.7.6"
         _ -> "~> 1.7"
       end
 
     logger_backends_dependency =
-      case Version.compare(system_version, "1.15.0") do
+      case Version.compare(versions.elixir, "1.15.0") do
         :lt -> []
         _ -> [{:logger_backends, "~> 1.0"}]
       end
@@ -193,7 +213,7 @@ defmodule Appsignal.Mixfile do
     # hpax is a transitive dependency (via finch/mint). Version 1.0.4 requires
     # Elixir ~> 1.15, so pin to the last compatible version on older Elixirs.
     hpax_dependency =
-      case Version.compare(system_version, "1.15.0") do
+      case Version.compare(versions.elixir, "1.15.0") do
         :lt -> [{:hpax, ">= 1.0.0 and < 1.0.4", override: true}]
         _ -> []
       end
@@ -216,4 +236,45 @@ defmodule Appsignal.Mixfile do
       {:httpoison, httpoison_version, optional: true}
     ] ++ mime_dependency ++ logger_backends_dependency ++ hpax_dependency ++ mint_dependency
   end
+
+  defp verify_publishable!(deps) do
+    publishable_deps = deps(@publish_versions)
+
+    if publishing?() and deps != publishable_deps do
+      Mix.raise("""
+      This package is being built for Hex, but the dependencies on this \
+      machine are not the ones that should be published.
+
+      Some dependency requirements are narrowed on older Elixir and OTP \
+      releases, so that this package keeps building there. Hex freezes the \
+      requirements into the package when it is published. Publishing these \
+      would impose the narrower requirements on every application that \
+      installs the package.
+
+      This machine runs Elixir #{System.version()} on OTP \
+      #{System.otp_release()}, and produces:
+
+      #{format_deps(deps -- publishable_deps)}
+
+      The published package must have:
+
+      #{format_deps(publishable_deps -- deps)}
+
+      Publish from the newest Elixir and OTP release instead.
+      """)
+    end
+  end
+
+  # Mix passes the name of the task it runs and that task's arguments as the
+  # command line arguments of the Elixir process. That makes it possible to
+  # tell, while this file is being evaluated, that it is being evaluated to
+  # build a package for Hex. The task name is not always the first argument,
+  # because `mix do` runs more than one task in a single invocation, so look
+  # for it anywhere in the arguments.
+  defp publishing? do
+    Enum.any?(["hex.build", "hex.publish"], &(&1 in System.argv()))
+  end
+
+  defp format_deps([]), do: "  (none)"
+  defp format_deps(deps), do: Enum.map_join(deps, "\n", &"  #{inspect(&1)}")
 end


### PR DESCRIPTION
This is based on https://github.com/appsignal/appsignal-elixir/pull/1055, which fixes the CI failures on the older Elixir versions.

This is one of three pull requests that make the same change. The other two are:

- https://github.com/appsignal/appsignal-elixir-plug/pull/65
- https://github.com/appsignal/appsignal-elixir-phoenix/pull/126

Several dependency requirements in `mix.exs` are narrowed on older
Elixir and OTP releases, so that the package keeps building on every
version in the CI matrix. Hex freezes those requirements into the
package metadata when the package is published, so a publish from one
of those releases would impose the narrowed requirements on every
application that installs the package. The requirements are now
computed from a map of versions, and `mix hex.build` and
`mix hex.publish` raise when the map for this machine does not produce
the same requirements as the newest Elixir and OTP releases do. Mix
passes the name of the task it runs as a command line argument, so the
mixfile can detect those two tasks on its own, without the publishing
tool having to tell it.

[skip changeset]
